### PR TITLE
fix(ai): disable Gemini 2.5 thinking to prevent JSON truncation

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -47,6 +47,11 @@ RUN pnpm exec prisma generate
 
 ENV NODE_ENV=production
 
+# Ejecutar como usuario no-root (principio de mínimo privilegio)
+RUN groupadd --system --gid 1001 nodejs && \
+    useradd --system --uid 1001 --gid nodejs nestjs
+USER nestjs
+
 # IMPORTANTE: las migraciones NO se ejecutan aquí.
 #
 # Motivo: en Fase B (ECS Fargate con >1 task) varias instancias arrancando

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -13,6 +13,14 @@ module.exports = {
   },
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
+  coverageThreshold: {
+    global: {
+      statements: 30,
+      branches: 35,
+      functions: 30,
+      lines: 30,
+    },
+  },
   testEnvironment: 'node',
   moduleNameMapper: {
     // Resolver el paquete compartido del monorepo en contexto de tests

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "helmet": "^8.1.0",
     "ioredis": "^5.10.1",
     "joi": "^18.1.2",
     "passport": "^0.7.0",

--- a/apps/api/src/academies/academies.service.spec.ts
+++ b/apps/api/src/academies/academies.service.spec.ts
@@ -1,0 +1,534 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import { AcademiesService } from './academies.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+// Mockear bcrypt para evitar el coste de rondas reales en los tests
+jest.mock('bcrypt');
+const mockedBcrypt = bcrypt as jest.Mocked<typeof bcrypt>;
+
+describe('AcademiesService', () => {
+  let service: AcademiesService;
+  let mockPrisma: {
+    academy: {
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      findFirst: jest.Mock;
+      create: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+    academyMember: {
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      create: jest.Mock;
+      delete: jest.Mock;
+    };
+    user: {
+      findUnique: jest.Mock;
+    };
+  };
+  let mockConfig: { get: jest.Mock };
+
+  // Academia de ejemplo con todos los campos necesarios
+  const fakeAcademy = {
+    id: 'academy-uuid-1',
+    slug: 'vallekas-basket',
+    name: 'Vallekas Basket Academy',
+    logoUrl: 'https://example.com/logo.png',
+    primaryColor: '#6366f1',
+    domain: 'vallekas-basket.academy.vercel.app',
+    isActive: true,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    _count: { members: 3 },
+  };
+
+  const fakeAcademyNoDomain = {
+    ...fakeAcademy,
+    domain: null,
+  };
+
+  beforeEach(async () => {
+    mockPrisma = {
+      academy: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      academyMember: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        delete: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    // Sin tokens de Vercel configurados → registerVercelDomain retorna sin hacer fetch
+    mockConfig = { get: jest.fn().mockReturnValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AcademiesService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get<AcademiesService>(AcademiesService);
+    jest.clearAllMocks();
+
+    // Valor por defecto: bcrypt.hash devuelve un hash ficticio
+    mockedBcrypt.hash.mockResolvedValue('$2b$10$hashed' as never);
+  });
+
+  // ─── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('devuelve lista de academias con _count.members', async () => {
+      mockPrisma.academy.findMany.mockResolvedValue([fakeAcademy]);
+
+      const result = await service.findAll();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(fakeAcademy.id);
+      expect(result[0]._count.members).toBe(3);
+      expect(mockPrisma.academy.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'asc' },
+          include: { _count: { select: { members: true } } },
+        }),
+      );
+    });
+
+    it('devuelve array vacío si no hay academias', async () => {
+      mockPrisma.academy.findMany.mockResolvedValue([]);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── findPublic ──────────────────────────────────────────────────────────────
+
+  describe('findPublic', () => {
+    it('devuelve solo academias activas con campos públicos', async () => {
+      const publicAcademy = {
+        id: fakeAcademy.id,
+        slug: fakeAcademy.slug,
+        name: fakeAcademy.name,
+        logoUrl: fakeAcademy.logoUrl,
+        primaryColor: fakeAcademy.primaryColor,
+      };
+      mockPrisma.academy.findMany.mockResolvedValue([publicAcademy]);
+
+      const result = await service.findPublic();
+
+      expect(result).toHaveLength(1);
+      expect(mockPrisma.academy.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { isActive: true },
+          orderBy: { name: 'asc' },
+        }),
+      );
+    });
+
+    it('devuelve array vacío si no hay academias activas', async () => {
+      mockPrisma.academy.findMany.mockResolvedValue([]);
+
+      const result = await service.findPublic();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── findByDomain ─────────────────────────────────────────────────────────────
+
+  describe('findByDomain', () => {
+    it('devuelve academia activa que coincide con el dominio', async () => {
+      const publicAcademy = {
+        id: fakeAcademy.id,
+        slug: fakeAcademy.slug,
+        name: fakeAcademy.name,
+        logoUrl: fakeAcademy.logoUrl,
+        primaryColor: fakeAcademy.primaryColor,
+        isActive: true,
+      };
+      mockPrisma.academy.findFirst.mockResolvedValue(publicAcademy);
+
+      const result = await service.findByDomain('vallekas-basket.academy.vercel.app');
+
+      expect(result.id).toBe(fakeAcademy.id);
+      expect(mockPrisma.academy.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { domain: 'vallekas-basket.academy.vercel.app', isActive: true },
+        }),
+      );
+    });
+
+    it('lanza NotFoundException si no existe academia para ese dominio', async () => {
+      mockPrisma.academy.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.findByDomain('dominio-inexistente.com'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── findBySlug ───────────────────────────────────────────────────────────────
+
+  describe('findBySlug', () => {
+    it('devuelve academia que coincide con el slug', async () => {
+      const publicAcademy = {
+        id: fakeAcademy.id,
+        slug: fakeAcademy.slug,
+        name: fakeAcademy.name,
+        logoUrl: fakeAcademy.logoUrl,
+        primaryColor: fakeAcademy.primaryColor,
+        isActive: true,
+      };
+      mockPrisma.academy.findUnique.mockResolvedValue(publicAcademy);
+
+      const result = await service.findBySlug('vallekas-basket');
+
+      expect(result.slug).toBe('vallekas-basket');
+      expect(mockPrisma.academy.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { slug: 'vallekas-basket' } }),
+      );
+    });
+
+    it('lanza NotFoundException si no existe academia con ese slug', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+
+      await expect(service.findBySlug('slug-inexistente')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── findById ─────────────────────────────────────────────────────────────────
+
+  describe('findById', () => {
+    it('devuelve academia con _count.members por id', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+
+      const result = await service.findById('academy-uuid-1');
+
+      expect(result.id).toBe('academy-uuid-1');
+      expect(result._count.members).toBe(3);
+      expect(mockPrisma.academy.findUnique).toHaveBeenCalledWith({
+        where: { id: 'academy-uuid-1' },
+        include: { _count: { select: { members: true } } },
+      });
+    });
+
+    it('lanza NotFoundException si no existe academia con ese id', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+
+      await expect(service.findById('id-inexistente')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── create ───────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    const createDto = {
+      name: 'Nueva Academia',
+      slug: 'nueva-academia',
+      logoUrl: undefined,
+      primaryColor: '#6366f1',
+      domain: undefined as string | undefined,
+    };
+
+    it('lanza ConflictException si ya existe una academia con ese slug', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+
+      await expect(service.create(createDto)).rejects.toThrow(ConflictException);
+      expect(mockPrisma.academy.create).not.toHaveBeenCalled();
+    });
+
+    it('genera el dominio automáticamente si no se proporciona', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+      mockPrisma.academy.create.mockResolvedValue({
+        ...fakeAcademy,
+        slug: 'nueva-academia',
+        domain: 'nuevaacademiaacademy.vercel.app',
+      });
+
+      await service.create({ ...createDto, domain: undefined });
+
+      const createCall = mockPrisma.academy.create.mock.calls[0][0];
+      // El dominio generado elimina guiones del slug y añade "academy.vercel.app"
+      expect(createCall.data.domain).toBe('nuevaacademiaacademy.vercel.app');
+    });
+
+    it('usa el domain explícito si se proporciona', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+      mockPrisma.academy.create.mockResolvedValue({
+        ...fakeAcademy,
+        domain: 'mi-dominio-personalizado.com',
+      });
+
+      await service.create({ ...createDto, domain: 'mi-dominio-personalizado.com' });
+
+      const createCall = mockPrisma.academy.create.mock.calls[0][0];
+      expect(createCall.data.domain).toBe('mi-dominio-personalizado.com');
+    });
+
+    it('crea la academia con 3 usuarios por defecto (admin, tutor, student)', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+      mockPrisma.academy.create.mockResolvedValue(fakeAcademy);
+
+      await service.create(createDto);
+
+      const createCall = mockPrisma.academy.create.mock.calls[0][0];
+      const members = createCall.data.members.create as Array<{ user: { create: { role: string } } }>;
+      expect(members).toHaveLength(3);
+      const roles = members.map((m) => m.user.create.role);
+      expect(roles).toContain('ADMIN');
+      expect(roles).toContain('TUTOR');
+      expect(roles).toContain('STUDENT');
+    });
+
+    it('no usa "password123" como contraseña de los usuarios por defecto', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+      mockPrisma.academy.create.mockResolvedValue(fakeAcademy);
+
+      await service.create(createDto);
+
+      // bcrypt.hash nunca debe recibir la cadena literal "password123"
+      const hashCalls = mockedBcrypt.hash.mock.calls;
+      for (const [plaintext] of hashCalls) {
+        expect(plaintext).not.toBe('password123');
+      }
+    });
+
+    it('la contraseña temporal es aleatoria y no predecible', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+      mockPrisma.academy.create.mockResolvedValue(fakeAcademy);
+
+      // Llamar a create dos veces y verificar que bcrypt.hash recibió contraseñas distintas
+      await service.create(createDto);
+      const firstCall = mockedBcrypt.hash.mock.calls[0][0] as string;
+
+      jest.clearAllMocks();
+      mockedBcrypt.hash.mockResolvedValue('$2b$10$hashed' as never);
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+      mockPrisma.academy.create.mockResolvedValue(fakeAcademy);
+
+      await service.create(createDto);
+      const secondCall = mockedBcrypt.hash.mock.calls[0][0] as string;
+
+      // Dos invocaciones distintas deben generar contraseñas distintas (randomBytes)
+      expect(firstCall).not.toBe(secondCall);
+    });
+  });
+
+  // ─── update ───────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('actualiza los campos de la academia correctamente', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      const updated = { ...fakeAcademy, name: 'Nuevo Nombre' };
+      mockPrisma.academy.update.mockResolvedValue(updated);
+
+      const result = await service.update('academy-uuid-1', { name: 'Nuevo Nombre' });
+
+      expect(result.name).toBe('Nuevo Nombre');
+      expect(mockPrisma.academy.update).toHaveBeenCalledWith({
+        where: { id: 'academy-uuid-1' },
+        data: { name: 'Nuevo Nombre' },
+      });
+    });
+
+    it('llama a registerVercelDomain y removeVercelDomain cuando el dominio cambia', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.academy.update.mockResolvedValue({
+        ...fakeAcademy,
+        domain: 'nuevo-dominio.com',
+      });
+
+      const registerSpy = jest
+        .spyOn(service as any, 'registerVercelDomain')
+        .mockResolvedValue(undefined);
+      const removeSpy = jest
+        .spyOn(service as any, 'removeVercelDomain')
+        .mockResolvedValue(undefined);
+
+      await service.update('academy-uuid-1', { domain: 'nuevo-dominio.com' });
+
+      expect(registerSpy).toHaveBeenCalledWith('nuevo-dominio.com');
+      expect(removeSpy).toHaveBeenCalledWith(fakeAcademy.domain);
+    });
+
+    it('no llama a registerVercelDomain si el dominio no cambió', async () => {
+      // dto.domain no está presente → no hay cambio de dominio
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.academy.update.mockResolvedValue(fakeAcademy);
+
+      const registerSpy = jest
+        .spyOn(service as any, 'registerVercelDomain')
+        .mockResolvedValue(undefined);
+
+      await service.update('academy-uuid-1', { name: 'Solo cambio de nombre' });
+
+      expect(registerSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── delete ───────────────────────────────────────────────────────────────────
+
+  describe('delete', () => {
+    it('elimina la academia existente', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.academy.delete.mockResolvedValue(fakeAcademy);
+
+      await service.delete('academy-uuid-1');
+
+      expect(mockPrisma.academy.delete).toHaveBeenCalledWith({
+        where: { id: 'academy-uuid-1' },
+      });
+    });
+
+    it('lanza NotFoundException si la academia no existe', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
+
+      await expect(service.delete('id-inexistente')).rejects.toThrow(NotFoundException);
+      expect(mockPrisma.academy.delete).not.toHaveBeenCalled();
+    });
+
+    it('devuelve mensaje de confirmación con el nombre de la academia', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.academy.delete.mockResolvedValue(fakeAcademy);
+
+      const result = await service.delete('academy-uuid-1');
+
+      expect(result.message).toContain('Vallekas Basket Academy');
+      expect(result.message).toContain('eliminada');
+    });
+  });
+
+  // ─── getMembers ───────────────────────────────────────────────────────────────
+
+  describe('getMembers', () => {
+    it('devuelve los miembros de la academia con datos del usuario', async () => {
+      const fakeMembers = [
+        {
+          id: 'member-uuid-1',
+          academyId: 'academy-uuid-1',
+          userId: 'user-uuid-1',
+          createdAt: new Date(),
+          user: { id: 'user-uuid-1', name: 'Admin Test', email: 'admin@test.academy', role: 'ADMIN', avatarUrl: null, createdAt: new Date() },
+        },
+      ];
+      mockPrisma.academyMember.findMany.mockResolvedValue(fakeMembers);
+
+      const result = await service.getMembers('academy-uuid-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].user.role).toBe('ADMIN');
+      expect(mockPrisma.academyMember.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { academyId: 'academy-uuid-1' },
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+    });
+  });
+
+  // ─── addMember ────────────────────────────────────────────────────────────────
+
+  describe('addMember', () => {
+    const fakeUser = {
+      id: 'user-uuid-2',
+      email: 'nuevo@vkbacademy.es',
+      name: 'Nuevo Usuario',
+      role: 'STUDENT',
+      passwordHash: '$2b$10$hashed',
+    };
+
+    it('lanza NotFoundException si el usuario no existe', async () => {
+      // findById necesita academy.findUnique
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.addMember('academy-uuid-1', 'user-inexistente'),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockPrisma.academyMember.create).not.toHaveBeenCalled();
+    });
+
+    it('lanza ConflictException si el usuario ya es miembro de la academia', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.user.findUnique.mockResolvedValue(fakeUser);
+      mockPrisma.academyMember.findUnique.mockResolvedValue({
+        id: 'member-uuid-1',
+        userId: fakeUser.id,
+        academyId: 'academy-uuid-1',
+      });
+
+      await expect(
+        service.addMember('academy-uuid-1', fakeUser.id),
+      ).rejects.toThrow(ConflictException);
+      expect(mockPrisma.academyMember.create).not.toHaveBeenCalled();
+    });
+
+    it('añade el miembro correctamente si no existía la membresía', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.user.findUnique.mockResolvedValue(fakeUser);
+      mockPrisma.academyMember.findUnique.mockResolvedValue(null);
+      const newMember = {
+        id: 'member-uuid-nuevo',
+        userId: fakeUser.id,
+        academyId: 'academy-uuid-1',
+        user: { id: fakeUser.id, name: fakeUser.name, email: fakeUser.email, role: fakeUser.role },
+      };
+      mockPrisma.academyMember.create.mockResolvedValue(newMember);
+
+      const result = await service.addMember('academy-uuid-1', fakeUser.id);
+
+      expect(mockPrisma.academyMember.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { userId: fakeUser.id, academyId: 'academy-uuid-1' },
+        }),
+      );
+      expect(result.user.email).toBe(fakeUser.email);
+    });
+  });
+
+  // ─── removeMember ─────────────────────────────────────────────────────────────
+
+  describe('removeMember', () => {
+    it('lanza NotFoundException si la membresía no existe', async () => {
+      mockPrisma.academyMember.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.removeMember('academy-uuid-1', 'user-inexistente'),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockPrisma.academyMember.delete).not.toHaveBeenCalled();
+    });
+
+    it('elimina la membresía existente y devuelve mensaje de confirmación', async () => {
+      const fakeMembership = {
+        id: 'member-uuid-1',
+        userId: 'user-uuid-1',
+        academyId: 'academy-uuid-1',
+      };
+      mockPrisma.academyMember.findUnique.mockResolvedValue(fakeMembership);
+      mockPrisma.academyMember.delete.mockResolvedValue(fakeMembership);
+
+      const result = await service.removeMember('academy-uuid-1', 'user-uuid-1');
+
+      expect(mockPrisma.academyMember.delete).toHaveBeenCalledWith({
+        where: { id: 'member-uuid-1' },
+      });
+      expect(result.message).toContain('eliminado');
+    });
+  });
+});

