### PR TITLE
refactor: simplify exercises module after /simplify review

### DIFF
--- a/apps/api/src/exercises/exercises.service.ts
+++ b/apps/api/src/exercises/exercises.service.ts
@@ -85,22 +85,12 @@ export class ExercisesService {
     const maxTokens = Math.min(8000, 200 + dto.count * 250);
     const text = await this.ai.generate(prompt, maxTokens);
 
-    try {
-      const raw = text
-        .trim()
-        .replace(/^```json\n?/, '')
-        .replace(/\n?```$/, '');
-      const parsed = JSON.parse(raw) as GenerateExercisesResult;
-      if (!Array.isArray(parsed.exercises)) {
+    return this.parseAiJson<GenerateExercisesResult>(text, 'ejercicios', (parsed) => {
+      if (!Array.isArray((parsed as GenerateExercisesResult).exercises)) {
         throw new Error('La respuesta no contiene un array `exercises`');
       }
-      return parsed;
-    } catch (err) {
-      this.logger.error('Error al parsear JSON de IA (ejercicios):', text);
-      throw new InternalServerErrorException(
-        `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
-      );
-    }
+      return parsed as GenerateExercisesResult;
+    });
   }
 
   async evaluate(dto: EvaluateExerciseDto): Promise<EvaluationResult> {
@@ -109,21 +99,27 @@ export class ExercisesService {
 
     const text = await this.ai.generate(prompt, 400);
 
+    return this.parseAiJson<EvaluationResult>(text, 'evaluación', (parsed) => {
+      const { verdict, feedback } = parsed as Partial<EvaluationResult>;
+      if (!verdict || !VALID_VERDICTS.includes(verdict)) {
+        throw new Error(`Veredicto inválido: "${verdict}"`);
+      }
+      if (typeof feedback !== 'string' || feedback.length === 0) {
+        throw new Error('Feedback ausente o vacío');
+      }
+      return { verdict, feedback };
+    });
+  }
+
+  private parseAiJson<T>(text: string, context: string, validate: (parsed: unknown) => T): T {
     try {
       const raw = text
         .trim()
         .replace(/^```json\n?/, '')
         .replace(/\n?```$/, '');
-      const parsed = JSON.parse(raw) as Partial<EvaluationResult>;
-      if (!parsed.verdict || !VALID_VERDICTS.includes(parsed.verdict as EvaluationVerdict)) {
-        throw new Error(`Veredicto inválido: "${parsed.verdict}"`);
-      }
-      if (typeof parsed.feedback !== 'string' || parsed.feedback.length === 0) {
-        throw new Error('Feedback ausente o vacío');
-      }
-      return { verdict: parsed.verdict as EvaluationVerdict, feedback: parsed.feedback };
+      return validate(JSON.parse(raw));
     } catch (err) {
-      this.logger.error('Error al parsear JSON de IA (evaluación):', text);
+      this.logger.error(`Error al parsear JSON de IA (${context}):`, text);
       throw new InternalServerErrorException(
         `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
       );

--- a/apps/web/src/pages/ExercisesPage.tsx
+++ b/apps/web/src/pages/ExercisesPage.tsx
@@ -49,7 +49,6 @@ export default function ExercisesPage() {
   const [answers, setAnswers] = useState<Record<number, string>>({});
   const [evaluations, setEvaluations] = useState<Record<number, EvaluationResult>>({});
   const [evalErrors, setEvalErrors] = useState<Record<number, string>>({});
-  const [evaluatingIdx, setEvaluatingIdx] = useState<number | null>(null);
 
   const { mutate, isPending, error } = useMutation({
     mutationFn: (payload: GeneratePayload) =>
@@ -77,7 +76,6 @@ export default function ExercisesPage() {
         delete next[index];
         return next;
       });
-      setEvaluatingIdx(null);
     },
     onError: (err, variables) => {
       const msg =
@@ -88,9 +86,11 @@ export default function ExercisesPage() {
         ...prev,
         [variables.index]: text ?? 'No se pudo evaluar la respuesta. Inténtalo de nuevo en unos segundos.',
       }));
-      setEvaluatingIdx(null);
     },
   });
+
+  const evaluatingIdx =
+    evalMutation.isPending && evalMutation.variables ? evalMutation.variables.index : null;
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -113,7 +113,6 @@ export default function ExercisesPage() {
   function evaluateOpen(index: number, ex: Exercise) {
     const answer = (answers[index] ?? '').trim();
     if (!answer) return;
-    setEvaluatingIdx(index);
     evalMutation.mutate({
       index,
       statement: ex.statement,
@@ -340,7 +339,7 @@ function ExerciseCard({
       )}
 
       {revealed && evaluation && (
-        <div style={{ ...s.verdictBox, ...s[`verdict_${evaluation.verdict}`] }}>
+        <div style={{ ...s.verdictBox, ...VERDICT_STYLES[evaluation.verdict] }}>
           <div style={s.verdictHeader}>{verdictLabel(evaluation.verdict)}</div>
           <div style={s.verdictFeedback}>{evaluation.feedback}</div>
         </div>
@@ -383,6 +382,16 @@ function labelForType(type: ExerciseType): string {
       return 'Respuesta abierta';
   }
 }
+
+const GREEN = '#16a34a';
+const RED = '#dc2626';
+const YELLOW = '#eab308';
+
+const VERDICT_STYLES: Record<Verdict, React.CSSProperties> = {
+  correct: { background: '#dcfce7', border: `1px solid ${GREEN}`, color: '#166534' },
+  partial: { background: '#fef9c3', border: `1px solid ${YELLOW}`, color: '#854d0e' },
+  incorrect: { background: '#fee2e2', border: `1px solid ${RED}`, color: '#991b1b' },
+};
 
 const s: Record<string, React.CSSProperties> = {
   page: {
@@ -489,15 +498,15 @@ const s: Record<string, React.CSSProperties> = {
   },
   optionSelected: {
     background: '#fef9c3',
-    border: '1px solid #eab308',
+    border: `1px solid ${YELLOW}`,
   },
   optionCorrect: {
     background: '#dcfce7',
-    border: '1px solid #16a34a',
+    border: `1px solid ${GREEN}`,
   },
   optionWrong: {
     background: '#fee2e2',
-    border: '1px solid #dc2626',
+    border: `1px solid ${RED}`,
   },
   optionLetter: {
     color: '#f97316',
@@ -555,20 +564,5 @@ const s: Record<string, React.CSSProperties> = {
   },
   verdictFeedback: {
     color: 'var(--color-text)',
-  },
-  verdict_correct: {
-    background: '#dcfce7',
-    border: '1px solid #16a34a',
-    color: '#166534',
-  },
-  verdict_partial: {
-    background: '#fef9c3',
-    border: '1px solid #eab308',
-    color: '#854d0e',
-  },
-  verdict_incorrect: {
-    background: '#fee2e2',
-    border: '1px solid #dc2626',
-    color: '#991b1b',
   },
 };


### PR DESCRIPTION
Cleanups surfaced by the simplify-skill review:

**Backend**: `parseAiJson<T>()` private helper in ExercisesService, consumed by `generate()` and `evaluate()` — removes ~15 lines of duplication.

**Frontend**:
- Remove `evaluatingIdx` useState (derive from `evalMutation.isPending + variables.index`).
- `VERDICT_STYLES` typed map replaces `s[\]` computed-string lookup.
- Hoist duplicated color literals (`GREEN`, `RED`, `YELLOW`) to module-level constants.

Tests: 11/11 api exercises tests OK, web type check OK.