### PR TITLE
feat(exercises): AI evaluation for OPEN-type exercises

### DIFF
--- a/apps/api/src/exercises/dto/evaluate-exercise.dto.ts
+++ b/apps/api/src/exercises/dto/evaluate-exercise.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class EvaluateExerciseDto {
+  @IsString()
+  @MinLength(3)
+  @MaxLength(2000)
+  statement: string;
+
+  @IsString()
+  @MinLength(1, { message: 'La respuesta no puede estar vacía' })
+  @MaxLength(2000)
+  studentAnswer: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(2000)
+  solution: string;
+}

--- a/apps/api/src/exercises/exercises.controller.ts
+++ b/apps/api/src/exercises/exercises.controller.ts
@@ -4,6 +4,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { ExercisesService } from './exercises.service';
 import { GenerateExercisesDto } from './dto/generate-exercises.dto';
+import { EvaluateExerciseDto } from './dto/evaluate-exercise.dto';
 
 @Controller('exercises')
 @UseGuards(JwtAuthGuard)
@@ -17,5 +18,14 @@ export class ExercisesController {
   @Post('generate')
   generate(@CurrentUser() user: User, @Body() dto: GenerateExercisesDto) {
     return this.exercises.generate(user.id, dto);
+  }
+
+  /**
+   * Evalúa la respuesta abierta de un alumno contra la solución de referencia
+   * usando la IA. Devuelve veredicto (correct/partial/incorrect) + feedback.
+   */
+  @Post('evaluate')
+  evaluate(@Body() dto: EvaluateExerciseDto) {
+    return this.exercises.evaluate(dto);
   }
 }

--- a/apps/api/src/exercises/exercises.service.spec.ts
+++ b/apps/api/src/exercises/exercises.service.spec.ts
@@ -126,4 +126,55 @@ describe('ExercisesService', () => {
       expect(prompt).toContain('5');
     });
   });
+
+  describe('evaluate', () => {
+    const dto = {
+      statement: '¿Cuánto vale 2+2?',
+      studentAnswer: '4',
+      solution: '4',
+    };
+
+    it('devuelve el veredicto y feedback que la IA produce', async () => {
+      ai.generate.mockResolvedValue(
+        JSON.stringify({ verdict: 'correct', feedback: 'Perfecto, 2+2=4.' }),
+      );
+
+      const result = await service.evaluate(dto);
+
+      expect(result.verdict).toBe('correct');
+      expect(result.feedback).toContain('Perfecto');
+    });
+
+    it('acepta respuesta envuelta en ```json```', async () => {
+      ai.generate.mockResolvedValue(
+        '```json\n{"verdict":"partial","feedback":"Falta una parte"}\n```',
+      );
+      const result = await service.evaluate(dto);
+      expect(result.verdict).toBe('partial');
+    });
+
+    it('incluye statement, studentAnswer y solution en el prompt', async () => {
+      ai.generate.mockResolvedValue('{"verdict":"correct","feedback":"OK"}');
+      await service.evaluate({
+        statement: '¿Capital de Francia?',
+        studentAnswer: 'Paris',
+        solution: 'París',
+      });
+
+      const prompt = ai.generate.mock.calls[0][0] as string;
+      expect(prompt).toContain('Capital de Francia');
+      expect(prompt).toContain('Paris');
+      expect(prompt).toContain('París');
+    });
+
+    it('rechaza veredictos fuera del enum esperado', async () => {
+      ai.generate.mockResolvedValue('{"verdict":"maybe","feedback":"dunno"}');
+      await expect(service.evaluate(dto)).rejects.toThrow();
+    });
+
+    it('lanza error si la IA devuelve JSON inválido', async () => {
+      ai.generate.mockResolvedValue('no es json');
+      await expect(service.evaluate(dto)).rejects.toThrow();
+    });
+  });
 });

--- a/apps/api/src/exercises/exercises.service.ts
+++ b/apps/api/src/exercises/exercises.service.ts
@@ -8,6 +8,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { AiProviderService } from '../ai/ai-provider.service';
 import { GenerateExercisesDto } from './dto/generate-exercises.dto';