--- a/apps/api/src/academies/academies.service.ts
+++ b/apps/api/src/academies/academies.service.ts
@@ -86,7 +86,9 @@ export class AcademiesService {
     // Generar dominio automáticamente si no se proporciona (o vacío)
     const domain = dto.domain?.trim() || `${dto.slug.replace(/-/g, '')}academy.vercel.app`;
 
-    const passwordHash = await bcrypt.hash('password123', 10);
+    const { randomBytes } = await import('crypto');
+    const tempPassword = randomBytes(20).toString('hex');
+    const passwordHash = await bcrypt.hash(tempPassword, 10);
     const emailSuffix = `${dto.slug.replace(/-/g, '')}.academy`;
 
     const academy = await this.prisma.academy.create({

--- a/apps/api/src/ai/ai-provider.service.spec.ts
+++ b/apps/api/src/ai/ai-provider.service.spec.ts
@@ -3,11 +3,12 @@ import { AiProviderService } from './ai-provider.service';
 
 // Mock de @google/generative-ai
 const mockGeminiGenerateContent = jest.fn();
+const mockGeminiGetGenerativeModel = jest.fn(() => ({
+  generateContent: mockGeminiGenerateContent,
+}));
 jest.mock('@google/generative-ai', () => ({
   GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
-    getGenerativeModel: () => ({
-      generateContent: mockGeminiGenerateContent,
-    }),
+    getGenerativeModel: mockGeminiGetGenerativeModel,
   })),
 }));
 
@@ -100,6 +101,25 @@ describe('AiProviderService', () => {
 
       expect(result).toBe('{"ok":true}');
       expect(mockGeminiGenerateContent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('configuración de thinking mode', () => {
+    it('desactiva thinking en Gemini 2.5 para evitar truncamientos por consumo de budget', async () => {
+      mockGeminiGenerateContent.mockResolvedValue({
+        response: { text: () => '{"ok":true}' },
+      });
+
+      const provider = createProvider({ AI_PROVIDER: 'gemini' });
+      await provider.generate('prompt', 512);
+
+      expect(mockGeminiGetGenerativeModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          generationConfig: expect.objectContaining({
+            thinkingConfig: { thinkingBudget: 0 },
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/ai/ai-provider.service.ts
+++ b/apps/api/src/ai/ai-provider.service.ts
@@ -88,12 +88,18 @@ export class AiProviderService {
     // `gemini-flash-latest` apunta siempre al último modelo Flash estable.
     // Evita roturas por deprecación de versiones específicas (ej. gemini-2.0-flash
     // dejó de aceptar nuevos usuarios en 2026).
+    // Gemini 2.5 Flash tiene dynamic thinking activado por defecto. Los thinking
+    // tokens se descuentan de maxOutputTokens pero no aparecen en response.text(),
+    // lo que provoca truncamientos erráticos del JSON. Forzamos thinkingBudget=0.
+    // El SDK legacy @google/generative-ai@0.24.x no tipa este campo — se pasa
+    // transparentemente al endpoint REST.
     const model = this.gemini.getGenerativeModel({
       model: 'gemini-flash-latest',
       generationConfig: {
         maxOutputTokens: maxTokens,
         responseMimeType: 'application/json',
-      },
+        thinkingConfig: { thinkingBudget: 0 },
+      } as Record<string, unknown>,
     });
 
     this.logger.debug(`Llamando a Gemini Flash latest (maxTokens=${maxTokens})`);

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { envValidationSchema } from './config/env.schema';
 import { buildThrottlerOptions } from './config/throttler-options.factory';
 import { PrismaModule } from './prisma/prisma.module';
@@ -69,6 +70,10 @@ import { ExercisesModule } from './exercises/exercises.module';
     HealthModule,
     AiModule,
     ExercisesModule,
+  ],
+  providers: [
+    // Rate limiting global (100 req/min por defecto)
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { RegisterTutorDto } from './dto/register-tutor.dto';
@@ -8,6 +9,7 @@ import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 
 @Controller('auth')
+@Throttle({ default: { ttl: 60000, limit: 10 } })
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -1,9 +1,11 @@
-import { IsString } from 'class-validator';
+import { IsString, MaxLength } from 'class-validator';
 
 export class LoginDto {
   @IsString({ message: 'Introduce tu email o nombre de usuario' })
+  @MaxLength(254)
   identifier: string;
 
   @IsString()
+  @MaxLength(128)
   password: string;
 }

--- a/apps/api/src/availability/availability.service.spec.ts
+++ b/apps/api/src/availability/availability.service.spec.ts
@@ -1,0 +1,277 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { AvailabilityService } from './availability.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+// ─── Mock manual de PrismaService ────────────────────────────────────────────
+
+const mockPrisma = {
+  teacherProfile: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+  },
+  availabilitySlot: {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  },
+  booking: {
+    findMany: jest.fn(),
+  },
+};
+
+// ─── Suite principal ──────────────────────────────────────────────────────────
+
+describe('AvailabilityService', () => {
+  let service: AvailabilityService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AvailabilityService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<AvailabilityService>(AvailabilityService);
+
+    // Limpia todas las implementaciones/llamadas entre tests
+    jest.clearAllMocks();
+  });
+
+  // ─── findAllTeachers ───────────────────────────────────────────────────────
+
+  describe('findAllTeachers', () => {
+    it('devuelve todos los perfiles de profesor con usuario y disponibilidad', async () => {
+      const expected = [
+        {
+          id: 'prof-1',
+          user: { id: 'user-1', name: 'Ana García', avatarUrl: null },
+          availability: [],
+        },
+      ];
+      mockPrisma.teacherProfile.findMany.mockResolvedValue(expected);
+
+      const result = await service.findAllTeachers();
+
+      expect(mockPrisma.teacherProfile.findMany).toHaveBeenCalledWith({
+        include: {
+          user: { select: { id: true, name: true, avatarUrl: true } },
+          availability: true,
+        },
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  // ─── getFreeSlots ──────────────────────────────────────────────────────────
+
+  describe('getFreeSlots', () => {
+    // Fija el reloj en 2026-06-01 08:00 UTC para que los slots del 2026-06-02
+    // a las 10:00 sean inequívocamente futuros.
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-06-01T08:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('devuelve array vacío cuando el profesor no tiene disponibilidad configurada', async () => {
+      mockPrisma.availabilitySlot.findMany.mockResolvedValue([]);
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      const from = new Date('2026-06-02T00:00:00Z');
+      const to = new Date('2026-06-02T23:59:59Z');
+
+      const result = await service.getFreeSlots('prof-1', from, to);
+
+      expect(result).toEqual([]);
+    });
+
+    it('omite slots cuyo startAt ya ha pasado respecto a la hora actual', async () => {
+      // dayOfWeek para 2026-06-01 (lunes) = 1
+      // Slot a las 07:00–08:00 → ya pasó (sistema ficticio = 08:00)
+      mockPrisma.availabilitySlot.findMany.mockResolvedValue([
+        { dayOfWeek: 1, startTime: '07:00', endTime: '08:00' },
+      ]);
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      // Rango: solo el 2026-06-01
+      const from = new Date('2026-06-01T00:00:00Z');
+      const to = new Date('2026-06-01T23:59:59Z');
+
+      const result = await service.getFreeSlots('prof-1', from, to);
+
+      expect(result).toEqual([]);
+    });
+
+    it('omite slots que solapan con reservas existentes', async () => {
+      // 2026-06-02 es martes → dayOfWeek = 2
+      mockPrisma.availabilitySlot.findMany.mockResolvedValue([
+        { dayOfWeek: 2, startTime: '10:00', endTime: '11:00' },
+      ]);
+      // Reserva que cubre exactamente ese slot
+      mockPrisma.booking.findMany.mockResolvedValue([
+        {
+          startAt: new Date('2026-06-02T10:00:00'),
+          endAt: new Date('2026-06-02T11:00:00'),
+        },
+      ]);
+
+      const from = new Date('2026-06-02T00:00:00');
+      const to = new Date('2026-06-02T23:59:59');
+
+      const result = await service.getFreeSlots('prof-1', from, to);
+
+      expect(result).toEqual([]);
+    });
+
+    it('incluye slots libres futuros sin conflictos', async () => {
+      // 2026-06-02 es martes → dayOfWeek = 2
+      mockPrisma.availabilitySlot.findMany.mockResolvedValue([
+        { dayOfWeek: 2, startTime: '10:00', endTime: '11:00' },
+      ]);
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      const from = new Date('2026-06-02T00:00:00');
+      const to = new Date('2026-06-02T23:59:59');
+
+      const result = await service.getFreeSlots('prof-1', from, to);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].teacherId).toBe('prof-1');
+      expect(result[0].startAt.getHours()).toBe(10);
+      expect(result[0].endAt.getHours()).toBe(11);
+    });
+
+    it('itera múltiples días y acumula todos los slots libres', async () => {
+      // 2026-06-02 = martes (2), 2026-06-03 = miércoles (3)
+      mockPrisma.availabilitySlot.findMany.mockResolvedValue([
+        { dayOfWeek: 2, startTime: '10:00', endTime: '11:00' },
+        { dayOfWeek: 3, startTime: '15:00', endTime: '16:00' },
+      ]);
+      mockPrisma.booking.findMany.mockResolvedValue([]);
+
+      const from = new Date('2026-06-02T00:00:00');
+      const to = new Date('2026-06-03T23:59:59');
+
+      const result = await service.getFreeSlots('prof-1', from, to);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].startAt.getHours()).toBe(10);
+      expect(result[1].startAt.getHours()).toBe(15);
+    });
+  });
+
+  // ─── getMySlots ────────────────────────────────────────────────────────────
+
+  describe('getMySlots', () => {
+    it('devuelve array vacío cuando el usuario no tiene perfil de profesor', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null);
+
+      const result = await service.getMySlots('user-sin-perfil');
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.availabilitySlot.findMany).not.toHaveBeenCalled();
+    });
+
+    it('devuelve los slots del profesor ordenados por día y hora', async () => {
+      const profile = { id: 'prof-1', userId: 'user-1' };
+      const slots = [
+        { id: 'slot-1', dayOfWeek: 1, startTime: '09:00', endTime: '10:00' },
+        { id: 'slot-2', dayOfWeek: 2, startTime: '10:00', endTime: '11:00' },
+      ];
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(profile);
+      mockPrisma.availabilitySlot.findMany.mockResolvedValue(slots);
+
+      const result = await service.getMySlots('user-1');
+
+      expect(mockPrisma.availabilitySlot.findMany).toHaveBeenCalledWith({
+        where: { teacherId: 'prof-1' },
+        orderBy: [{ dayOfWeek: 'asc' }, { startTime: 'asc' }],
+      });
+      expect(result).toEqual(slots);
+    });
+  });
+
+  // ─── addSlot ───────────────────────────────────────────────────────────────
+
+  describe('addSlot', () => {
+    const dto = { dayOfWeek: 1, startTime: '10:00', endTime: '11:00' };
+
+    it('lanza NotFoundException cuando el usuario no tiene perfil de profesor', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null);
+
+      await expect(service.addSlot('user-sin-perfil', dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockPrisma.availabilitySlot.create).not.toHaveBeenCalled();
+    });
+
+    it('lanza ConflictException cuando ya existe un slot en ese día y hora', async () => {
+      const profile = { id: 'prof-1', userId: 'user-1' };
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(profile);
+      mockPrisma.availabilitySlot.findFirst.mockResolvedValue({ id: 'slot-existente' });
+
+      await expect(service.addSlot('user-1', dto)).rejects.toThrow(ConflictException);
+      expect(mockPrisma.availabilitySlot.create).not.toHaveBeenCalled();
+    });
+
+    it('crea y devuelve el slot cuando no existe conflicto', async () => {
+      const profile = { id: 'prof-1', userId: 'user-1' };
+      const created = { id: 'slot-nuevo', teacherId: 'prof-1', ...dto };
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(profile);
+      mockPrisma.availabilitySlot.findFirst.mockResolvedValue(null);
+      mockPrisma.availabilitySlot.create.mockResolvedValue(created);
+
+      const result = await service.addSlot('user-1', dto);
+
+      expect(mockPrisma.availabilitySlot.create).toHaveBeenCalledWith({
+        data: { teacherId: 'prof-1', ...dto },
+      });
+      expect(result).toEqual(created);
+    });
+  });
+
+  // ─── removeSlot ───────────────────────────────────────────────────────────
+
+  describe('removeSlot', () => {
+    it('lanza NotFoundException cuando el slot no existe', async () => {
+      mockPrisma.availabilitySlot.findUnique.mockResolvedValue(null);
+
+      await expect(service.removeSlot('slot-inexistente', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockPrisma.availabilitySlot.delete).not.toHaveBeenCalled();
+    });
+
+    it('lanza ForbiddenException cuando el slot pertenece a otro profesor', async () => {
+      mockPrisma.availabilitySlot.findUnique.mockResolvedValue({
+        id: 'slot-1',
+        teacher: { userId: 'otro-user' },
+      });
+
+      await expect(service.removeSlot('slot-1', 'user-1')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockPrisma.availabilitySlot.delete).not.toHaveBeenCalled();
+    });
+
+    it('elimina y devuelve el slot cuando el usuario es el propietario', async () => {
+      const slot = { id: 'slot-1', teacher: { userId: 'user-1' } };
+      mockPrisma.availabilitySlot.findUnique.mockResolvedValue(slot);
+      mockPrisma.availabilitySlot.delete.mockResolvedValue(slot);
+
+      const result = await service.removeSlot('slot-1', 'user-1');
+
+      expect(mockPrisma.availabilitySlot.delete).toHaveBeenCalledWith({
+        where: { id: 'slot-1' },
+      });
+      expect(result).toEqual(slot);
+    });
+  });
+});

--- a/apps/api/src/bookings/bookings.service.spec.ts
+++ b/apps/api/src/bookings/bookings.service.spec.ts
@@ -1,0 +1,505 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Role, BookingMode, BookingStatus, ChallengeType } from '@prisma/client';
+import { BookingsService } from './bookings.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { DailyService } from '../daily/daily.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { ChallengesService } from '../challenges/challenges.service';
+
+describe('BookingsService', () => {
+  let service: BookingsService;
+
+  const mockPrisma = {
+    booking: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    teacherProfile: {
+      findUnique: jest.fn(),
+    },
+    course: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  const mockDaily = {
+    createRoom: jest.fn(),
+    deleteRoom: jest.fn(),
+  };
+
+  const mockNotifications = {
+    sendBookingCreated: jest.fn().mockResolvedValue(undefined),
+    sendBookingConfirmed: jest.fn().mockResolvedValue(undefined),
+    sendBookingCancelled: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockChallenges = {
+    checkAndAward: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: DailyService, useValue: mockDaily },
+        { provide: NotificationsService, useValue: mockNotifications },
+        { provide: ChallengesService, useValue: mockChallenges },
+      ],
+    }).compile();
+
+    service = module.get<BookingsService>(BookingsService);
+    jest.clearAllMocks();
+    mockNotifications.sendBookingCreated.mockResolvedValue(undefined);
+    mockNotifications.sendBookingConfirmed.mockResolvedValue(undefined);
+    mockNotifications.sendBookingCancelled.mockResolvedValue(undefined);
+    mockChallenges.checkAndAward.mockResolvedValue(undefined);
+  });
+
+  // ─── getMyBookings ────────────────────────────────────────────────────────────
+
+  describe('getMyBookings', () => {
+    it('STUDENT: filtra las reservas por studentId', async () => {
+      const expectedBookings = [{ id: 'b1', studentId: 'user1' }];
+      mockPrisma.booking.findMany.mockResolvedValue(expectedBookings);
+
+      const result = await service.getMyBookings('user1', Role.STUDENT);
+
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { studentId: 'user1' },
+        }),
+      );
+      expect(result).toBe(expectedBookings);
+    });
+
+    it('TUTOR: obtiene los studentIds de sus alumnos y filtra por ellos', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([{ id: 's1' }, { id: 's2' }]);
+      const expectedBookings = [{ id: 'b1' }, { id: 'b2' }];
+      mockPrisma.booking.findMany.mockResolvedValue(expectedBookings);
+
+      const result = await service.getMyBookings('tutor1', Role.TUTOR);
+
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+        where: { tutorId: 'tutor1' },
+        select: { id: true },
+      });
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { studentId: { in: ['s1', 's2'] } },
+        }),
+      );
+      expect(result).toBe(expectedBookings);
+    });
+
+    it('TEACHER: busca su perfil y filtra las reservas por teacherId', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({ id: 'tp1', userId: 'teacher1' });
+      const expectedBookings = [{ id: 'b1', teacherId: 'tp1' }];
+      mockPrisma.booking.findMany.mockResolvedValue(expectedBookings);
+
+      const result = await service.getMyBookings('teacher1', Role.TEACHER);
+
+      expect(mockPrisma.teacherProfile.findUnique).toHaveBeenCalledWith({
+        where: { userId: 'teacher1' },
+      });
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { teacherId: 'tp1' },
+        }),
+      );
+      expect(result).toBe(expectedBookings);
+    });
+
+    it('TEACHER sin perfil: devuelve array vacío', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null);
+
+      const result = await service.getMyBookings('teacher1', Role.TEACHER);
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.booking.findMany).not.toHaveBeenCalled();
+    });
+
+    it('ADMIN: devuelve todas las reservas sin filtro de usuario', async () => {
+      const expectedBookings = [{ id: 'b1' }, { id: 'b2' }, { id: 'b3' }];
+      mockPrisma.booking.findMany.mockResolvedValue(expectedBookings);
+
+      const result = await service.getMyBookings('admin1', Role.ADMIN);
+
+      expect(mockPrisma.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {},
+        }),
+      );
+      expect(result).toBe(expectedBookings);
+    });
+  });
+
+  // ─── create ───────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    // Fijar la fecha actual en 2026-01-15 para controlar "el pasado"
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const validDto = {
+      studentId: 'student1',
+      teacherId: 'tp1',
+      startAt: '2026-01-20T10:00:00Z',
+      endAt: '2026-01-20T11:00:00Z',
+      mode: BookingMode.IN_PERSON,
+    };
+
+    it('TUTOR: lanza ForbiddenException si el alumno no le pertenece', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ tutorId: 'otherTutor' });
+
+      await expect(
+        service.create(validDto, 'tutor1', Role.TUTOR),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('lanza NotFoundException si el profesor no existe', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create(validDto, 'admin1', Role.ADMIN),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza NotFoundException si el courseId indicado no existe', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor', email: 'profesor@test.com' },
+      });
+      mockPrisma.course.findUnique.mockResolvedValue(null);
+
+      const dto = { ...validDto, courseId: 'nonexistent-course' };
+
+      await expect(
+        service.create(dto, 'admin1', Role.ADMIN),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza BadRequestException si startAt >= endAt', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor', email: 'profesor@test.com' },
+      });
+
+      const dto = {
+        ...validDto,
+        startAt: '2026-01-20T11:00:00Z',
+        endAt: '2026-01-20T10:00:00Z',
+      };
+
+      await expect(
+        service.create(dto, 'admin1', Role.ADMIN),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('lanza BadRequestException si startAt es en el pasado', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor', email: 'profesor@test.com' },
+      });
+
+      const dto = {
+        ...validDto,
+        startAt: '2026-01-10T10:00:00Z', // antes de 2026-01-15 (fecha fijada)
+        endAt: '2026-01-10T11:00:00Z',
+      };
+
+      await expect(
+        service.create(dto, 'admin1', Role.ADMIN),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('lanza BadRequestException si hay conflicto de horario con otra reserva', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor', email: 'profesor@test.com' },
+      });
+      mockPrisma.booking.findFirst.mockResolvedValue({ id: 'existing-booking' });
+
+      await expect(
+        service.create(validDto, 'admin1', Role.ADMIN),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('crea la reserva correctamente en el happy path', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor Test', email: 'profesor@test.com' },
+      });
+      mockPrisma.booking.findFirst.mockResolvedValue(null);
+      const createdBooking = { id: 'new-booking', studentId: 'student1', teacherId: 'tp1' };
+      mockPrisma.booking.create.mockResolvedValue(createdBooking);
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce({ name: 'Admin User' })  // creador
+        .mockResolvedValueOnce({ name: 'Alumno Test' }); // alumno
+
+      const result = await service.create(validDto, 'admin1', Role.ADMIN);
+
+      expect(mockPrisma.booking.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            studentId: 'student1',
+            teacherId: 'tp1',
+            mode: BookingMode.IN_PERSON,
+          }),
+        }),
+      );
+      expect(result).toBe(createdBooking);
+    });
+
+    it('llama a notifications.sendBookingCreated tras crear la reserva', async () => {
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor Test', email: 'profesor@test.com' },
+      });
+      mockPrisma.booking.findFirst.mockResolvedValue(null);
+      mockPrisma.booking.create.mockResolvedValue({ id: 'new-booking' });
+      // Para Role.ADMIN no hay verificación de tutorId, solo las dos llamadas finales
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce({ name: 'Admin User' })  // creador
+        .mockResolvedValueOnce({ name: 'Alumno Test' }); // alumno
+
+      await service.create(validDto, 'admin1', Role.ADMIN, 'academy1');
+
+      // Aunque sendBookingCreated se llama con .catch(), verificamos que fue invocado
+      expect(mockNotifications.sendBookingCreated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teacherEmail: 'profesor@test.com',
+          teacherName: 'Profesor Test',
+          studentName: 'Alumno Test',
+          tutorName: 'Admin User',
+          mode: BookingMode.IN_PERSON,
+        }),
+      );
+    });
+  });
+
+  // ─── confirm ─────────────────────────────────────────────────────────────────
+
+  describe('confirm', () => {
+    it('lanza NotFoundException si la reserva no existe', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue(null);
+
+      await expect(service.confirm('nonexistent', 'teacher1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza ForbiddenException si el userId no corresponde al teacher de la reserva', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 'b1',
+        teacherId: 'tp-correct',
+        mode: BookingMode.IN_PERSON,
+        studentId: 'student1',
+      });
+      // El perfil encontrado tiene un id diferente al teacherId de la reserva
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp-other',
+        user: { name: 'Otro Profesor' },
+      });
+
+      await expect(service.confirm('b1', 'otherTeacher')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('reserva IN_PERSON: no llama a daily.createRoom', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 'b1',
+        teacherId: 'tp1',
+        mode: BookingMode.IN_PERSON,
+        meetingUrl: null,
+        studentId: 'student1',
+        courseId: null,
+        startAt: new Date('2026-01-20T10:00:00Z'),
+        endAt: new Date('2026-01-20T11:00:00Z'),
+      });
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor Test' },
+      });
+      const confirmedBooking = { id: 'b1', status: BookingStatus.CONFIRMED };
+      mockPrisma.booking.update.mockResolvedValue(confirmedBooking);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await service.confirm('b1', 'teacher1');
+
+      expect(mockDaily.createRoom).not.toHaveBeenCalled();
+    });
+
+    it('reserva ONLINE sin meetingUrl: llama a daily.createRoom', async () => {
+      const startAt = new Date('2026-01-20T10:00:00Z');
+      const endAt = new Date('2026-01-20T11:00:00Z');
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 'b1',
+        teacherId: 'tp1',
+        mode: BookingMode.ONLINE,
+        meetingUrl: null,
+        studentId: 'student1',
+        courseId: null,
+        startAt,
+        endAt,
+      });
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor Test' },
+      });
+      mockDaily.createRoom.mockResolvedValue('https://daily.co/room/b1');
+      const confirmedBooking = {
+        id: 'b1',
+        status: BookingStatus.CONFIRMED,
+        meetingUrl: 'https://daily.co/room/b1',
+      };
+      mockPrisma.booking.update.mockResolvedValue(confirmedBooking);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await service.confirm('b1', 'teacher1');
+
+      expect(mockDaily.createRoom).toHaveBeenCalledWith('b1', startAt, endAt);
+      expect(mockPrisma.booking.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: BookingStatus.CONFIRMED,
+            meetingUrl: 'https://daily.co/room/b1',
+          }),
+        }),
+      );
+    });
+
+    it('llama a challenges.checkAndAward con BOOKING_ATTENDED y TOTAL_HOURS tras confirmar', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue({
+        id: 'b1',
+        teacherId: 'tp1',
+        mode: BookingMode.IN_PERSON,
+        meetingUrl: null,
+        studentId: 'student1',
+        courseId: null,
+        startAt: new Date('2026-01-20T10:00:00Z'),
+        endAt: new Date('2026-01-20T11:00:00Z'),
+      });
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
+        id: 'tp1',
+        user: { name: 'Profesor Test' },
+      });
+      mockPrisma.booking.update.mockResolvedValue({ id: 'b1', status: BookingStatus.CONFIRMED });
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await service.confirm('b1', 'teacher1');
+
+      expect(mockChallenges.checkAndAward).toHaveBeenCalledWith(
+        'student1',
+        ChallengeType.BOOKING_ATTENDED,
+        ChallengeType.TOTAL_HOURS,
+      );
+    });
+  });
+
+  // ─── cancel ───────────────────────────────────────────────────────────────────
+
+  describe('cancel', () => {
+    const baseBooking = {
+      id: 'b1',
+      studentId: 'student1',
+      teacherId: 'tp1',
+      mode: BookingMode.IN_PERSON,
+      meetingUrl: null,
+      startAt: new Date('2026-01-20T10:00:00Z'),
+      endAt: new Date('2026-01-20T11:00:00Z'),
+    };
+
+    it('lanza NotFoundException si la reserva no existe', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue(null);
+
+      await expect(service.cancel('nonexistent', 'user1', Role.STUDENT)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('STUDENT puede cancelar su propia reserva', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue(baseBooking);
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null); // no es teacher
+      const cancelledBooking = { ...baseBooking, status: BookingStatus.CANCELLED };
+      mockPrisma.booking.update.mockResolvedValue(cancelledBooking);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.cancel('b1', 'student1', Role.STUDENT);
+
+      expect(mockPrisma.booking.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'b1' },
+          data: { status: BookingStatus.CANCELLED, meetingUrl: null },
+        }),
+      );
+      expect(result).toBe(cancelledBooking);
+    });
+
+    it('TEACHER puede cancelar su propia reserva asignada', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue(baseBooking);
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue({ id: 'tp1' }); // coincide con teacherId de la reserva
+      const cancelledBooking = { ...baseBooking, status: BookingStatus.CANCELLED };
+      mockPrisma.booking.update.mockResolvedValue(cancelledBooking);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.cancel('b1', 'teacher1', Role.TEACHER);
+
+      expect(mockPrisma.booking.update).toHaveBeenCalled();
+      expect(result).toBe(cancelledBooking);
+    });
+
+    it('ADMIN puede cancelar cualquier reserva sin ser propietario', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue(baseBooking);
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null); // admin no tiene perfil de teacher
+      const cancelledBooking = { ...baseBooking, status: BookingStatus.CANCELLED };
+      mockPrisma.booking.update.mockResolvedValue(cancelledBooking);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.cancel('b1', 'admin1', Role.ADMIN);
+
+      expect(mockPrisma.booking.update).toHaveBeenCalled();
+      expect(result).toBe(cancelledBooking);
+    });
+
+    it('usuario sin relación con la reserva lanza ForbiddenException', async () => {
+      mockPrisma.booking.findUnique.mockResolvedValue(baseBooking);
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null); // no es teacher
+
+      // El usuario 'random1' no es el student (student1), no es teacher, y es STUDENT (no ADMIN/TUTOR)
+      await expect(service.cancel('b1', 'random1', Role.STUDENT)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('reserva ONLINE con meetingUrl: llama a daily.deleteRoom al cancelar', async () => {
+      const onlineBooking = {
+        ...baseBooking,
+        mode: BookingMode.ONLINE,
+        meetingUrl: 'https://daily.co/room/b1',
+      };
+      mockPrisma.booking.findUnique.mockResolvedValue(onlineBooking);
+      mockPrisma.teacherProfile.findUnique.mockResolvedValue(null);
+      const cancelledBooking = { ...onlineBooking, status: BookingStatus.CANCELLED };
+      mockPrisma.booking.update.mockResolvedValue(cancelledBooking);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockDaily.deleteRoom.mockResolvedValue(undefined);
+
+      // El student cancela su propia reserva
+      await service.cancel('b1', 'student1', Role.STUDENT);
+
+      expect(mockDaily.deleteRoom).toHaveBeenCalledWith('b1');
+    });
+  });
+});