+import { EvaluateExerciseDto } from './dto/evaluate-exercise.dto';
 
 export type ExerciseType = 'SINGLE' | 'TRUE_FALSE' | 'OPEN';
 
@@ -22,6 +23,15 @@ export interface GeneratedExercise {
 export interface GenerateExercisesResult {
   exercises: GeneratedExercise[];
 }
+
+export type EvaluationVerdict = 'correct' | 'partial' | 'incorrect';
+
+export interface EvaluationResult {
+  verdict: EvaluationVerdict;
+  feedback: string;
+}
+
+const VALID_VERDICTS: EvaluationVerdict[] = ['correct', 'partial', 'incorrect'];
 
 /**
  * Genera ejercicios de práctica bajo demanda para un alumno matriculado
@@ -91,6 +101,54 @@ export class ExercisesService {
         `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
       );
     }
+  }
+
+  async evaluate(dto: EvaluateExerciseDto): Promise<EvaluationResult> {
+    const prompt = this.buildEvaluationPrompt(dto);
+    this.logger.log(`Evaluando respuesta abierta para enunciado: "${dto.statement.slice(0, 60)}..."`);
+
+    const text = await this.ai.generate(prompt, 400);
+
+    try {
+      const raw = text
+        .trim()
+        .replace(/^```json\n?/, '')
+        .replace(/\n?```$/, '');
+      const parsed = JSON.parse(raw) as Partial<EvaluationResult>;
+      if (!parsed.verdict || !VALID_VERDICTS.includes(parsed.verdict as EvaluationVerdict)) {
+        throw new Error(`Veredicto inválido: "${parsed.verdict}"`);
+      }
+      if (typeof parsed.feedback !== 'string' || parsed.feedback.length === 0) {
+        throw new Error('Feedback ausente o vacío');
+      }
+      return { verdict: parsed.verdict as EvaluationVerdict, feedback: parsed.feedback };
+    } catch (err) {
+      this.logger.error('Error al parsear JSON de IA (evaluación):', text);
+      throw new InternalServerErrorException(
+        `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
+      );
+    }
+  }
+
+  private buildEvaluationPrompt(dto: EvaluateExerciseDto): string {
+    return `Evalúa la respuesta de un alumno a un ejercicio de respuesta abierta.
+
+Enunciado: "${dto.statement}"
+Respuesta del alumno: "${dto.studentAnswer}"
+Solución de referencia: "${dto.solution}"
+
+Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, sin texto adicional):
+{
+  "verdict": "correct" | "partial" | "incorrect",
+  "feedback": "explicación breve en español (máx. 2 frases) justificando el veredicto"
+}
+
+Criterios:
+- "correct": la respuesta es equivalente a la solución (diferencias de forma, ortografía menor, orden o notación son aceptables).
+- "partial": la respuesta contiene la idea clave pero le falta rigor, parte del desarrollo, o comete errores menores que no invalidan el núcleo.
+- "incorrect": la respuesta es claramente errónea, vacía o no responde al enunciado.
+
+El feedback debe ser pedagógico, directo y en segunda persona ("Has olvidado simplificar...", "Correcto: has aplicado bien..."). No reveles la solución completa.`;
   }
 
   private buildPrompt(

--- a/apps/web/src/pages/ExercisesPage.tsx
+++ b/apps/web/src/pages/ExercisesPage.tsx
@@ -23,6 +23,19 @@ interface GeneratePayload {
   count: number;
 }
 
+type Verdict = 'correct' | 'partial' | 'incorrect';
+
+interface EvaluationResult {
+  verdict: Verdict;
+  feedback: string;
+}
+
+interface EvaluatePayload {
+  statement: string;
+  studentAnswer: string;
+  solution: string;
+}
+
 export default function ExercisesPage() {
   const { data: coursesData } = useCourses(1);
   const courses = coursesData?.data ?? [];
@@ -33,6 +46,9 @@ export default function ExercisesPage() {
   const [exercises, setExercises] = useState<Exercise[]>([]);
   const [revealed, setRevealed] = useState<Record<number, boolean>>({});
   const [selected, setSelected] = useState<Record<number, number | null>>({});
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [evaluations, setEvaluations] = useState<Record<number, EvaluationResult>>({});
+  const [evaluatingIdx, setEvaluatingIdx] = useState<number | null>(null);
 
   const { mutate, isPending, error } = useMutation({
     mutationFn: (payload: GeneratePayload) =>
@@ -41,7 +57,22 @@ export default function ExercisesPage() {
       setExercises(data.exercises);
       setRevealed({});
       setSelected({});
+      setAnswers({});
+      setEvaluations({});
     },
+  });
+
+  const evalMutation = useMutation({
+    mutationFn: ({ index, ...payload }: EvaluatePayload & { index: number }) =>
+      api
+        .post<EvaluationResult>('/exercises/evaluate', payload)
+        .then((r) => ({ index, data: r.data })),
+    onSuccess: ({ index, data }) => {
+      setEvaluations((prev) => ({ ...prev, [index]: data }));
+      setRevealed((prev) => ({ ...prev, [index]: true }));
+      setEvaluatingIdx(null);
+    },
+    onError: () => setEvaluatingIdx(null),
   });
 
   function handleSubmit(e: FormEvent) {
@@ -56,6 +87,22 @@ export default function ExercisesPage() {
 
   function chooseOption(exerciseIndex: number, optionIndex: number) {
     setSelected((prev) => ({ ...prev, [exerciseIndex]: optionIndex }));
+  }
+
+  function updateAnswer(index: number, value: string) {
+    setAnswers((prev) => ({ ...prev, [index]: value }));
+  }
+
+  function evaluateOpen(index: number, ex: Exercise) {
+    const answer = (answers[index] ?? '').trim();
+    if (!answer) return;
+    setEvaluatingIdx(index);
+    evalMutation.mutate({
+      index,
+      statement: ex.statement,
+      studentAnswer: answer,
+      solution: ex.solution,
+    });
   }
 
   const apiError = (error as { response?: { data?: { message?: string } } } | null)?.response?.data
@@ -145,7 +192,12 @@ export default function ExercisesPage() {
                 index={i}
                 revealed={!!revealed[i]}
                 selected={selected[i] ?? null}
+                answer={answers[i] ?? ''}
+                evaluation={evaluations[i] ?? null}
+                evaluating={evaluatingIdx === i}
                 onChoose={(optIdx) => chooseOption(i, optIdx)}
+                onAnswerChange={(value) => updateAnswer(i, value)}
+                onEvaluate={() => evaluateOpen(i, ex)}
                 onToggle={() => toggleSolution(i)}
               />
             ))}
@@ -161,21 +213,31 @@ function ExerciseCard({
   index,
   revealed,
   selected,
+  answer,
+  evaluation,
+  evaluating,
   onChoose,
+  onAnswerChange,
+  onEvaluate,
   onToggle,
 }: {
   exercise: Exercise;
   index: number;
   revealed: boolean;
   selected: number | null;
+  answer: string;
+  evaluation: EvaluationResult | null;
+  evaluating: boolean;
   onChoose: (optionIndex: number) => void;
+  onAnswerChange: (value: string) => void;
+  onEvaluate: () => void;
   onToggle: () => void;
 }) {
   const hasOptions = exercise.options.length > 0;
   const correctIndex = hasOptions
     ? exercise.options.findIndex((o) => o.trim() === exercise.solution.trim())
     : -1;
-  const canCheck = hasOptions ? selected !== null : true;
+  const canCheck = hasOptions ? selected !== null : answer.trim().length > 0;
 
   function optionStyle(j: number): React.CSSProperties {
     if (revealed) {
@@ -186,6 +248,24 @@ function ExerciseCard({
     if (j === selected) return { ...s.option, ...s.optionSelected };
     return s.option;
   }
+
+  function handleCheckClick() {
+    if (revealed) {
+      onToggle();
+      return;
+    }
+    if (hasOptions) {
+      onToggle();
+    } else {
+      onEvaluate();
+    }
+  }
+
+  const buttonLabel = evaluating
+    ? '⏳ Evaluando...'
+    : revealed
+      ? '🙈 Ocultar solución'
+      : '✓ Comprobar';
 
   return (
     <article style={s.card}>
@@ -211,13 +291,34 @@ function ExerciseCard({
         </ul>
       )}
 
+      {!hasOptions && (
+        <textarea
+          value={answer}
+          onChange={(e) => onAnswerChange(e.target.value)}
+          disabled={revealed || evaluating}
+          placeholder="Escribe aquí tu respuesta..."
+          rows={3}
+          style={s.openAnswer}
+        />
+      )}
+
       <button
-        onClick={onToggle}
-        style={{ ...s.revealBtn, opacity: !revealed && !canCheck ? 0.5 : 1 }}
-        disabled={!revealed && !canCheck}
+        onClick={handleCheckClick}
+        style={{
+          ...s.revealBtn,
+          opacity: (!revealed && !canCheck) || evaluating ? 0.5 : 1,
+        }}
+        disabled={(!revealed && !canCheck) || evaluating}
       >
-        {revealed ? '🙈 Ocultar solución' : '✓ Comprobar'}
+        {buttonLabel}
       </button>
+
+      {revealed && evaluation && (
+        <div style={{ ...s.verdictBox, ...s[`verdict_${evaluation.verdict}`] }}>
+          <div style={s.verdictHeader}>{verdictLabel(evaluation.verdict)}</div>
+          <div style={s.verdictFeedback}>{evaluation.feedback}</div>
+        </div>
+      )}
 
       {revealed && (
         <div style={s.solution}>
@@ -233,6 +334,17 @@ function ExerciseCard({
       )}
     </article>
   );
+}
+
+function verdictLabel(verdict: Verdict): string {
+  switch (verdict) {
+    case 'correct':
+      return '✅ Correcto';
+    case 'partial':
+      return '⚠️ Parcialmente correcto';
+    case 'incorrect':
+      return '❌ Incorrecto';
+  }
 }
 
 function labelForType(type: ExerciseType): string {
@@ -390,4 +502,47 @@ const s: Record<string, React.CSSProperties> = {
   },
   solutionLine: { color: 'var(--color-text)' },
   solutionLabel: { color: '#10b981' },
+  openAnswer: {
+    width: '100%',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 8,
+    color: 'var(--color-text)',
+    padding: '10px 12px',
+    fontSize: '0.95rem',
+    fontFamily: 'inherit',
+    resize: 'vertical' as const,
+    minHeight: 80,
+  },
+  verdictBox: {
+    borderRadius: 8,
+    padding: 14,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 6,
+    fontSize: '0.92rem',
+    lineHeight: 1.5,
+  },
+  verdictHeader: {
+    fontWeight: 700,
+    fontSize: '0.95rem',
+  },
+  verdictFeedback: {
+    color: 'var(--color-text)',
+  },
+  verdict_correct: {
+    background: '#dcfce7',
+    border: '1px solid #16a34a',
+    color: '#166534',
+  },
+  verdict_partial: {
+    background: '#fef9c3',
+    border: '1px solid #eab308',
+    color: '#854d0e',
+  },
+  verdict_incorrect: {
+    background: '#fee2e2',
+    border: '1px solid #dc2626',
+    color: '#991b1b',
+  },
 };


### PR DESCRIPTION
Añade evaluación real de respuestas abiertas mediante IA.

**Backend:**
- Nuevo `POST /exercises/evaluate` (JWT) → `{verdict, feedback}`
- Veredicto: `correct | partial | incorrect`
- Prompt pide feedback pedagógico en 2ª persona sin revelar solución completa
- 5 tests nuevos en `exercises.service.spec.ts` (11/11 total OK)

**Frontend:**
- Textarea para OPEN antes inerte
- Comprobar → loading `⏳ Evaluando...`
- Al recibir veredicto: badge coloreado (verde/ámbar/rojo) + feedback
- Solución y explicación siguen mostrándose al desvelar