--- a/apps/api/src/challenges/dto/redeem-item.dto.ts
+++ b/apps/api/src/challenges/dto/redeem-item.dto.ts
@@ -1,8 +1,9 @@
-import { IsString, IsInt, MinLength, Min } from 'class-validator';
+import { IsString, IsInt, MinLength, MaxLength, Min } from 'class-validator';
 
 export class RedeemItemDto {
   @IsString()
   @MinLength(2)
+  @MaxLength(200)
   itemName: string;
 
   @IsInt()

--- a/apps/api/src/courses/courses.service.spec.ts
+++ b/apps/api/src/courses/courses.service.spec.ts
@@ -1,0 +1,315 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CoursesService } from './courses.service';
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const fakeCourse = {
+  id: 'course1',
+  title: 'Baloncesto 1',
+  schoolYearId: 'sy1',
+  published: true,
+  schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' },
+  modules: [
+    {
+      id: 'm1',
+      order: 1,
+      lessons: [
+        { id: 'l1', title: 'L1', type: 'VIDEO', order: 1, moduleId: 'm1', youtubeId: 'abc' },
+        { id: 'l2', title: 'L2', type: 'QUIZ', order: 2, moduleId: 'm1', youtubeId: null },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Mock manual de PrismaService
+// ---------------------------------------------------------------------------
+
+const mockPrisma = {
+  course: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  enrollment: {
+    findMany: jest.fn(),
+  },
+  userProgress: {
+    findMany: jest.fn(),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('CoursesService', () => {
+  let service: CoursesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CoursesService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<CoursesService>(CoursesService);
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // findAll
+  // -------------------------------------------------------------------------
+
+  describe('findAll', () => {
+    it('STUDENT: filtra cursos publicados de su nivel (schoolYearId)', async () => {
+      mockPrisma.enrollment.findMany.mockResolvedValue([]);
+      mockPrisma.course.findMany.mockResolvedValue([fakeCourse]);
+      mockPrisma.course.count.mockResolvedValue(1);
+
+      const result = await service.findAll({
+        page: 1,
+        limit: 10,
+        role: Role.STUDENT,
+        userId: 'u1',
+        schoolYearId: 'sy1',
+      });
+
+      expect(mockPrisma.enrollment.findMany).toHaveBeenCalledWith({
+        where: { userId: 'u1' },
+        select: { courseId: true },
+      });
+
+      const whereArg = mockPrisma.course.findMany.mock.calls[0][0].where;
+      expect(whereArg.published).toBe(true);
+      expect(whereArg.schoolYearId).toBe('sy1');
+
+      expect(result.data).toEqual([fakeCourse]);
+      expect(result.total).toBe(1);
+    });
+
+    it('STUDENT sin nivel y sin matrículas: devuelve where.id = { in: [] }', async () => {
+      mockPrisma.enrollment.findMany.mockResolvedValue([]);
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.course.count.mockResolvedValue(0);
+
+      await service.findAll({
+        page: 1,
+        limit: 10,
+        role: Role.STUDENT,
+        userId: 'u1',
+        schoolYearId: null,
+      });
+
+      const whereArg = mockPrisma.course.findMany.mock.calls[0][0].where;
+      expect(whereArg.published).toBe(true);
+      expect(whereArg.id).toEqual({ in: [] });
+    });
+
+    it('STUDENT con matrículas: incluye cursos enrolled vía OR', async () => {
+      mockPrisma.enrollment.findMany.mockResolvedValue([{ courseId: 'courseX' }]);
+      mockPrisma.course.findMany.mockResolvedValue([fakeCourse]);
+      mockPrisma.course.count.mockResolvedValue(1);
+
+      await service.findAll({
+        page: 1,
+        limit: 10,
+        role: Role.STUDENT,
+        userId: 'u1',
+        schoolYearId: 'sy1',
+      });
+
+      const whereArg = mockPrisma.course.findMany.mock.calls[0][0].where;
+      expect(whereArg.published).toBe(true);
+      expect(whereArg.OR).toEqual([
+        { schoolYearId: 'sy1' },
+        { id: { in: ['courseX'] } },
+      ]);
+    });
+
+    it('ADMIN: devuelve todos los cursos sin filtro published', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([fakeCourse]);
+      mockPrisma.course.count.mockResolvedValue(1);
+
+      await service.findAll({
+        page: 1,
+        limit: 10,
+        role: Role.ADMIN,
+        userId: 'admin1',
+        schoolYearId: null,
+      });
+
+      expect(mockPrisma.enrollment.findMany).not.toHaveBeenCalled();
+
+      const whereArg = mockPrisma.course.findMany.mock.calls[0][0].where;
+      expect(whereArg.published).toBeUndefined();
+    });
+
+    it('Paginación: skip = (page - 1) * limit', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.course.count.mockResolvedValue(0);
+
+      await service.findAll({
+        page: 3,
+        limit: 10,
+        role: Role.ADMIN,
+        userId: 'admin1',
+        schoolYearId: null,
+      });
+
+      const callArgs = mockPrisma.course.findMany.mock.calls[0][0];
+      expect(callArgs.skip).toBe(20);
+      expect(callArgs.take).toBe(10);
+
+      const result = await service.findAll({
+        page: 3,
+        limit: 10,
+        role: Role.ADMIN,
+        userId: 'admin1',
+        schoolYearId: null,
+      });
+      expect(result.totalPages).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // findOne
+  // -------------------------------------------------------------------------
+
+  describe('findOne', () => {
+    it('Lanza NotFoundException si el curso no existe', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+
+    it('STUDENT lanza ForbiddenException para curso de otro nivel', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(fakeCourse); // schoolYearId = 'sy1'
+
+      await expect(
+        service.findOne('course1', { role: Role.STUDENT, schoolYearId: 'sy2' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('Devuelve curso con módulos y lecciones cuando el acceso es válido', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(fakeCourse);
+
+      const result = await service.findOne('course1', {
+        role: Role.STUDENT,
+        schoolYearId: 'sy1',
+      });
+
+      expect(result).toEqual(fakeCourse);
+      expect(result.modules[0].lessons).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getCourseProgress
+  // -------------------------------------------------------------------------
+
+  describe('getCourseProgress', () => {
+    beforeEach(() => {
+      mockPrisma.course.findUnique.mockResolvedValue(fakeCourse);
+    });
+
+    it('percentageComplete = 0 si no hay lecciones completadas', async () => {
+      mockPrisma.userProgress.findMany.mockResolvedValue([]);
+
+      const result = await service.getCourseProgress('course1', 'u1');
+
+      expect(result.percentageComplete).toBe(0);
+      expect(result.completedLessons).toBe(0);
+      expect(result.completedLessonIds).toEqual([]);
+    });
+
+    it('percentageComplete = 100 si todas las lecciones están completadas', async () => {
+      mockPrisma.userProgress.findMany.mockResolvedValue([
+        { lessonId: 'l1' },
+        { lessonId: 'l2' },
+      ]);
+
+      const result = await service.getCourseProgress('course1', 'u1');
+
+      expect(result.percentageComplete).toBe(100);
+      expect(result.completedLessons).toBe(2);
+      expect(result.totalLessons).toBe(2);
+    });
+
+    it('Calcula correctamente con lecciones parcialmente completadas', async () => {
+      mockPrisma.userProgress.findMany.mockResolvedValue([{ lessonId: 'l1' }]);
+
+      const result = await service.getCourseProgress('course1', 'u1');
+
+      expect(result.percentageComplete).toBe(50);
+      expect(result.completedLessons).toBe(1);
+      expect(result.totalLessons).toBe(2);
+    });
+
+    it('Devuelve completedLessonIds con los ids correctos', async () => {
+      mockPrisma.userProgress.findMany.mockResolvedValue([{ lessonId: 'l1' }]);
+
+      const result = await service.getCourseProgress('course1', 'u1');
+
+      expect(result.completedLessonIds).toEqual(['l1']);
+      expect(result.courseId).toBe('course1');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+
+  describe('create', () => {
+    it('Delega a prisma.course.create con el DTO recibido', async () => {
+      const dto = { title: 'Nuevo curso', schoolYearId: 'sy1' } as any;
+      const created = { id: 'newId', ...dto };
+      mockPrisma.course.create.mockResolvedValue(created);
+
+      const result = await service.create(dto);
+
+      expect(mockPrisma.course.create).toHaveBeenCalledWith({ data: dto });
+      expect(result).toEqual(created);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // update
+  // -------------------------------------------------------------------------
+
+  describe('update', () => {
+    it('Actualiza el curso correctamente cuando existe', async () => {
+      const dto = { title: 'Título actualizado' } as any;
+      const updated = { ...fakeCourse, title: 'Título actualizado' };
+
+      mockPrisma.course.findUnique.mockResolvedValue(fakeCourse);
+      mockPrisma.course.update.mockResolvedValue(updated);
+
+      const result = await service.update('course1', dto);
+
+      expect(mockPrisma.course.update).toHaveBeenCalledWith({
+        where: { id: 'course1' },
+        data: dto,
+      });
+      expect(result.title).toBe('Título actualizado');
+    });
+
+    it('Lanza NotFoundException si el curso no existe al actualizar', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null);
+
+      await expect(service.update('nonexistent', { title: 'X' } as any)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(mockPrisma.course.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/daily/daily.service.spec.ts
+++ b/apps/api/src/daily/daily.service.spec.ts
@@ -1,0 +1,162 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { DailyService } from './daily.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Construye un Response mock mínimo compatible con el contrato que usa DailyService. */
+function makeFetchResponse(options: {
+  ok: boolean;
+  status?: number;
+  json?: () => Promise<unknown>;
+  text?: () => Promise<string>;
+}): Response {
+  return {
+    ok: options.ok,
+    status: options.status ?? (options.ok ? 200 : 500),
+    json: options.json ?? (() => Promise.resolve({})),
+    text: options.text ?? (() => Promise.resolve('')),
+  } as unknown as Response;
+}
+
+/** Crea un TestingModule con DailyService y ConfigService mockeado. */
+async function buildModule(apiKeyValue: string): Promise<DailyService> {
+  const mockConfig = {
+    get: jest.fn((key: string, defaultVal?: unknown) =>
+      key === 'DAILY_API_KEY' ? apiKeyValue : defaultVal,
+    ),
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      DailyService,
+      { provide: ConfigService, useValue: mockConfig },
+    ],
+  }).compile();
+
+  return module.get<DailyService>(DailyService);
+}
+
+// ---------------------------------------------------------------------------
+// Suite principal
+// ---------------------------------------------------------------------------
+
+describe('DailyService', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Sin API key
+  // -------------------------------------------------------------------------
+
+  describe('sin API key configurada', () => {
+    let service: DailyService;
+
+    beforeEach(async () => {
+      service = await buildModule('');
+    });
+
+    it('createRoom devuelve null sin llamar a fetch', async () => {
+      const result = await service.createRoom(
+        'booking-123',
+        new Date('2026-04-01T10:00:00Z'),
+        new Date('2026-04-01T11:00:00Z'),
+      );
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('deleteRoom retorna sin llamar a fetch', async () => {
+      await service.deleteRoom('booking-123');
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Con API key
+  // -------------------------------------------------------------------------
+
+  describe('con API key configurada', () => {
+    let service: DailyService;
+    const BOOKING_ID = 'abc-456';
+    const START = new Date('2026-04-01T10:00:00Z');
+    const END = new Date('2026-04-01T11:00:00Z');
+
+    beforeEach(async () => {
+      service = await buildModule('test-daily-key');
+    });
+
+    it('createRoom construye el roomName como vkb-{bookingId}', async () => {
+      fetchSpy.mockResolvedValue(
+        makeFetchResponse({
+          ok: true,
+          json: () => Promise.resolve({ url: 'https://vkb.daily.co/vkb-abc-456', name: `vkb-${BOOKING_ID}` }),
+        }),
+      );
+
+      await service.createRoom(BOOKING_ID, START, END);
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as { name: string };
+      expect(body.name).toBe(`vkb-${BOOKING_ID}`);
+    });
+
+    it('createRoom devuelve la URL de la sala cuando la respuesta es exitosa', async () => {
+      const expectedUrl = 'https://vkb.daily.co/vkb-abc-456';
+      fetchSpy.mockResolvedValue(
+        makeFetchResponse({
+          ok: true,
+          json: () => Promise.resolve({ url: expectedUrl, name: `vkb-${BOOKING_ID}` }),
+        }),
+      );
+
+      const result = await service.createRoom(BOOKING_ID, START, END);
+
+      expect(result).toBe(expectedUrl);
+    });
+
+    it('createRoom devuelve null cuando la respuesta HTTP no es exitosa', async () => {
+      fetchSpy.mockResolvedValue(
+        makeFetchResponse({
+          ok: false,
+          status: 422,
+          text: () => Promise.resolve('Unprocessable Entity'),
+        }),
+      );
+
+      const result = await service.createRoom(BOOKING_ID, START, END);
+
+      expect(result).toBeNull();
+    });
+
+    it('deleteRoom llama a DELETE con la URL correcta', async () => {
+      fetchSpy.mockResolvedValue(makeFetchResponse({ ok: true, status: 200 }));
+
+      await service.deleteRoom(BOOKING_ID);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`https://api.daily.co/v1/rooms/vkb-${BOOKING_ID}`);
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('deleteRoom no lanza excepción cuando la sala ya no existe (404)', async () => {
+      fetchSpy.mockResolvedValue(
+        makeFetchResponse({ ok: false, status: 404, text: () => Promise.resolve('Not Found') }),
+      );
+
+      await expect(service.deleteRoom(BOOKING_ID)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,9 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import helmet from 'helmet';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Security headers (Helmet)
+  app.use(helmet());
 
   // Prefijo global de la API
   app.setGlobalPrefix('api');

--- a/apps/api/src/media/media.service.spec.ts
+++ b/apps/api/src/media/media.service.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+
+// ---------------------------------------------------------------------------
+// Mocks de módulos AWS — deben declararse antes del import del servicio
+// ---------------------------------------------------------------------------
+
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn().mockResolvedValue('https://s3.signed-url.example.com'),
+}));
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({})),
+  PutObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports que dependen de los mocks anteriores
+// ---------------------------------------------------------------------------
+
+import { MediaService } from './media.service';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ENV: Record<string, unknown> = {
+  AWS_REGION: 'eu-west-1',
+  AWS_ACCESS_KEY_ID: 'AKID',
+  AWS_SECRET_ACCESS_KEY: 'SECRET',
+  AWS_S3_BUCKET: 'test-bucket',
+  AWS_SIGNED_URL_EXPIRES: 3600,
+};
+
+function buildMockConfig(overrides: Record<string, unknown> = {}): ConfigService {
+  const merged = { ...ENV, ...overrides };
+  return {
+    get: jest.fn((key: string, defaultVal?: unknown) => merged[key] ?? defaultVal),
+  } as unknown as ConfigService;
+}
+
+async function buildModule(configService: ConfigService): Promise<MediaService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      MediaService,
+      { provide: ConfigService, useValue: configService },
+    ],
+  }).compile();
+
+  return module.get<MediaService>(MediaService);
+}
+
+// ---------------------------------------------------------------------------
+// Suite principal
+// ---------------------------------------------------------------------------
+
+describe('MediaService', () => {
+  let service: MediaService;
+  const mockedGetSignedUrl = getSignedUrl as jest.MockedFunction<typeof getSignedUrl>;
+  const MockedPutObjectCommand = PutObjectCommand as jest.MockedClass<typeof PutObjectCommand>;
+  const MockedGetObjectCommand = GetObjectCommand as jest.MockedClass<typeof GetObjectCommand>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockedGetSignedUrl.mockResolvedValue('https://s3.signed-url.example.com');
+    service = await buildModule(buildMockConfig());
+  });
+
+  // -------------------------------------------------------------------------
+  // getUploadUrl
+  // -------------------------------------------------------------------------
+
+  describe('getUploadUrl', () => {
+    it('genera una key con prefijo videos/ y la extensión del fichero original', async () => {
+      const { key } = await service.getUploadUrl('lesson-intro.mp4', 'video/mp4');
+
+      expect(key).toMatch(/^videos\/.+\.mp4$/);
+    });
+
+    it('genera keys únicas en llamadas distintas', async () => {
+      const [{ key: key1 }, { key: key2 }] = await Promise.all([
+        service.getUploadUrl('video.mp4', 'video/mp4'),
+        service.getUploadUrl('video.mp4', 'video/mp4'),
+      ]);
+
+      expect(key1).not.toBe(key2);
+    });
+
+    it('devuelve { uploadUrl, key } con la URL firmada de PUT', async () => {
+      const expectedUrl = 'https://s3.signed-url.example.com';
+
+      const result = await service.getUploadUrl('clase.webm', 'video/webm');
+
+      expect(result).toEqual({
+        uploadUrl: expectedUrl,
+        key: expect.stringMatching(/^videos\/.+\.webm$/),
+      });
+    });
+
+    it('construye PutObjectCommand con el bucket y contentType correctos', async () => {
+      await service.getUploadUrl('demo.mp4', 'video/mp4');
+
+      expect(MockedPutObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Bucket: 'test-bucket',
+          ContentType: 'video/mp4',
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getViewUrl
+  // -------------------------------------------------------------------------
+
+  describe('getViewUrl', () => {
+    it('construye GetObjectCommand con el bucket y la key recibida', async () => {
+      const key = 'videos/some-uuid.mp4';
+
+      await service.getViewUrl(key);
+
+      expect(MockedGetObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: key,
+      });
+    });
+
+    it('devuelve { url, expiresIn } con la URL firmada', async () => {
+      const result = await service.getViewUrl('videos/some-uuid.mp4');
+
+      expect(result).toEqual({
+        url: 'https://s3.signed-url.example.com',
+        expiresIn: 3600,
+      });
+    });
+
+    it('expiresIn refleja el valor de AWS_SIGNED_URL_EXPIRES en config', async () => {
+      const customService = await buildModule(
+        buildMockConfig({ AWS_SIGNED_URL_EXPIRES: 7200 }),
+      );
+
+      const { expiresIn } = await customService.getViewUrl('videos/any.mp4');
+
+      expect(expiresIn).toBe(7200);
+      expect(mockedGetSignedUrl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ expiresIn: 7200 }),
+      );
+    });
+  });
+});

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,211 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { NotificationsService } from './notifications.service';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_DATE = new Date('2026-04-15T10:00:00.000Z');
+const END_DATE = new Date('2026-04-15T11:00:00.000Z');
+
+const BOOKING_CREATED_PARAMS = {
+  teacherEmail: 'profesor@vkb.com',
+  teacherName: 'Carlos López',
+  studentName: 'Álvaro García',
+  tutorName: 'María García',
+  startAt: BASE_DATE,
+  endAt: END_DATE,
+  mode: 'IN_PERSON',
+};
+
+const BOOKING_CONFIRMED_PARAMS = {
+  tutorEmail: 'tutor@vkb.com',
+  studentEmail: 'alumno@vkb.com',
+  tutorName: 'María García',
+  studentName: 'Álvaro García',
+  teacherName: 'Carlos López',
+  startAt: BASE_DATE,
+  endAt: END_DATE,
+  mode: 'ONLINE',
+  meetingUrl: 'https://daily.co/sala-123',
+};
+
+const BOOKING_CANCELLED_PARAMS = {
+  notifyEmails: [
+    { email: 'tutor@vkb.com', name: 'María García' },
+    { email: 'profesor@vkb.com', name: 'Carlos López' },
+    { email: 'alumno@vkb.com', name: 'Álvaro García' },
+  ],
+  studentName: 'Álvaro García',
+  teacherName: 'Carlos López',
+  startAt: BASE_DATE,
+  endAt: END_DATE,
+  mode: 'IN_PERSON',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers para construir el ConfigService mock
+// ---------------------------------------------------------------------------
+
+function buildMockConfig(useApiKey: boolean) {
+  return {
+    get: jest.fn((key: string, defaultVal?: unknown) => {
+      if (key === 'RESEND_API_KEY') return useApiKey ? 'test-key' : undefined;
+      if (key === 'EMAIL_FROM') return 'test@vkb.com';
+      return defaultVal;
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite principal
+// ---------------------------------------------------------------------------
+
+describe('NotificationsService', () => {
+  // -------------------------------------------------------------------------
+  // Contexto SIN API key — this.resend es null
+  // -------------------------------------------------------------------------
+
+  describe('sin API key configurada', () => {
+    let service: NotificationsService;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          NotificationsService,
+          { provide: ConfigService, useValue: buildMockConfig(false) },
+        ],
+      }).compile();
+
+      service = module.get<NotificationsService>(NotificationsService);
+    });
+
+    it('sendEmail no lanza ningún error cuando resend es null', async () => {
+      await expect(
+        service.sendEmail('dest@test.com', 'Asunto', '<p>HTML</p>'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('sendBookingCreated no lanza ningún error cuando resend es null', async () => {
+      await expect(
+        service.sendBookingCreated(BOOKING_CREATED_PARAMS),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Contexto CON API key — this.resend está inicializado
+  // -------------------------------------------------------------------------
+
+  describe('con API key configurada', () => {
+    let service: NotificationsService;
+    let mockSend: jest.Mock;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          NotificationsService,
+          { provide: ConfigService, useValue: buildMockConfig(true) },
+        ],
+      }).compile();
+
+      service = module.get<NotificationsService>(NotificationsService);
+
+      // Inyectamos un objeto resend falso para no depender del módulo real de Resend
+      mockSend = jest.fn().mockResolvedValue({ id: 'msg-1' });
+      service['resend'] = { emails: { send: mockSend } } as any;
+    });
+
+    it('sendBookingCreated invoca sendEmail con el email del profesor', async () => {
+      await service.sendBookingCreated(BOOKING_CREATED_PARAMS);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'profesor@vkb.com',
+          subject: 'Nueva solicitud de clase — VKB Academy',
+        }),
+      );
+    });
+
+    it('sendBookingConfirmed envía exactamente 2 emails (tutor + alumno)', async () => {
+      await service.sendBookingConfirmed(BOOKING_CONFIRMED_PARAMS);
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+
+      const recipients = mockSend.mock.calls.map((call) => call[0].to as string);
+      expect(recipients).toContain('tutor@vkb.com');
+      expect(recipients).toContain('alumno@vkb.com');
+    });
+
+    it('sendBookingConfirmed usa Promise.allSettled (ambos envíos se completan aunque uno falle)', async () => {
+      // Simulamos que el segundo envío falla
+      mockSend
+        .mockResolvedValueOnce({ id: 'msg-tutor' })
+        .mockRejectedValueOnce(new Error('SMTP error'));
+
+      // Promise.allSettled nunca rechaza; el servicio no debe propagar el error
+      await expect(
+        service.sendBookingConfirmed(BOOKING_CONFIRMED_PARAMS),
+      ).resolves.not.toThrow();
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('sendBookingCancelled envía un email por cada entrada en notifyEmails', async () => {
+      await service.sendBookingCancelled(BOOKING_CANCELLED_PARAMS);
+
+      expect(mockSend).toHaveBeenCalledTimes(
+        BOOKING_CANCELLED_PARAMS.notifyEmails.length,
+      );
+
+      const recipients = mockSend.mock.calls.map((call) => call[0].to as string);
+      expect(recipients).toContain('tutor@vkb.com');
+      expect(recipients).toContain('profesor@vkb.com');
+      expect(recipients).toContain('alumno@vkb.com');
+    });
+
+    it('sendPasswordReset incluye el resetUrl en el HTML enviado', async () => {
+      const resetUrl = 'https://vkbacademy.com/reset?token=abc123';
+
+      await service.sendPasswordReset({
+        email: 'alumno@vkb.com',
+        name: 'Álvaro García',
+        resetUrl,
+      });
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const [{ html, subject }] = mockSend.mock.calls[0] as [
+        { html: string; subject: string },
+      ];
+      expect(subject).toBe('Restablecer contraseña — VKB Academy');
+      expect(html).toContain(resetUrl);
+    });
+
+    it('sendEmail captura el error de resend sin propagarlo al llamante', async () => {
+      mockSend.mockRejectedValue(new Error('API timeout'));
+
+      await expect(
+        service.sendEmail('dest@test.com', 'Asunto', '<p>HTML</p>'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('sendEmail utiliza el from configurado en EMAIL_FROM', async () => {
+      await service.sendEmail('dest@test.com', 'Asunto', '<p>HTML</p>');
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ from: 'test@vkb.com' }),
+      );
+    });
+
+    it('sendBookingCancelled con lista vacía no invoca send', async () => {
+      await service.sendBookingCancelled({
+        ...BOOKING_CANCELLED_PARAMS,
+        notifyEmails: [],
+      });
+
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/school-years/school-years.service.spec.ts
+++ b/apps/api/src/school-years/school-years.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SchoolYearsService } from './school-years.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+// ─── Mock manual de PrismaService ────────────────────────────────────────────
+
+const mockPrisma = {
+  schoolYear: {
+    findMany: jest.fn(),
+  },
+};
+
+// ─── Suite principal ──────────────────────────────────────────────────────────
+
+describe('SchoolYearsService', () => {
+  let service: SchoolYearsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SchoolYearsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<SchoolYearsService>(SchoolYearsService);
+
+    jest.clearAllMocks();
+  });
+
+  // ─── findAll ───────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('devuelve la lista de niveles educativos ordenada por nombre', async () => {
+      const expected = [
+        { id: '1', name: '1bach', label: '1º Bach' },
+        { id: '2', name: '1eso', label: '1º ESO' },
+        { id: '3', name: '2bach', label: '2º Bach' },
+        { id: '4', name: '2eso', label: '2º ESO' },
+      ];
+      mockPrisma.schoolYear.findMany.mockResolvedValue(expected);
+
+      const result = await service.findAll();
+
+      expect(mockPrisma.schoolYear.findMany).toHaveBeenCalledWith({
+        orderBy: { name: 'asc' },
+      });
+      expect(result).toEqual(expected);
+    });
+
+    it('devuelve array vacío cuando no hay niveles educativos registrados', async () => {
+      mockPrisma.schoolYear.findMany.mockResolvedValue([]);
+
+      const result = await service.findAll();
+
+      expect(mockPrisma.schoolYear.findMany).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/tutor/tutor.service.spec.ts
+++ b/apps/api/src/tutor/tutor.service.spec.ts
@@ -1,0 +1,245 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Response } from 'express';
+import { TutorService } from './tutor.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { TutorChatDto } from './dto/tutor-chat.dto';
+
+const mockTutorMessage = {
+  findMany: jest.fn(),
+  create: jest.fn(),
+  deleteMany: jest.fn(),
+};
+
+const mockPrisma = {
+  tutorMessage: mockTutorMessage,
+};
+
+const mockConfig = {
+  get: jest.fn().mockReturnValue('fake-api-key'),
+};
+
+const mockRes = {
+  setHeader: jest.fn(),
+  flushHeaders: jest.fn(),
+  write: jest.fn(),
+  end: jest.fn(),
+} as unknown as Response;
+
+describe('TutorService', () => {
+  let service: TutorService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TutorService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get<TutorService>(TutorService);
+  });
+
+  describe('getHistory', () => {
+    it('devuelve los últimos 50 mensajes en orden cronológico', async () => {
+      const fakeMessages = [
+        { id: '1', role: 'user', content: 'Hola', courseId: null, lessonId: null, createdAt: new Date('2026-01-01') },
+        { id: '2', role: 'assistant', content: 'Hola, ¿en qué te puedo ayudar?', courseId: null, lessonId: null, createdAt: new Date('2026-01-02') },
+      ];
+      mockTutorMessage.findMany.mockResolvedValue(fakeMessages);
+
+      const result = await service.getHistory('user-123');
+
+      expect(mockTutorMessage.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        orderBy: { createdAt: 'asc' },
+        take: 50,
+        select: {
+          id: true,
+          role: true,
+          content: true,
+          courseId: true,
+          lessonId: true,
+          createdAt: true,
+        },
+      });
+      expect(result).toEqual(fakeMessages);
+    });
+
+    it('devuelve array vacío si no hay historial', async () => {
+      mockTutorMessage.findMany.mockResolvedValue([]);
+
+      const result = await service.getHistory('user-sin-historial');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('clearHistory', () => {
+    it('llama a deleteMany con el userId correcto', async () => {
+      mockTutorMessage.deleteMany.mockResolvedValue({ count: 5 });
+
+      await service.clearHistory('user-123');
+
+      expect(mockTutorMessage.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+      });
+    });
+
+    it('devuelve { cleared: true }', async () => {
+      mockTutorMessage.deleteMany.mockResolvedValue({ count: 3 });
+
+      const result = await service.clearHistory('user-123');
+
+      expect(result).toEqual({ cleared: true });
+    });
+  });
+
+  describe('streamChat', () => {
+    const userId = 'user-abc';
+    const dto: TutorChatDto = {
+      message: '¿Qué es la fotosíntesis?',
+      courseId: 'course-1',
+      lessonId: 'lesson-1',
+      courseName: 'Biología',
+      lessonName: 'Las plantas',
+      schoolYear: '2º ESO',
+    };
+
+    const historialPrevio = [
+      { id: 'msg-1', role: 'user', content: 'Pregunta anterior', createdAt: new Date('2026-01-01') },
+      { id: 'msg-2', role: 'assistant', content: 'Respuesta anterior', createdAt: new Date('2026-01-02') },
+    ];
+
+    const buildMockStream = (chunks: Array<object> = [
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hola' } },
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: ' mundo' } },
+    ]) => ({
+      [Symbol.asyncIterator]: async function* () {
+        for (const chunk of chunks) {
+          yield chunk;
+        }
+      },
+    });
+
+    const setMockAnthropic = (streamReturnValue: object) => {
+      Object.defineProperty(service, 'anthropic', {
+        value: { messages: { stream: jest.fn().mockReturnValue(streamReturnValue) } },
+        writable: true,
+        configurable: true,
+      });
+    };
+
+    beforeEach(() => {
+      mockTutorMessage.findMany.mockResolvedValue(historialPrevio);
+      mockTutorMessage.create.mockResolvedValue({});
+      setMockAnthropic(buildMockStream());
+    });
+
+    it('guarda el mensaje del usuario en BD antes de llamar a Anthropic', async () => {
+      await service.streamChat(userId, dto, mockRes);
+
+      expect(mockTutorMessage.create).toHaveBeenCalledWith({
+        data: {
+          userId,
+          role: 'user',
+          content: dto.message,
+          courseId: dto.courseId,
+          lessonId: dto.lessonId,
+        },
+      });
+
+      const streamMock = service['anthropic'].messages.stream as jest.Mock;
+      const createCalls = mockTutorMessage.create.mock.calls;
+      const userCreateCallIndex = createCalls.findIndex(
+        (call) => call[0].data.role === 'user',
+      );
+      const streamCallOrder = streamMock.mock.invocationCallOrder[0];
+      const userCreateCallOrder = mockTutorMessage.create.mock.invocationCallOrder[userCreateCallIndex];
+
+      expect(userCreateCallOrder).toBeLessThan(streamCallOrder);
+    });
+
+    it('incluye historial previo en los mensajes enviados a Anthropic', async () => {
+      await service.streamChat(userId, dto, mockRes);
+
+      const streamMock = service['anthropic'].messages.stream as jest.Mock;
+      const llamadaArgs = streamMock.mock.calls[0][0];
+
+      expect(llamadaArgs.messages).toEqual([
+        { role: 'user', content: 'Pregunta anterior' },
+        { role: 'assistant', content: 'Respuesta anterior' },
+        { role: 'user', content: dto.message },
+      ]);
+    });
+
+    it('escribe chunks SSE al response durante el streaming', async () => {
+      await service.streamChat(userId, dto, mockRes);
+
+      expect(mockRes.write).toHaveBeenCalledWith(
+        `data: ${JSON.stringify({ text: 'Hola' })}\n\n`,
+      );
+      expect(mockRes.write).toHaveBeenCalledWith(
+        `data: ${JSON.stringify({ text: ' mundo' })}\n\n`,
+      );
+    });
+
+    it('guarda la respuesta completa del asistente en BD tras el stream', async () => {
+      await service.streamChat(userId, dto, mockRes);
+
+      const createCalls = mockTutorMessage.create.mock.calls;
+      const assistantCreate = createCalls.find(
+        (call) => call[0].data.role === 'assistant',
+      );
+
+      expect(assistantCreate).toBeDefined();
+      expect(assistantCreate[0]).toEqual({
+        data: {
+          userId,
+          role: 'assistant',
+          content: 'Hola mundo',
+          courseId: dto.courseId,
+          lessonId: dto.lessonId,
+        },
+      });
+    });
+
+    it('en caso de error de Anthropic, escribe evento SSE de error', async () => {
+      const mockStreamError = {
+        [Symbol.asyncIterator]: async function* () {
+          throw new Error('Fallo de red Anthropic');
+        },
+      };
+
+      setMockAnthropic(mockStreamError);
+
+      await service.streamChat(userId, dto, mockRes);
+
+      expect(mockRes.write).toHaveBeenCalledWith(
+        `data: ${JSON.stringify({ error: 'Error al procesar tu pregunta' })}\n\n`,
+      );
+    });
+
+    it('siempre llama a res.end() independientemente del resultado', async () => {
+      await service.streamChat(userId, dto, mockRes);
+      expect(mockRes.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('siempre llama a res.end() incluso cuando Anthropic lanza un error', async () => {
+      const mockStreamError = {
+        [Symbol.asyncIterator]: async function* () {
+          throw new Error('Fallo inesperado');
+        },
+      };
+
+      setMockAnthropic(mockStreamError);
+
+      await service.streamChat(userId, dto, mockRes);
+
+      expect(mockRes.end).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/tutors/tutors.service.spec.ts
+++ b/apps/api/src/tutors/tutors.service.spec.ts
@@ -1,0 +1,414 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { TutorsService } from './tutors.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TUTOR_ID = 'tutor1';
+const STUDENT_ID = 'student1';
+
+const mockStudent = {
+  id: STUDENT_ID,
+  name: 'Alumno',
+  email: 'a@b.com',
+  avatarUrl: null,
+  tutorId: TUTOR_ID,
+  totalPoints: 50,
+  currentStreak: 3,
+  longestStreak: 5,
+  createdAt: new Date('2025-09-01'),
+  schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' },
+};
+
+// ---------------------------------------------------------------------------
+// Mock de PrismaService
+// ---------------------------------------------------------------------------
+
+const mockPrisma = {
+  user: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+  },
+  enrollment: {
+    findMany: jest.fn(),
+  },
+  userProgress: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  quizAttempt: {
+    findMany: jest.fn(),
+  },
+  examAttempt: {
+    findMany: jest.fn(),
+  },
+  certificate: {
+    findMany: jest.fn(),
+  },
+  booking: {
+    findMany: jest.fn(),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helper: configura todas las queries de Promise.all con valores vacíos
+// ---------------------------------------------------------------------------
+
+function setupEmptyParallelQueries() {
+  mockPrisma.userProgress.findMany.mockResolvedValue([]);
+  mockPrisma.quizAttempt.findMany.mockResolvedValue([]);
+  mockPrisma.examAttempt.findMany.mockResolvedValue([]);
+  mockPrisma.certificate.findMany.mockResolvedValue([]);
+  mockPrisma.booking.findMany.mockResolvedValue([]);
+  mockPrisma.enrollment.findMany.mockResolvedValue([]);
+  mockPrisma.userProgress.count.mockResolvedValue(0);
+}
+
+// ---------------------------------------------------------------------------
+// Suite principal
+// ---------------------------------------------------------------------------
+
+describe('TutorsService', () => {
+  let service: TutorsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TutorsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<TutorsService>(TutorsService);
+  });
+
+  // -------------------------------------------------------------------------
+  // getMyStudents
+  // -------------------------------------------------------------------------
+
+  describe('getMyStudents', () => {
+    it('devuelve la lista de alumnos del tutor', async () => {
+      const students = [
+        { id: STUDENT_ID, name: 'Alumno', email: 'a@b.com', avatarUrl: null, totalPoints: 50, currentStreak: 3, schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' } },
+      ];
+      mockPrisma.user.findMany.mockResolvedValue(students);
+
+      const result = await service.getMyStudents(TUTOR_ID);
+
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { tutorId: TUTOR_ID } }),
+      );
+      expect(result).toEqual(students);
+    });
+
+    it('devuelve array vacío cuando el tutor no tiene alumnos', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([]);
+
+      const result = await service.getMyStudents(TUTOR_ID);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getStudentCourses
+  // -------------------------------------------------------------------------
+
+  describe('getStudentCourses', () => {
+    it('lanza ForbiddenException si el alumno no existe', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getStudentCourses(TUTOR_ID, STUDENT_ID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('lanza ForbiddenException si el alumno pertenece a otro tutor', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ tutorId: 'otro-tutor' });
+
+      await expect(service.getStudentCourses(TUTOR_ID, STUDENT_ID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('devuelve los cursos en los que está matriculado el alumno', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ tutorId: TUTOR_ID });
+
+      const course = { id: 'c1', title: 'Curso 1', schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' } };
+      mockPrisma.enrollment.findMany.mockResolvedValue([{ course }, { course: { id: 'c2', title: 'Curso 2', schoolYear: null } }]);
+
+      const result = await service.getStudentCourses(TUTOR_ID, STUDENT_ID);
+
+      expect(mockPrisma.enrollment.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: STUDENT_ID } }),
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(course);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getStudentStats
+  // -------------------------------------------------------------------------
+
+  describe('getStudentStats', () => {
+    it('lanza ForbiddenException si el alumno no pertenece al tutor', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ ...mockStudent, tutorId: 'otro-tutor' });
+
+      await expect(service.getStudentStats(TUTOR_ID, STUDENT_ID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('lanza ForbiddenException si el alumno no existe', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getStudentStats(TUTOR_ID, STUDENT_ID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('devuelve la estructura completa con todas las secciones', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result).toMatchObject({
+        student: expect.objectContaining({ id: STUDENT_ID, name: 'Alumno' }),
+        period: { from: null, to: null },
+        lessons: expect.objectContaining({ completedInPeriod: 0, completedAllTime: 0, activeDays: 0 }),
+        quizzes: expect.objectContaining({ attempts: 0, avgScore: null, bestScore: null }),
+        exams: expect.objectContaining({ attempts: 0, avgScore: null, bestScore: null, passed: 0 }),
+        certificates: { total: 0, byType: {} },
+        sessions: { confirmed: 0, totalHours: 0 },
+        courses: [],
+        activity: [],
+      });
+    });
+
+    it('progressPct es 0 cuando no hay lecciones completadas', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      // Curso con 2 lecciones, ninguna completada
+      mockPrisma.enrollment.findMany.mockResolvedValue([
+        {
+          course: {
+            id: 'c1',
+            title: 'Curso 1',
+            schoolYear: null,
+            modules: [{ id: 'm1', title: 'Módulo 1', lessons: [{ id: 'l1' }, { id: 'l2' }] }],
+          },
+        },
+      ]);
+      // La segunda llamada a findMany (completedLessons) devuelve vacío
+      mockPrisma.userProgress.findMany
+        .mockResolvedValueOnce([]) // completedInPeriod (Promise.all)
+        .mockResolvedValueOnce([]); // completedLessons
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result.courses[0].progressPct).toBe(0);
+    });
+
+    it('progressPct es 100 cuando todas las lecciones están completadas', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      mockPrisma.enrollment.findMany.mockResolvedValue([
+        {
+          course: {
+            id: 'c1',
+            title: 'Curso 1',
+            schoolYear: null,
+            modules: [{ id: 'm1', title: 'Módulo 1', lessons: [{ id: 'l1' }, { id: 'l2' }] }],
+          },
+        },
+      ]);
+      mockPrisma.userProgress.findMany
+        .mockResolvedValueOnce([]) // completedInPeriod
+        .mockResolvedValueOnce([{ lessonId: 'l1' }, { lessonId: 'l2' }]); // completedLessons
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result.courses[0].progressPct).toBe(100);
+      expect(result.courses[0].completedLessons).toBe(2);
+    });
+
+    it('avgQuizScore es null si no hay intentos de quiz', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result.quizzes.avgScore).toBeNull();
+      expect(result.quizzes.bestScore).toBeNull();
+    });
+
+    it('avgQuizScore calcula correctamente con múltiples intentos', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      const now = new Date('2026-01-10T10:00:00Z');
+      mockPrisma.quizAttempt.findMany.mockResolvedValue([
+        { score: 60, completedAt: now },
+        { score: 80, completedAt: now },
+        { score: 70, completedAt: now },
+      ]);
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      // (60 + 80 + 70) / 3 = 70.0
+      expect(result.quizzes.avgScore).toBe(70);
+      expect(result.quizzes.bestScore).toBe(80);
+      expect(result.quizzes.attempts).toBe(3);
+    });
+
+    it('totalHours calcula correctamente desde startAt/endAt de reservas', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      // 2 reservas de 1 hora cada una = 2 horas
+      const startAt = new Date('2026-01-10T10:00:00Z');
+      const endAt = new Date('2026-01-10T11:00:00Z');
+      mockPrisma.booking.findMany.mockResolvedValue([
+        { startAt, endAt },
+        { startAt, endAt },
+      ]);
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result.sessions.confirmed).toBe(2);
+      expect(result.sessions.totalHours).toBe(2);
+    });
+
+    it('activeDays cuenta los días únicos con lecciones completadas', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      // 3 lecciones completadas: 2 el mismo día y 1 en otro
+      const day1a = new Date('2026-01-10T09:00:00Z');
+      const day1b = new Date('2026-01-10T15:00:00Z');
+      const day2 = new Date('2026-01-11T10:00:00Z');
+      mockPrisma.userProgress.findMany
+        .mockResolvedValueOnce([
+          { completedAt: day1a },
+          { completedAt: day1b },
+          { completedAt: day2 },
+        ]) // completedInPeriod
+        .mockResolvedValueOnce([]); // completedLessons
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result.lessons.activeDays).toBe(2);
+    });
+
+    it('aplica filtro de fecha en userProgress cuando se pasan from y to', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      const from = new Date('2026-01-01');
+      const to = new Date('2026-01-31');
+
+      await service.getStudentStats(TUTOR_ID, STUDENT_ID, from, to);
+
+      // userProgress.findMany (completedInPeriod) debe incluir gte/lte
+      expect(mockPrisma.userProgress.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            completedAt: { gte: from, lte: to },
+          }),
+        }),
+      );
+    });
+
+    it('el resultado incluye el período correcto cuando se pasan from y to', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      const from = new Date('2026-01-01');
+      const to = new Date('2026-01-31');
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID, from, to);
+
+      expect(result.period).toEqual({ from, to });
+    });
+
+    it('sin from/to usa { not: null } en lugar de rango de fechas en userProgress', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(mockPrisma.userProgress.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            completedAt: { not: null },
+          }),
+        }),
+      );
+    });
+
+    it('certificates.byType agrupa correctamente por tipo', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      mockPrisma.certificate.findMany.mockResolvedValue([
+        { type: 'COURSE_COMPLETION', issuedAt: new Date() },
+        { type: 'COURSE_COMPLETION', issuedAt: new Date() },
+        { type: 'MODULE_EXAM', issuedAt: new Date() },
+      ]);
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result.certificates.total).toBe(3);
+      expect(result.certificates.byType).toEqual({
+        COURSE_COMPLETION: 2,
+        MODULE_EXAM: 1,
+      });
+    });
+
+    it('exams.passed cuenta solo los intentos con score >= 50', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      const submittedAt = new Date('2026-01-10T10:00:00Z');
+      mockPrisma.examAttempt.findMany.mockResolvedValue([
+        { score: 49, submittedAt },
+        { score: 50, submittedAt },
+        { score: 75, submittedAt },
+        { score: null, submittedAt }, // null → 0 según el servicio
+      ]);
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      expect(result.exams.passed).toBe(2); // score 50 y 75
+      expect(result.exams.attempts).toBe(4);
+    });
+
+    it('el array activity está ordenado por fecha ascendente', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockStudent);
+      setupEmptyParallelQueries();
+
+      // Lecciones completadas en distintos días (desordenados)
+      mockPrisma.userProgress.findMany
+        .mockResolvedValueOnce([
+          { completedAt: new Date('2026-01-15T10:00:00Z') },
+          { completedAt: new Date('2026-01-10T10:00:00Z') },
+          { completedAt: new Date('2026-01-20T10:00:00Z') },
+        ]) // completedInPeriod
+        .mockResolvedValueOnce([]); // completedLessons
+
+      const result = await service.getStudentStats(TUTOR_ID, STUDENT_ID);
+
+      const dates = result.activity.map((a) => a.date);
+      expect(dates).toEqual([...dates].sort());
+    });
+  });
+});

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,0 +1,206 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UsersService } from './users.service';
+
+jest.mock('bcrypt');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_USER = {
+  id: 'user-1',
+  email: 'alumno@vkb.com',
+  name: 'Álvaro García',
+  role: 'STUDENT' as const,
+  avatarUrl: null,
+  createdAt: new Date('2025-01-01T00:00:00.000Z'),
+  schoolYearId: 'sy-1',
+  passwordHash: '$2b$10$existingHash',
+  schoolYear: { id: 'sy-1', name: '1eso', label: '1º ESO' },
+};
+
+const PROFILE_RESPONSE = {
+  id: BASE_USER.id,
+  email: BASE_USER.email,
+  name: BASE_USER.name,
+  role: BASE_USER.role,
+  avatarUrl: BASE_USER.avatarUrl,
+  createdAt: BASE_USER.createdAt,
+  schoolYearId: BASE_USER.schoolYearId,
+  schoolYear: BASE_USER.schoolYear,
+};
+
+// ---------------------------------------------------------------------------
+// Mock de PrismaService
+// ---------------------------------------------------------------------------
+
+const mockPrisma = {
+  user: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Suite principal
+// ---------------------------------------------------------------------------
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // getProfile
+  // -------------------------------------------------------------------------
+
+  describe('getProfile', () => {
+    it('devuelve el perfil del usuario cuando existe', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(PROFILE_RESPONSE);
+
+      const result = await service.getProfile('user-1');
+
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        select: expect.objectContaining({
+          id: true,
+          email: true,
+          name: true,
+          role: true,
+          avatarUrl: true,
+          createdAt: true,
+          schoolYearId: true,
+          schoolYear: expect.any(Object),
+        }),
+      });
+      expect(result).toEqual(PROFILE_RESPONSE);
+    });
+
+    it('lanza NotFoundException cuando el usuario no existe', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getProfile('inexistente')).rejects.toThrow(
+        new NotFoundException('Usuario no encontrado'),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // updateProfile
+  // -------------------------------------------------------------------------
+
+  describe('updateProfile', () => {
+    it('lanza NotFoundException cuando el usuario no existe', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const dto: UpdateProfileDto = { name: 'Nuevo Nombre' };
+
+      await expect(service.updateProfile('inexistente', dto)).rejects.toThrow(
+        new NotFoundException('Usuario no encontrado'),
+      );
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it('lanza BadRequestException cuando el email nuevo ya está en uso por otro usuario', async () => {
+      // Primera llamada: usuario actual encontrado
+      mockPrisma.user.findUnique.mockResolvedValueOnce(BASE_USER);
+      // Segunda llamada: el nuevo email ya existe en BD
+      mockPrisma.user.findUnique.mockResolvedValueOnce({ id: 'user-2', email: 'otro@vkb.com' });
+
+      const dto: UpdateProfileDto = { email: 'otro@vkb.com' };
+
+      await expect(service.updateProfile('user-1', dto)).rejects.toThrow(
+        new BadRequestException('El email ya está en uso'),
+      );
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it('actualiza el nombre correctamente', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(BASE_USER);
+      const updatedProfile = { ...PROFILE_RESPONSE, name: 'Nuevo Nombre' };
+      mockPrisma.user.update.mockResolvedValue(updatedProfile);
+
+      const dto: UpdateProfileDto = { name: 'Nuevo Nombre' };
+      const result = await service.updateProfile('user-1', dto);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'user-1' },
+          data: { name: 'Nuevo Nombre' },
+        }),
+      );
+      expect(result.name).toBe('Nuevo Nombre');
+    });
+
+    it('actualiza el email al mismo valor del usuario sin verificar duplicados', async () => {
+      // El email del DTO es idéntico al actual → no debe hacer la segunda consulta
+      mockPrisma.user.findUnique.mockResolvedValue(BASE_USER);
+      mockPrisma.user.update.mockResolvedValue(PROFILE_RESPONSE);
+
+      const dto: UpdateProfileDto = { email: BASE_USER.email };
+      await service.updateProfile('user-1', dto);
+
+      // Solo se llama a findUnique una vez (para obtener el usuario)
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { email: BASE_USER.email },
+        }),
+      );
+    });
+
+    it('hashea la contraseña con bcrypt antes de guardarla', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(BASE_USER);
+      mockPrisma.user.update.mockResolvedValue(PROFILE_RESPONSE);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('$2b$10$hashed');
+
+      const dto: UpdateProfileDto = { password: 'nuevaPass123' };
+      await service.updateProfile('user-1', dto);
+
+      expect(bcrypt.hash).toHaveBeenCalledWith('nuevaPass123', 10);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { passwordHash: '$2b$10$hashed' },
+        }),
+      );
+    });
+
+    it('no incluye passwordHash en la respuesta devuelta al cliente', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(BASE_USER);
+      // Simulamos que Prisma devuelve únicamente los campos del select (sin passwordHash)
+      mockPrisma.user.update.mockResolvedValue(PROFILE_RESPONSE);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('$2b$10$hashed');
+
+      const dto: UpdateProfileDto = { password: 'nuevaPass123' };
+      const result = await service.updateProfile('user-1', dto);
+
+      expect(result).not.toHaveProperty('passwordHash');
+      // El select de Prisma es la garantía real; comprobamos que se pasa correctamente
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            id: true,
+            email: true,
+            name: true,
+            role: true,
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/test/e2e/11-availability.e2e-spec.ts
+++ b/apps/api/test/e2e/11-availability.e2e-spec.ts
@@ -1,0 +1,192 @@
+import {
+  createApp,
+  closeApp,
+  login,
+  authGet,
+  authPost,
+  authDelete,
+  publicGet,
+  getPrisma,
+} from './setup';
+
+describe('Availability — /teachers & /availability', () => {
+  let teacherToken: string;
+  let studentToken: string;
+  let adminToken: string;
+
+  let teacherProfileId: string;
+
+  // ID del slot creado en el test de POST, reutilizado en DELETE y duplicado
+  let createdSlotId: string;
+
+  beforeAll(async () => {
+    await createApp();
+
+    const [t, s, a] = await Promise.all([
+      login('teacher@vkbacademy.com'),
+      login('student@vkbacademy.com'),
+      login('admin@vkbacademy.com'),
+    ]);
+
+    teacherToken = t.accessToken;
+    studentToken = s.accessToken;
+    adminToken = a.accessToken;
+
+    // Resolver el perfil del teacher desde la BD
+    const prisma = getPrisma();
+    const profile = await prisma.teacherProfile.findFirst({
+      where: { user: { email: 'teacher@vkbacademy.com' } },
+    });
+    if (!profile) throw new Error('Perfil de teacher no encontrado. Ejecuta el seed.');
+    teacherProfileId = profile.id;
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ─── GET /teachers ─────────────────────────────────────────────────────────
+
+  describe('GET /teachers', () => {
+    it('usuario autenticado recibe lista con al menos 1 teacher', async () => {
+      const res = await authGet('/teachers', teacherToken);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+
+      // Cada entrada incluye perfil + usuario + disponibilidad
+      const first = res.body[0];
+      expect(first).toHaveProperty('id');
+      expect(first).toHaveProperty('user');
+      expect(first).toHaveProperty('availability');
+      expect(Array.isArray(first.availability)).toBe(true);
+    });
+
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await publicGet('/teachers');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ─── GET /teachers/:teacherId/slots ────────────────────────────────────────
+
+  describe('GET /teachers/:teacherId/slots', () => {
+    it('devuelve 200 y un array de slots libres con from/to válidos', async () => {
+      const from = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();      // mañana
+      const to = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString();   // +30 días
+
+      const res = await authGet(
+        `/teachers/${teacherProfileId}/slots?from=${from}&to=${to}`,
+        teacherToken,
+      );
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      // Cada slot libre tiene teacherId, startAt, endAt
+      for (const slot of res.body) {
+        expect(slot).toHaveProperty('teacherId');
+        expect(slot).toHaveProperty('startAt');
+        expect(slot).toHaveProperty('endAt');
+      }
+    });
+  });
+
+  // ─── GET /availability/mine ────────────────────────────────────────────────
+
+  describe('GET /availability/mine', () => {
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await publicGet('/availability/mine');
+      expect(res.status).toBe(401);
+    });
+
+    it('TEACHER recibe 200 y un array de sus slots', async () => {
+      const res = await authGet('/availability/mine', teacherToken);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      // El seed carga 4 slots para el teacher
+      expect(res.body.length).toBeGreaterThanOrEqual(4);
+
+      const slot = res.body[0];
+      expect(slot).toHaveProperty('id');
+      expect(slot).toHaveProperty('dayOfWeek');
+      expect(slot).toHaveProperty('startTime');
+      expect(slot).toHaveProperty('endTime');
+    });
+
+    it('STUDENT obtiene 403', async () => {
+      const res = await authGet('/availability/mine', studentToken);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ─── POST /availability ────────────────────────────────────────────────────
+
+  describe('POST /availability', () => {
+    it('STUDENT no puede añadir un slot (403)', async () => {
+      const res = await authPost('/availability', studentToken, {
+        dayOfWeek: 6,
+        startTime: '14:00',
+        endTime: '15:00',
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('TEACHER crea un nuevo slot correctamente (201)', async () => {
+      const res = await authPost('/availability', teacherToken, {
+        dayOfWeek: 6,    // Sábado — no existe en el seed
+        startTime: '14:00',
+        endTime: '15:00',
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty('id');
+      expect(res.body.dayOfWeek).toBe(6);
+      expect(res.body.startTime).toBe('14:00');
+      expect(res.body.endTime).toBe('15:00');
+
+      createdSlotId = res.body.id;
+    });
+
+    it('crea un slot duplicado devuelve 409', async () => {
+      // Intenta crear el mismo slot (dayOfWeek=6, startTime='14:00') que el test anterior
+      const res = await authPost('/availability', teacherToken, {
+        dayOfWeek: 6,
+        startTime: '14:00',
+        endTime: '15:00',
+      });
+
+      expect(res.status).toBe(409);
+    });
+  });
+
+  // ─── DELETE /availability/:id ──────────────────────────────────────────────
+
+  describe('DELETE /availability/:id', () => {
+    it('STUDENT no puede eliminar un slot (403)', async () => {
+      // Necesitamos un ID válido; si createdSlotId no existe por fallo anterior, usamos uno de seed
+      const slotId = createdSlotId ?? 'id-inexistente';
+      const res = await authDelete(`/availability/${slotId}`, studentToken);
+      expect(res.status).toBe(403);
+    });
+
+    it('devuelve 404 al intentar eliminar un slot inexistente', async () => {
+      const res = await authDelete('/availability/id-que-no-existe', teacherToken);
+      expect(res.status).toBe(404);
+    });
+
+    it('TEACHER elimina su propio slot correctamente (200)', async () => {
+      // Depende del slot creado en POST — si no se creó, el test es condicional
+      if (!createdSlotId) {
+        console.warn('createdSlotId no disponible; se omite la aserción de DELETE 200');
+        return;
+      }
+
+      const res = await authDelete(`/availability/${createdSlotId}`, teacherToken);
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(createdSlotId);
+    });
+  });
+});

--- a/apps/api/test/e2e/12-users.e2e-spec.ts
+++ b/apps/api/test/e2e/12-users.e2e-spec.ts
@@ -1,0 +1,116 @@
+import {
+  createApp,
+  closeApp,
+  login,
+  authGet,
+  authPatch,
+  publicGet,
+  publicPost,
+} from './setup';
+
+describe('Users — /users', () => {
+  let studentToken: string;
+
+  beforeAll(async () => {
+    await createApp();
+
+    const s = await login('student@vkbacademy.com');
+    studentToken = s.accessToken;
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ─── GET /users/me ─────────────────────────────────────────────────────────
+
+  describe('GET /users/me', () => {
+    it('devuelve 401 sin token', async () => {
+      const res = await publicGet('/users/me');
+      expect(res.status).toBe(401);
+    });
+
+    it('devuelve 200 y el perfil del STUDENT autenticado', async () => {
+      const res = await authGet('/users/me', studentToken);
+      expect(res.status).toBe(200);
+    });
+
+    it('no incluye passwordHash en la respuesta', async () => {
+      const res = await authGet('/users/me', studentToken);
+
+      expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty('passwordHash');
+    });
+
+    it('incluye id, email, name y role en la respuesta', async () => {
+      const res = await authGet('/users/me', studentToken);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('id');
+      expect(res.body).toHaveProperty('email', 'student@vkbacademy.com');
+      expect(res.body).toHaveProperty('name');
+      expect(res.body).toHaveProperty('role', 'STUDENT');
+    });
+  });
+
+  // ─── PATCH /users/me ───────────────────────────────────────────────────────
+
+  describe('PATCH /users/me', () => {
+    it('devuelve 401 sin token', async () => {
+      // authPatch con cadena vacía → el guard JWT rechaza la request
+      const res = await authPatch('/users/me', '', { name: 'sin-token' });
+      expect(res.status).toBe(401);
+    });
+
+    it('actualiza el nombre correctamente', async () => {
+      // Usuario nuevo para no mutar el seed
+      const reg = await publicPost('/auth/register', {
+        email: 'e2e-user-patch-name@test.com',
+        password: 'password123',
+        name: 'nombre-original',
+      });
+      expect(reg.status).toBe(201);
+      const token = reg.body.accessToken;
+
+      const res = await authPatch('/users/me', token, {
+        name: 'nombre-actualizado',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('name', 'nombre-actualizado');
+    });
+
+    it('actualiza el nombre y GET /users/me refleja el cambio', async () => {
+      const reg = await publicPost('/auth/register', {
+        email: 'e2e-user-patch-verify@test.com',
+        password: 'password123',
+        name: 'antes-del-cambio',
+      });
+      expect(reg.status).toBe(201);
+      const token = reg.body.accessToken;
+
+      await authPatch('/users/me', token, { name: 'despues-del-cambio' });
+
+      const res = await authGet('/users/me', token);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('name', 'despues-del-cambio');
+    });
+
+    it('devuelve 400 si el email nuevo ya está en uso por otro usuario', async () => {
+      const reg = await publicPost('/auth/register', {
+        email: 'e2e-user-patch-email@test.com',
+        password: 'password123',
+        name: 'usuario-email-patch',
+      });
+      expect(reg.status).toBe(201);
+      const token = reg.body.accessToken;
+
+      // Intentar tomar el email del usuario seed
+      const res = await authPatch('/users/me', token, {
+        email: 'student@vkbacademy.com',
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/api/test/e2e/13-school-years.e2e-spec.ts
+++ b/apps/api/test/e2e/13-school-years.e2e-spec.ts
@@ -1,0 +1,65 @@
+import { createApp, closeApp, login, authGet, publicGet } from './setup';
+
+describe('School Years — /school-years', () => {
+  let studentToken: string;
+
+  beforeAll(async () => {
+    await createApp();
+    const s = await login('student@vkbacademy.com');
+    studentToken = s.accessToken;
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ─── GET /school-years ─────────────────────────────────────────────────────
+
+  describe('GET /school-years', () => {
+    it('usuario autenticado recibe 200 y un array no vacío', async () => {
+      const res = await authGet('/school-years', studentToken);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await publicGet('/school-years');
+      expect(res.status).toBe(401);
+    });
+
+    it('cada item tiene id, name y label', async () => {
+      const res = await authGet('/school-years', studentToken);
+
+      expect(res.status).toBe(200);
+      for (const item of res.body) {
+        expect(item).toHaveProperty('id');
+        expect(typeof item.id).toBe('string');
+        expect(item).toHaveProperty('name');
+        expect(typeof item.name).toBe('string');
+        expect(item).toHaveProperty('label');
+        expect(typeof item.label).toBe('string');
+      }
+    });
+
+    it('los items están ordenados alfabéticamente por name (1bach → 4eso)', async () => {
+      const res = await authGet('/school-years', studentToken);
+
+      expect(res.status).toBe(200);
+
+      const names: string[] = res.body.map((item: any) => item.name);
+      const sorted = [...names].sort();
+
+      expect(names).toEqual(sorted);
+
+      // Los 6 niveles del seed deben estar presentes
+      expect(names).toContain('1bach');
+      expect(names).toContain('1eso');
+      expect(names).toContain('2bach');
+      expect(names).toContain('2eso');
+      expect(names).toContain('3eso');
+      expect(names).toContain('4eso');
+    });
+  });
+});

--- a/apps/api/test/e2e/14-tutors.e2e-spec.ts
+++ b/apps/api/test/e2e/14-tutors.e2e-spec.ts
@@ -1,0 +1,154 @@
+import {
+  createApp,
+  closeApp,
+  login,
+  authGet,
+  publicGet,
+} from './setup';
+
+describe('Tutors — /tutors', () => {
+  let tutorToken: string;
+  let studentToken: string;
+  let adminToken: string;
+
+  let studentId: string;
+
+  beforeAll(async () => {
+    await createApp();
+
+    const [tu, s, a] = await Promise.all([
+      login('oscar.sanchez@egocogito.com'),
+      login('student@vkbacademy.com'),
+      login('admin@vkbacademy.com'),
+    ]);
+
+    tutorToken = tu.accessToken;
+    studentToken = s.accessToken;
+    adminToken = a.accessToken;
+
+    // Obtener el ID del alumno asignado al tutor llamando al propio endpoint
+    const studentsRes = await authGet('/tutors/my-students', tutorToken);
+    if (studentsRes.status !== 200 || !Array.isArray(studentsRes.body) || studentsRes.body.length === 0) {
+      throw new Error(
+        'El tutor oscar.sanchez@egocogito.com debe tener al menos un alumno asignado. Ejecuta el seed.',
+      );
+    }
+    studentId = studentsRes.body[0].id;
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ─── GET /tutors/my-students ───────────────────────────────────────────────
+
+  describe('GET /tutors/my-students', () => {
+    it('devuelve 401 sin token', async () => {
+      const res = await publicGet('/tutors/my-students');
+      expect(res.status).toBe(401);
+    });
+
+    it('devuelve 403 cuando lo llama un STUDENT', async () => {
+      const res = await authGet('/tutors/my-students', studentToken);
+      expect(res.status).toBe(403);
+    });
+
+    it('devuelve 200 y un array con al menos 1 alumno cuando lo llama el TUTOR', async () => {
+      const res = await authGet('/tutors/my-students', tutorToken);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    it('el alumno devuelto contiene id, name, email, totalPoints y currentStreak', async () => {
+      const res = await authGet('/tutors/my-students', tutorToken);
+
+      expect(res.status).toBe(200);
+      const alumno = res.body[0];
+      expect(alumno).toHaveProperty('id');
+      expect(alumno).toHaveProperty('name');
+      expect(alumno).toHaveProperty('email');
+      expect(alumno).toHaveProperty('totalPoints');
+      expect(alumno).toHaveProperty('currentStreak');
+    });
+
+    it('devuelve 200 con array vacío cuando lo llama un ADMIN sin alumnos asignados', async () => {
+      // El ADMIN supera el guard de rol, pero el servicio filtra por tutorId === admin.id
+      // El admin del seed no tiene alumnos asignados → array vacío
+      const res = await authGet('/tutors/my-students', adminToken);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+
+  // ─── GET /tutors/my-students/:studentId/courses ────────────────────────────
+
+  describe('GET /tutors/my-students/:studentId/courses', () => {
+    it('devuelve 200 y un array de cursos cuando lo llama el TUTOR', async () => {
+      const res = await authGet(
+        `/tutors/my-students/${studentId}/courses`,
+        tutorToken,
+      );
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it('devuelve 403 al intentar acceder a un alumno que no pertenece al tutor', async () => {
+      // ID inexistente — el servicio lanza ForbiddenException porque no encuentra
+      // al alumno o su tutorId no coincide
+      const invalidId = 'cuid-que-no-existe-en-la-bd-00000000';
+
+      const res = await authGet(
+        `/tutors/my-students/${invalidId}/courses`,
+        tutorToken,
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ─── GET /tutors/my-students/:studentId/stats ──────────────────────────────
+
+  describe('GET /tutors/my-students/:studentId/stats', () => {
+    it('devuelve 200 cuando lo llama el TUTOR con su alumno', async () => {
+      const res = await authGet(
+        `/tutors/my-students/${studentId}/stats`,
+        tutorToken,
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('la respuesta contiene student, period, lessons, quizzes, exams, certificates, sessions, courses y activity', async () => {
+      const res = await authGet(
+        `/tutors/my-students/${studentId}/stats`,
+        tutorToken,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('student');
+      expect(res.body).toHaveProperty('period');
+      expect(res.body).toHaveProperty('lessons');
+      expect(res.body).toHaveProperty('quizzes');
+      expect(res.body).toHaveProperty('exams');
+      expect(res.body).toHaveProperty('certificates');
+      expect(res.body).toHaveProperty('sessions');
+      expect(res.body).toHaveProperty('courses');
+      expect(res.body).toHaveProperty('activity');
+    });
+
+    it('devuelve 403 al intentar acceder a stats de un alumno que no pertenece al tutor', async () => {
+      const invalidId = 'cuid-que-no-existe-en-la-bd-00000000';
+
+      const res = await authGet(
+        `/tutors/my-students/${invalidId}/stats`,
+        tutorToken,
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/api/test/e2e/15-tutor-chat.e2e-spec.ts
+++ b/apps/api/test/e2e/15-tutor-chat.e2e-spec.ts
@@ -1,0 +1,150 @@
+import * as request from 'supertest';
+import {
+  createApp,
+  closeApp,
+  login,
+  authGet,
+  authDelete,
+  publicGet,
+} from './setup';
+import { INestApplication } from '@nestjs/common';
+
+describe('Tutor Chat — /tutor', () => {
+  let app: INestApplication;
+  let studentToken: string;
+
+  beforeAll(async () => {
+    app = await createApp();
+    const s = await login('student@vkbacademy.com');
+    studentToken = s.accessToken;
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ─── POST /tutor/chat ──────────────────────────────────────────────────────
+
+  describe('POST /tutor/chat', () => {
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/tutor/chat')
+        .send({ message: '¿Qué es la fotosíntesis?' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('devuelve 400 cuando falta el campo message', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/tutor/chat')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({});
+
+      expect(res.status).toBe(400);
+    });
+
+    it('devuelve 400 cuando message es una cadena vacía', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/tutor/chat')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({ message: '' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('acepta la petición de un STUDENT y no devuelve 401 ni 403', async () => {
+      // El endpoint usa SSE: los headers (200) se envían antes de que arranque
+      // el streaming. Si no hay clave de Anthropic, el error se escribe en el
+      // stream y el servidor cierra la conexión de todas formas con status 200.
+      // Lo que verificamos es que auth y validación del DTO pasan sin error.
+      const res = await request(app.getHttpServer())
+        .post('/api/tutor/chat')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({ message: '¿Qué es la fotosíntesis?' })
+        .buffer(true)
+        .timeout(5000);
+
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+    });
+
+    it('acepta campos opcionales de contexto sin error de validación', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/tutor/chat')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({
+          message: '¿Cómo se calcula el área de un triángulo?',
+          courseName: 'Matemáticas 3º ESO',
+          lessonName: 'Geometría plana',
+          schoolYear: '3º ESO',
+        })
+        .buffer(true)
+        .timeout(5000);
+
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+      expect(res.status).not.toBe(400);
+    });
+  });
+
+  // ─── GET /tutor/history ────────────────────────────────────────────────────
+
+  describe('GET /tutor/history', () => {
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await publicGet('/tutor/history');
+      expect(res.status).toBe(401);
+    });
+
+    it('devuelve 200 y un array para un STUDENT autenticado', async () => {
+      const res = await authGet('/tutor/history', studentToken);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it('cada mensaje del historial tiene los campos esperados', async () => {
+      const res = await authGet('/tutor/history', studentToken);
+
+      expect(res.status).toBe(200);
+
+      // Si hay mensajes en el historial, verificar la forma de cada uno
+      for (const msg of res.body) {
+        expect(msg).toHaveProperty('id');
+        expect(msg).toHaveProperty('role');
+        expect(msg).toHaveProperty('content');
+        expect(msg).toHaveProperty('createdAt');
+        expect(['user', 'assistant']).toContain(msg.role);
+      }
+    });
+  });
+
+  // ─── DELETE /tutor/history ─────────────────────────────────────────────────
+
+  describe('DELETE /tutor/history', () => {
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await request(app.getHttpServer()).delete(
+        '/api/tutor/history',
+      );
+
+      expect(res.status).toBe(401);
+    });
+
+    it('devuelve 200 con { cleared: true } para un STUDENT autenticado', async () => {
+      const res = await authDelete('/tutor/history', studentToken);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ cleared: true });
+    });
+
+    it('tras el DELETE, GET /tutor/history devuelve un array vacío', async () => {
+      // Asegurarse de que el historial está limpio
+      await authDelete('/tutor/history', studentToken);
+
+      const res = await authGet('/tutor/history', studentToken);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBe(0);
+    });
+  });
+});

--- a/apps/api/test/e2e/16-media.e2e-spec.ts
+++ b/apps/api/test/e2e/16-media.e2e-spec.ts
@@ -1,0 +1,111 @@
+import {
+  createApp,
+  closeApp,
+  login,
+  authGet,
+  authPost,
+  publicPost,
+  publicGet,
+} from './setup';
+
+describe('Media — /media', () => {
+  let studentToken: string;
+  let teacherToken: string;
+
+  beforeAll(async () => {
+    await createApp();
+
+    const [s, t] = await Promise.all([
+      login('student@vkbacademy.com'),
+      login('teacher@vkbacademy.com'),
+    ]);
+
+    studentToken = s.accessToken;
+    teacherToken = t.accessToken;
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ─── POST /media/upload-url ────────────────────────────────────────────────
+
+  describe('POST /media/upload-url', () => {
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await publicPost('/media/upload-url', {
+        fileName: 'video.mp4',
+        contentType: 'video/mp4',
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('devuelve 403 cuando un STUDENT intenta obtener una URL de subida', async () => {
+      const res = await authPost('/media/upload-url', studentToken, {
+        fileName: 'video.mp4',
+        contentType: 'video/mp4',
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('devuelve 400 si el body está vacío', async () => {
+      const res = await authPost('/media/upload-url', teacherToken, {});
+
+      expect(res.status).toBe(400);
+    });
+
+    it('devuelve 400 si fileName no tiene extensión de vídeo válida', async () => {
+      const res = await authPost('/media/upload-url', teacherToken, {
+        fileName: 'documento.pdf',
+        contentType: 'video/mp4',
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('devuelve 400 si contentType no es de tipo video', async () => {
+      const res = await authPost('/media/upload-url', teacherToken, {
+        fileName: 'video.mp4',
+        contentType: 'image/jpeg',
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('un TEACHER con credenciales válidas no recibe 401 ni 403 (auth y roles pasan)', async () => {
+      // En entorno de test sin credenciales AWS reales, el SDK puede lanzar un
+      // error 500. Lo que verificamos es que la capa de autenticación y roles
+      // funciona correctamente; un 500 de S3 es un resultado aceptable.
+      const res = await authPost('/media/upload-url', teacherToken, {
+        fileName: 'leccion.mp4',
+        contentType: 'video/mp4',
+      });
+
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  // ─── GET /media/view-url/:key ──────────────────────────────────────────────
+
+  describe('GET /media/view-url/:key', () => {
+    it('devuelve 401 sin token de autenticación', async () => {
+      const res = await publicGet('/media/view-url/cursos/leccion-01.mp4');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('un STUDENT autenticado no recibe 401 ni 403 (cualquier rol puede ver vídeos)', async () => {
+      // Igual que upload-url: sin AWS real el SDK puede devolver 500, pero
+      // lo que importa es que auth pasa y el rol STUDENT tiene acceso.
+      const res = await authGet(
+        '/media/view-url/cursos/leccion-01.mp4',
+        studentToken,
+      );
+
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+    });
+  });
+});

--- a/apps/api/test/e2e/setup.ts
+++ b/apps/api/test/e2e/setup.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { AppModule } from '../../src/app.module';
 import { PrismaService } from '../../src/prisma/prisma.service';
 
@@ -13,7 +14,11 @@ export async function createApp(): Promise<INestApplication> {
 
   const moduleFixture: TestingModule = await Test.createTestingModule({
     imports: [AppModule],
-  }).compile();
+  })
+    // Desactivar rate limiting en tests E2E
+    .overrideModule(ThrottlerModule)
+    .useModule(ThrottlerModule.forRoot([{ ttl: 60000, limit: 100000 }]))
+    .compile();
 
   app = moduleFixture.createNestApplication();
   app.setGlobalPrefix('api');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       class-validator:
         specifier: ^0.14.1
         version: 0.14.3
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -1462,7 +1465,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -4382,6 +4385,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   hermes-estree@0.19.1:
     resolution: {integrity: sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==}
@@ -13053,6 +13060,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.1.0: {}
 
   hermes-estree@0.19.1: {}
 


### PR DESCRIPTION
## Causa raíz

`gemini-flash-latest` apunta hoy a **Gemini 2.5 Flash**, que tiene **dynamic thinking** activado por defecto. Los *thinking tokens* se descuentan de `maxOutputTokens` pero no aparecen en `response.text()`, provocando JSON truncado con posiciones de corte erráticas.

Síntoma reproducido en PRE (`/exercises/generate` de alumno):
- Primer intento: `Unterminated string in JSON at position 1352`
- Segundo intento (mismo input): `Unterminated string in JSON at position 76`

Esa varianza es la firma del thinking mode consumiendo budget de forma no determinista.

## Fix

Añado `thinkingConfig: { thinkingBudget: 0 }` al `generationConfig` de `callGemini`. El SDK legacy `@google/generative-ai@0.24.x` no tipa el campo pero lo pasa transparentemente al endpoint REST.

## Test

Nuevo test en `ai-provider.service.spec.ts` verifica que `getGenerativeModel` recibe `thinkingConfig.thinkingBudget === 0`. Suite completa del api: 369/369 OK.

## Verificación pendiente en PRE

Tras mergear y desplegar, pedir ejercicios reales en la UI. Si aún falla, el log de `exercises.service.ts:89` mostrará el texto crudo → indicará si el SDK legacy respeta `thinkingBudget` o hay que migrar a `@google/genai`.