### PR TITLE
feat: theory on-demand (AI-generated study modules per student)

### DIFF
--- a/apps/api/prisma/migrations/20260503174854_theory_on_demand/migration.sql
+++ b/apps/api/prisma/migrations/20260503174854_theory_on_demand/migration.sql
@@ -1,0 +1,46 @@
+-- CreateEnum
+CREATE TYPE "TheoryLessonKind" AS ENUM ('INTRO', 'CONTENT', 'EXAMPLE', 'VIDEO');
+
+-- CreateTable
+CREATE TABLE "TheoryModule" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "topic" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TheoryModule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TheoryLesson" (
+    "id" TEXT NOT NULL,
+    "moduleId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "kind" "TheoryLessonKind" NOT NULL,
+    "heading" TEXT NOT NULL,
+    "body" TEXT,
+    "youtubeId" TEXT,
+
+    CONSTRAINT "TheoryLesson_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TheoryModule_userId_courseId_idx" ON "TheoryModule"("userId", "courseId");
+
+-- CreateIndex
+CREATE INDEX "TheoryModule_userId_createdAt_idx" ON "TheoryModule"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "TheoryLesson_moduleId_order_idx" ON "TheoryLesson"("moduleId", "order");
+
+-- AddForeignKey
+ALTER TABLE "TheoryModule" ADD CONSTRAINT "TheoryModule_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TheoryModule" ADD CONSTRAINT "TheoryModule_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TheoryLesson" ADD CONSTRAINT "TheoryLesson_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "TheoryModule"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -14,7 +14,7 @@ datasource db {
 model SchoolYear {
   id    String @id @default(cuid())
   name  String @unique // "1eso", "2eso", "3eso", "4eso", "1bach", "2bach"
-  label String          // "1º ESO", "2º ESO", ...
+  label String // "1º ESO", "2º ESO", ...
 
   users   User[]
   courses Course[]
@@ -26,11 +26,11 @@ model SchoolYear {
 
 model Academy {
   id           String   @id @default(cuid())
-  slug         String   @unique   // "vallekas-basket", "cb-oscar"
-  name         String              // "Vallekas Basket Academy"
+  slug         String   @unique // "vallekas-basket", "cb-oscar"
+  name         String // "Vallekas Basket Academy"
   logoUrl      String?
   primaryColor String?  @default("#6366f1")
-  domain       String?  @unique   // dominio personalizado (opcional)
+  domain       String?  @unique // dominio personalizado (opcional)
   isActive     Boolean  @default(true)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
@@ -89,24 +89,25 @@ model User {
   students User[]  @relation("TutorStudents")
 
   // Gamificación — racha y puntos
-  currentStreak  Int     @default(0)   // semanas consecutivas con actividad
+  currentStreak  Int     @default(0) // semanas consecutivas con actividad
   longestStreak  Int     @default(0)
-  lastActiveWeek String?               // "2026-W07" (ISO week)
-  totalPoints    Int     @default(0)   // puntos acumulados (denormalizado para performance)
+  lastActiveWeek String? // "2026-W07" (ISO week)
+  totalPoints    Int     @default(0) // puntos acumulados (denormalizado para performance)
 
   // Relaciones
-  progress         UserProgress[]
-  quizAttempts     QuizAttempt[]
-  bookingsAsStudent Booking[]      @relation("StudentBookings")
-  teacherProfile   TeacherProfile?
-  refreshTokens    RefreshToken[]
-  enrollments      Enrollment[]
-  userChallenges   UserChallenge[]
-  redemptions      Redemption[]
-  examAttempts     ExamAttempt[]
-  certificates     Certificate[]
-  tutorMessages    TutorMessage[]
-  academyMembers   AcademyMember[]
+  progress          UserProgress[]
+  quizAttempts      QuizAttempt[]
+  bookingsAsStudent Booking[]       @relation("StudentBookings")
+  teacherProfile    TeacherProfile?
+  refreshTokens     RefreshToken[]
+  enrollments       Enrollment[]
+  userChallenges    UserChallenge[]
+  redemptions       Redemption[]
+  examAttempts      ExamAttempt[]
+  certificates      Certificate[]
+  tutorMessages     TutorMessage[]
+  academyMembers    AcademyMember[]
+  theoryModules     TheoryModule[]
 }
 
 model RefreshToken {
@@ -146,6 +147,7 @@ model Course {
   examAttempts  ExamAttempt[]  @relation("CourseExamAttempts")
   certificates  Certificate[]  @relation("CourseCertificates")
   tutorMessages TutorMessage[] @relation("TutorMessageCourse")
+  theoryModules TheoryModule[] @relation("CourseTheoryModules")
 }
 
 // ─────────────────────────────────────────────────────────
@@ -255,7 +257,7 @@ model QuizAttempt {
   id          String   @id @default(cuid())
   userId      String
   quizId      String
-  score       Float    // 0.0 - 100.0
+  score       Float // 0.0 - 100.0
   /// [{questionId, answerId}]
   answers     Json
   completedAt DateTime @default(now())
@@ -298,9 +300,9 @@ model TeacherProfile {
 }
 
 model AvailabilitySlot {
-  id          String @id @default(cuid())
+  id          String  @id @default(cuid())
   teacherId   String
-  dayOfWeek   Int    // 0=Dom, 1=Lun, ..., 6=Sáb
+  dayOfWeek   Int // 0=Dom, 1=Lun, ..., 6=Sáb
   startTime   String // "09:00"
   endTime     String // "10:00"
   isRecurring Boolean @default(true)
@@ -322,20 +324,20 @@ enum BookingMode {
 }
 
 model Booking {
-  id        String        @id @default(cuid())
-  studentId String
-  teacherId String
-  startAt   DateTime
-  endAt     DateTime
-  status    BookingStatus @default(PENDING)
-  mode      BookingMode   @default(IN_PERSON)
+  id         String        @id @default(cuid())
+  studentId  String
+  teacherId  String
+  startAt    DateTime
+  endAt      DateTime
+  status     BookingStatus @default(PENDING)
+  mode       BookingMode   @default(IN_PERSON)
   notes      String?
   courseId   String?
   academyId  String?
   /// URL de sala Daily.co — solo presente cuando mode=ONLINE y status=CONFIRMED
   meetingUrl String?
-  createdAt  DateTime     @default(now())
-  updatedAt DateTime      @updatedAt
+  createdAt  DateTime      @default(now())
+  updatedAt  DateTime      @updatedAt
 
   student User           @relation("StudentBookings", fields: [studentId], references: [id])
   teacher TeacherProfile @relation(fields: [teacherId], references: [id])
@@ -375,13 +377,13 @@ model Redemption {
 // ─────────────────────────────────────────────────────────
 
 enum ChallengeType {
-  LESSON_COMPLETED   // completa N lecciones en total
-  MODULE_COMPLETED   // completa N módulos enteros
-  COURSE_COMPLETED   // completa N cursos completos
-  QUIZ_SCORE         // consigue ≥ N% en cualquier quiz
-  BOOKING_ATTENDED   // asiste a N clases confirmadas (endAt < now)
-  STREAK_WEEKLY      // racha activa de N semanas consecutivas
-  TOTAL_HOURS        // acumula N horas (bookings + lecciones VIDEO × 20min)
+  LESSON_COMPLETED // completa N lecciones en total
+  MODULE_COMPLETED // completa N módulos enteros
+  COURSE_COMPLETED // completa N cursos completos
+  QUIZ_SCORE // consigue ≥ N% en cualquier quiz
+  BOOKING_ATTENDED // asiste a N clases confirmadas (endAt < now)
+  STREAK_WEEKLY // racha activa de N semanas consecutivas
+  TOTAL_HOURS // acumula N horas (bookings + lecciones VIDEO × 20min)
 }
 
 model Challenge {
@@ -389,8 +391,8 @@ model Challenge {
   title       String
   description String
   type        ChallengeType
-  target      Int           // umbral numérico (ej: 5, 80, 3)
-  points      Int           // puntos al completarse
+  target      Int // umbral numérico (ej: 5, 80, 3)
+  points      Int // puntos al completarse
   badgeIcon   String        @default("🏅")
   badgeColor  String        @default("#6366f1")
   isActive    Boolean       @default(true)
@@ -424,16 +426,16 @@ model UserChallenge {
 // ─────────────────────────────────────────────────────────
 
 model BillingConfig {
-  id                       String   @id @default("default")
-  academyId                String?  @unique
-  studentMonthlyPrice      Float    @default(15.00)
-  classOnlineRatePerHour   Float    @default(15.00)
-  classInPersonRatePerHour Float    @default(18.00)
-  clubCommissionRate       Float    @default(0.10)
-  infrastructureMonthlyCost Float   @default(25.00)
-  s3MonthlyCost            Float    @default(2.00)
-  anthropicMonthlyCost     Float    @default(5.00)
-  updatedAt                DateTime @updatedAt
+  id                        String   @id @default("default")
+  academyId                 String?  @unique
+  studentMonthlyPrice       Float    @default(15.00)
+  classOnlineRatePerHour    Float    @default(15.00)
+  classInPersonRatePerHour  Float    @default(18.00)
+  clubCommissionRate        Float    @default(0.10)
+  infrastructureMonthlyCost Float    @default(25.00)
+  s3MonthlyCost             Float    @default(2.00)
+  anthropicMonthlyCost      Float    @default(5.00)
+  updatedAt                 DateTime @updatedAt
 
   academy Academy? @relation(fields: [academyId], references: [id])
 }
@@ -443,20 +445,20 @@ model BillingConfig {
 // ─────────────────────────────────────────────────────────
 
 enum CertificateType {
-  MODULE_COMPLETION   // completó todas las lecciones del módulo
-  COURSE_COMPLETION   // completó todas las lecciones del curso
-  MODULE_EXAM         // aprobó el examen del módulo (≥ 50%)
-  COURSE_EXAM         // aprobó el examen del curso (≥ 50%)
+  MODULE_COMPLETION // completó todas las lecciones del módulo
+  COURSE_COMPLETION // completó todas las lecciones del curso
+  MODULE_EXAM // aprobó el examen del módulo (≥ 50%)
+  COURSE_EXAM // aprobó el examen del curso (≥ 50%)
 }
 
 model Certificate {
   id         String          @id @default(cuid())
   userId     String
-  courseId   String?         // null si es certificado de módulo
-  moduleId   String?         // null si es certificado de curso
+  courseId   String? // null si es certificado de módulo
+  moduleId   String? // null si es certificado de curso
   type       CertificateType
   verifyCode String          @unique @default(cuid())
-  examScore  Float?          // solo para MODULE_EXAM / COURSE_EXAM
+  examScore  Float? // solo para MODULE_EXAM / COURSE_EXAM
   issuedAt   DateTime        @default(now())
 
   user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -477,8 +479,8 @@ model ExamQuestion {
   text     String
   type     QuestionType // reutiliza el enum existente (SINGLE, MULTIPLE, TRUE_FALSE)
   order    Int          @default(0)
-  courseId String?      // null si es de módulo
-  moduleId String?      // null si es de curso
+  courseId String? // null si es de módulo
+  moduleId String? // null si es de curso
 
   course  Course?      @relation("CourseExamQuestions", fields: [courseId], references: [id], onDelete: Cascade)
   module  Module?      @relation("ModuleExamQuestions", fields: [moduleId], references: [id], onDelete: Cascade)
@@ -489,10 +491,10 @@ model ExamQuestion {
 }
 
 model ExamAnswer {
-  id         String      @id @default(cuid())
+  id         String  @id @default(cuid())
   text       String
   /// NUNCA exponer isCorrect en respuestas del endpoint de inicio de examen
-  isCorrect  Boolean     @default(false)
+  isCorrect  Boolean @default(false)
   questionId String
 
   question ExamQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
@@ -504,10 +506,10 @@ model ExamAttempt {
   courseId          String?
   moduleId          String?
   numQuestions      Int
-  timeLimit         Int?      // segundos; null = sin límite
+  timeLimit         Int? // segundos; null = sin límite
   onlyOnce          Boolean   @default(false)
-  score             Float?    // null hasta submit
-  questionsSnapshot Json      // snapshot con isCorrect para corrección server-side
+  score             Float? // null hasta submit
+  questionsSnapshot Json // snapshot con isCorrect para corrección server-side
   answers           Json      @default("[]") // [{questionId, answerId}]
   startedAt         DateTime  @default(now())
   submittedAt       DateTime?
@@ -528,7 +530,7 @@ model ExamAttempt {
 model TutorMessage {
   id        String   @id @default(cuid())
   userId    String
-  role      String   // 'user' | 'assistant'
+  role      String // 'user' | 'assistant'
   content   String   @db.Text
   courseId  String?
   lessonId  String?
@@ -539,4 +541,49 @@ model TutorMessage {
   lesson Lesson? @relation("TutorMessageLesson", fields: [lessonId], references: [id], onDelete: SetNull)
 
   @@index([userId, createdAt])
+}
+
+// ─────────────────────────────────────────────────────────
+// TEORÍA BAJO DEMANDA
+// ─────────────────────────────────────────────────────────
+// Módulos generados por IA en tiempo de ejecución, scoped al alumno
+// (privacidad por construcción vía userId). Estructura paralela a
+// Module/Lesson para no polucionar el contenido global del curso.
+
+enum TheoryLessonKind {
+  INTRO
+  CONTENT
+  EXAMPLE
+  VIDEO
+}
+
+model TheoryModule {
+  id        String   @id @default(cuid())
+  userId    String
+  courseId  String
+  topic     String // lo que pidió el alumno (input crudo)
+  title     String // título limpio generado por la IA
+  summary   String   @db.Text
+  createdAt DateTime @default(now())
+
+  user    User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  course  Course         @relation("CourseTheoryModules", fields: [courseId], references: [id], onDelete: Cascade)
+  lessons TheoryLesson[]
+
+  @@index([userId, courseId])
+  @@index([userId, createdAt])
+}
+
+model TheoryLesson {
+  id        String           @id @default(cuid())
+  moduleId  String
+  order     Int
+  kind      TheoryLessonKind
+  heading   String
+  body      String?          @db.Text // markdown; null cuando kind=VIDEO
+  youtubeId String? // solo cuando kind=VIDEO
+
+  module TheoryModule @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+
+  @@index([moduleId, order])
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -25,6 +25,7 @@ import { AcademiesModule } from './academies/academies.module';
 import { HealthModule } from './health/health.module';
 import { AiModule } from './ai/ai.module';
 import { ExercisesModule } from './exercises/exercises.module';
+import { TheoryModule } from './theory/theory.module';
 
 @Module({
   imports: [
@@ -70,6 +71,7 @@ import { ExercisesModule } from './exercises/exercises.module';
     HealthModule,
     AiModule,
     ExercisesModule,
+    TheoryModule,
   ],
   providers: [
     // Rate limiting global (100 req/min por defecto)

--- a/apps/api/src/theory/dto/generate-theory.dto.ts
+++ b/apps/api/src/theory/dto/generate-theory.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class GenerateTheoryDto {
+  @IsString()
+  courseId: string;
+
+  @IsString()
+  @MinLength(3, { message: 'El tema debe tener al menos 3 caracteres' })
+  @MaxLength(500, { message: 'El tema es demasiado largo' })
+  topic: string;
+}

--- a/apps/api/src/theory/theory.controller.ts
+++ b/apps/api/src/theory/theory.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { User } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { TheoryService } from './theory.service';
+import { GenerateTheoryDto } from './dto/generate-theory.dto';
+
+@Controller('theory')
+@UseGuards(JwtAuthGuard)
+export class TheoryController {
+  constructor(private readonly theory: TheoryService) {}
+
+  /** Genera un temario nuevo y lo guarda en la biblioteca privada del alumno. */
+  @Post('generate')
+  generate(@CurrentUser() user: User, @Body() dto: GenerateTheoryDto) {
+    return this.theory.generate(user.id, dto);
+  }
+
+  /** Lista los temarios del alumno (opcionalmente filtrados por curso). */
+  @Get('mine')
+  listMine(@CurrentUser() user: User, @Query('courseId') courseId?: string) {
+    return this.theory.listMine(user.id, courseId);
+  }
+
+  /** Devuelve un temario completo con sus lecciones (solo el dueño). */
+  @Get(':id')
+  getById(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.theory.getById(user.id, id);
+  }
+
+  /** Elimina un temario de la biblioteca (solo el dueño). */
+  @Delete(':id')
+  @HttpCode(204)
+  async deleteById(@CurrentUser() user: User, @Param('id') id: string) {
+    await this.theory.deleteById(user.id, id);
+  }
+}

--- a/apps/api/src/theory/theory.module.ts
+++ b/apps/api/src/theory/theory.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AiModule } from '../ai/ai.module';
+import { YoutubeModule } from '../youtube/youtube.module';
+import { TheoryController } from './theory.controller';
+import { TheoryService } from './theory.service';
+
+@Module({
+  imports: [PrismaModule, AiModule, YoutubeModule],
+  controllers: [TheoryController],
+  providers: [TheoryService],
+})
+export class TheoryModule {}

--- a/apps/api/src/theory/theory.service.spec.ts
+++ b/apps/api/src/theory/theory.service.spec.ts
@@ -1,0 +1,268 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { TheoryLessonKind } from '@prisma/client';
+import { TheoryService } from './theory.service';
+
+describe('TheoryService', () => {
+  let prisma: {
+    course: { findUnique: jest.Mock };
+    enrollment: { findFirst: jest.Mock };
+    theoryModule: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let ai: { generate: jest.Mock };
+  let youtube: { findBestVideo: jest.Mock };
+  let service: TheoryService;
+
+  const baseCourse = {
+    id: 'course-1',
+    title: 'Matemáticas 3º ESO',
+    schoolYear: { label: '3º ESO' },
+  };
+
+  const validAiPayload = {
+    title: 'Logaritmos: propiedades fundamentales',
+    summary: 'Repaso de las propiedades del logaritmo y su aplicación.',
+    lessons: [
+      {
+        kind: 'INTRO',
+        heading: 'Introducción',
+        body: 'El logaritmo es la operación inversa de la exponenciación.',
+      },
+      {
+        kind: 'CONTENT',
+        heading: 'Propiedades',
+        body: '**Producto**: log(a*b) = log(a) + log(b).',
+      },
+      {
+        kind: 'EXAMPLE',
+        heading: 'Ejemplos',
+        body: 'log(100) = 2 porque 10^2 = 100.',
+      },
+      {
+        kind: 'VIDEO',
+        heading: 'Vídeo recomendado',
+        ytQuery: 'propiedades logaritmos bachillerato',
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    prisma = {
+      course: { findUnique: jest.fn() },
+      enrollment: { findFirst: jest.fn() },
+      theoryModule: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    ai = { generate: jest.fn() };
+    youtube = { findBestVideo: jest.fn() };
+    service = new TheoryService(prisma as never, ai as never, youtube as never);
+  });
+
+  describe('generate', () => {
+    it('persiste el módulo con sus lecciones cuando el alumno está matriculado', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
+      youtube.findBestVideo.mockResolvedValue({ youtubeId: 'abc123' });
+      prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
+
+      await service.generate('user-1', {
+        courseId: 'course-1',
+        topic: 'propiedades de logaritmos',
+      });
+
+      expect(prisma.theoryModule.create).toHaveBeenCalledTimes(1);
+      const args = prisma.theoryModule.create.mock.calls[0][0];
+      expect(args.data.userId).toBe('user-1');
+      expect(args.data.courseId).toBe('course-1');
+      expect(args.data.title).toBe(validAiPayload.title);
+      const created = args.data.lessons.create as Array<{
+        order: number;
+        kind: TheoryLessonKind;
+        body: string | null;
+        youtubeId: string | null;
+      }>;
+      expect(created).toHaveLength(4);
+      expect(created.map((l) => l.kind)).toEqual([
+        TheoryLessonKind.INTRO,
+        TheoryLessonKind.CONTENT,
+        TheoryLessonKind.EXAMPLE,
+        TheoryLessonKind.VIDEO,
+      ]);
+      expect(created[0].order).toBe(0);
+      expect(created[3].youtubeId).toBe('abc123');
+      expect(created[3].body).toBeNull();
+      expect(created[0].body).toContain('logaritmo');
+    });
+
+    it('persiste lección VIDEO con youtubeId=null si YouTube no encuentra resultados', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
+      youtube.findBestVideo.mockResolvedValue(null);
+      prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
+
+      await service.generate('user-1', { courseId: 'course-1', topic: 't' });
+
+      const created = prisma.theoryModule.create.mock.calls[0][0].data.lessons.create;
+      expect(created[3].kind).toBe(TheoryLessonKind.VIDEO);
+      expect(created[3].youtubeId).toBeNull();
+    });
+
+    it('lanza NotFoundException si el curso no existe', async () => {
+      prisma.course.findUnique.mockResolvedValue(null);
+      await expect(service.generate('user-1', { courseId: 'missing', topic: 't' })).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(ai.generate).not.toHaveBeenCalled();
+    });
+
+    it('lanza ForbiddenException si el alumno no está matriculado', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue(null);
+      await expect(
+        service.generate('user-1', { courseId: 'course-1', topic: 't' }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(ai.generate).not.toHaveBeenCalled();
+    });
+
+    it('parsea respuesta IA envuelta en ```json```', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(`\`\`\`json\n${JSON.stringify(validAiPayload)}\n\`\`\``);
+      youtube.findBestVideo.mockResolvedValue({ youtubeId: 'xyz' });
+      prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
+
+      await service.generate('user-1', { courseId: 'course-1', topic: 't' });
+      expect(prisma.theoryModule.create).toHaveBeenCalled();
+    });
+
+    it('lanza error si la IA devuelve JSON inválido', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue('no es json {malformado');
+      await expect(
+        service.generate('user-1', { courseId: 'course-1', topic: 't' }),
+      ).rejects.toThrow();
+      expect(prisma.theoryModule.create).not.toHaveBeenCalled();
+    });
+
+    it('lanza error si una lección INTRO/CONTENT/EXAMPLE no tiene body', async () => {
+      const broken = {
+        ...validAiPayload,
+        lessons: [{ kind: 'CONTENT', heading: 'sin body' }],
+      };
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(JSON.stringify(broken));
+      await expect(
+        service.generate('user-1', { courseId: 'course-1', topic: 't' }),
+      ).rejects.toThrow(/body/);
+    });
+
+    it('lanza error si una lección tiene kind desconocido', async () => {
+      const broken = {
+        ...validAiPayload,
+        lessons: [{ kind: 'UNKNOWN', heading: 'x', body: 'y' }],
+      };
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(JSON.stringify(broken));
+      await expect(
+        service.generate('user-1', { courseId: 'course-1', topic: 't' }),
+      ).rejects.toThrow(/inválido/);
+    });
+
+    it('incluye título de curso, nivel y tema en el prompt', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
+      youtube.findBestVideo.mockResolvedValue(null);
+      prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
+
+      await service.generate('user-1', {
+        courseId: 'course-1',
+        topic: 'propiedades de logaritmos',
+      });
+
+      const prompt = ai.generate.mock.calls[0][0] as string;
+      expect(prompt).toContain('Matemáticas 3º ESO');
+      expect(prompt).toContain('3º ESO');
+      expect(prompt).toContain('propiedades de logaritmos');
+    });
+  });
+
+  describe('listMine', () => {
+    it('filtra por userId y opcionalmente por courseId', async () => {
+      prisma.theoryModule.findMany.mockResolvedValue([]);
+      await service.listMine('user-1', 'course-1');
+      expect(prisma.theoryModule.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', courseId: 'course-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('omite courseId si no se pasa', async () => {
+      prisma.theoryModule.findMany.mockResolvedValue([]);
+      await service.listMine('user-1');
+      expect(prisma.theoryModule.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+  });
+
+  describe('getById', () => {
+    it('devuelve el módulo si el usuario es dueño', async () => {
+      prisma.theoryModule.findUnique.mockResolvedValue({
+        id: 'mod-1',
+        userId: 'user-1',
+        lessons: [],
+      });
+      const mod = await service.getById('user-1', 'mod-1');
+      expect(mod.id).toBe('mod-1');
+    });
+
+    it('lanza NotFoundException si no existe', async () => {
+      prisma.theoryModule.findUnique.mockResolvedValue(null);
+      await expect(service.getById('user-1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza ForbiddenException si pertenece a otro usuario (aislamiento)', async () => {
+      prisma.theoryModule.findUnique.mockResolvedValue({
+        id: 'mod-1',
+        userId: 'otro-user',
+        lessons: [],
+      });
+      await expect(service.getById('user-1', 'mod-1')).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('elimina el módulo si el usuario es dueño', async () => {
+      prisma.theoryModule.findUnique.mockResolvedValue({ id: 'mod-1', userId: 'user-1' });
+      prisma.theoryModule.delete.mockResolvedValue({ id: 'mod-1' });
+      await service.deleteById('user-1', 'mod-1');
+      expect(prisma.theoryModule.delete).toHaveBeenCalledWith({ where: { id: 'mod-1' } });
+    });
+
+    it('lanza ForbiddenException si pertenece a otro usuario', async () => {
+      prisma.theoryModule.findUnique.mockResolvedValue({ id: 'mod-1', userId: 'otro-user' });
+      await expect(service.deleteById('user-1', 'mod-1')).rejects.toThrow(ForbiddenException);
+      expect(prisma.theoryModule.delete).not.toHaveBeenCalled();
+    });
+
+    it('lanza NotFoundException si el módulo no existe', async () => {
+      prisma.theoryModule.findUnique.mockResolvedValue(null);
+      await expect(service.deleteById('user-1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -1,0 +1,223 @@
+import {
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { TheoryLessonKind, type TheoryModule, type TheoryLesson } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AiProviderService } from '../ai/ai-provider.service';
+import { YoutubeService } from '../youtube/youtube.service';
+import { GenerateTheoryDto } from './dto/generate-theory.dto';
+
+interface GeneratedTheoryLesson {
+  kind: TheoryLessonKind;
+  heading: string;
+  body?: string;
+  ytQuery?: string;
+}
+
+interface GeneratedTheoryPayload {
+  title: string;
+  summary: string;
+  lessons: GeneratedTheoryLesson[];
+}
+
+export type TheoryModuleWithLessons = TheoryModule & { lessons: TheoryLesson[] };
+
+const VALID_KINDS = new Set<TheoryLessonKind>([
+  TheoryLessonKind.INTRO,
+  TheoryLessonKind.CONTENT,
+  TheoryLessonKind.EXAMPLE,
+  TheoryLessonKind.VIDEO,
+]);
+
+/**
+ * Genera módulos de teoría bajo demanda, persistidos en la biblioteca
+ * privada del alumno (scoped por userId). Cada módulo contiene varias
+ * lecciones (introducción, desarrollo, ejemplos, vídeo de YouTube).
+ */
+@Injectable()
+export class TheoryService {
+  private readonly logger = new Logger(TheoryService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ai: AiProviderService,
+    private readonly youtube: YoutubeService,
+  ) {}
+
+  async generate(userId: string, dto: GenerateTheoryDto): Promise<TheoryModuleWithLessons> {
+    const course = await this.prisma.course.findUnique({
+      where: { id: dto.courseId },
+      include: { schoolYear: true },
+    });
+
+    if (!course) {
+      throw new NotFoundException(`Curso "${dto.courseId}" no encontrado`);
+    }
+
+    const enrollment = await this.prisma.enrollment.findFirst({
+      where: { userId, courseId: dto.courseId },
+    });
+
+    if (!enrollment) {
+      throw new ForbiddenException('No estás matriculado en este curso');
+    }
+
+    const schoolYearLabel = course.schoolYear?.label ?? '';
+    const prompt = this.buildPrompt(course.title, schoolYearLabel, dto.topic);
+
+    this.logger.log(`Generando temario sobre "${dto.topic}" para curso "${course.title}"`);
+
+    const text = await this.ai.generate(prompt, 4000);
+    const payload = this.parseAi(text);
+
+    // Resolver vídeo de YouTube para lecciones VIDEO (puede haber varias o ninguna)
+    const lessonsWithVideo = await Promise.all(
+      payload.lessons.map(async (lesson) => {
+        if (lesson.kind !== TheoryLessonKind.VIDEO) return { ...lesson, youtubeId: null };
+        const query = lesson.ytQuery ?? `${dto.topic} ${course.title}`;
+        const candidate = await this.youtube.findBestVideo(query, schoolYearLabel);
+        return { ...lesson, youtubeId: candidate?.youtubeId ?? null };
+      }),
+    );
+
+    return this.prisma.theoryModule.create({
+      data: {
+        userId,
+        courseId: dto.courseId,
+        topic: dto.topic,
+        title: payload.title,
+        summary: payload.summary,
+        lessons: {
+          create: lessonsWithVideo.map((lesson, idx) => ({
+            order: idx,
+            kind: lesson.kind,
+            heading: lesson.heading,
+            body: lesson.kind === TheoryLessonKind.VIDEO ? null : (lesson.body ?? ''),
+            youtubeId: lesson.kind === TheoryLessonKind.VIDEO ? lesson.youtubeId : null,
+          })),
+        },
+      },
+      include: { lessons: { orderBy: { order: 'asc' } } },
+    });
+  }
+
+  listMine(userId: string, courseId?: string): Promise<TheoryModule[]> {
+    return this.prisma.theoryModule.findMany({
+      where: { userId, ...(courseId ? { courseId } : {}) },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async getById(userId: string, id: string): Promise<TheoryModuleWithLessons> {
+    const mod = await this.prisma.theoryModule.findUnique({
+      where: { id },
+      include: { lessons: { orderBy: { order: 'asc' } } },
+    });
+    if (!mod) {
+      throw new NotFoundException(`Temario "${id}" no encontrado`);
+    }
+    if (mod.userId !== userId) {
+      throw new ForbiddenException('No tienes acceso a este temario');
+    }
+    return mod;
+  }
+
+  async deleteById(userId: string, id: string): Promise<void> {
+    const mod = await this.prisma.theoryModule.findUnique({ where: { id } });
+    if (!mod) {
+      throw new NotFoundException(`Temario "${id}" no encontrado`);
+    }
+    if (mod.userId !== userId) {
+      throw new ForbiddenException('No tienes acceso a este temario');
+    }
+    await this.prisma.theoryModule.delete({ where: { id } });
+  }
+
+  private parseAi(text: string): GeneratedTheoryPayload {
+    let parsed: unknown;
+    try {
+      const raw = text
+        .trim()
+        .replace(/^```json\n?/, '')
+        .replace(/\n?```$/, '');
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      this.logger.error('Error al parsear JSON de IA (teoría):', text);
+      throw new InternalServerErrorException(
+        `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
+      );
+    }
+
+    const obj = parsed as Partial<GeneratedTheoryPayload>;
+    if (!obj.title || !obj.summary || !Array.isArray(obj.lessons) || obj.lessons.length === 0) {
+      throw new InternalServerErrorException(
+        'La respuesta de la IA no contiene title/summary/lessons válidos',
+      );
+    }
+
+    for (const lesson of obj.lessons) {
+      if (!VALID_KINDS.has(lesson.kind)) {
+        throw new InternalServerErrorException(`Tipo de lección inválido: "${lesson.kind}"`);
+      }
+      if (typeof lesson.heading !== 'string' || lesson.heading.length === 0) {
+        throw new InternalServerErrorException('Una lección no tiene heading');
+      }
+      if (lesson.kind !== TheoryLessonKind.VIDEO && !lesson.body) {
+        throw new InternalServerErrorException(
+          `La lección "${lesson.heading}" (${lesson.kind}) no tiene body`,
+        );
+      }
+    }
+
+    return obj as GeneratedTheoryPayload;
+  }
+
+  private buildPrompt(courseTitle: string, schoolYearLabel: string, topic: string): string {
+    return `Genera un temario de teoría en español sobre "${topic}".
+
+Curso: "${courseTitle}"
+${schoolYearLabel ? `Nivel educativo: "${schoolYearLabel}" (sistema educativo español)` : ''}
+
+Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, sin texto adicional):
+{
+  "title": "título limpio del temario (no repitas el tema literal)",
+  "summary": "resumen del temario en 1-2 frases",
+  "lessons": [
+    {
+      "kind": "INTRO",
+      "heading": "Introducción",
+      "body": "explicación introductoria en markdown (2-3 párrafos)"
+    },
+    {
+      "kind": "CONTENT",
+      "heading": "título de la sección de desarrollo",
+      "body": "explicación detallada en markdown (3-5 párrafos, puede usar listas y negritas)"
+    },
+    {
+      "kind": "EXAMPLE",
+      "heading": "Ejemplos",
+      "body": "ejemplos resueltos en markdown (al menos 2 ejemplos con paso a paso)"
+    },
+    {
+      "kind": "VIDEO",
+      "heading": "Vídeo recomendado",
+      "ytQuery": "consulta optimizada para buscar el mejor vídeo en YouTube sobre este tema"
+    }
+  ]
+}
+
+Reglas:
+- Mínimo 3 lecciones, máximo 6.
+- Estructura recomendada: 1 INTRO + 1-3 CONTENT + 1 EXAMPLE + 1 VIDEO (último).
+- INTRO/CONTENT/EXAMPLE: campo "body" obligatorio en markdown. NO incluir "ytQuery".
+- VIDEO: campo "ytQuery" obligatorio. NO incluir "body".
+- El markdown puede usar **negritas**, *cursivas*, listas con guiones, encabezados con ##, fórmulas LaTeX inline con $...$.
+- Contenido curricular real y riguroso, adaptado al nivel ${schoolYearLabel || 'del curso'}.
+- "ytQuery" debe ser una búsqueda específica y descriptiva (ej. "demostración propiedades logaritmos bachillerato").
+- Solo devuelve JSON puro, sin markdown alrededor del JSON.`;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,9 @@
     "jspdf": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^6.28.0",
+    "remark-gfm": "^4.0.1",
     "zustand": "^5.0.2"
   },
   "devDependencies": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,6 +25,8 @@ import TutorStudentsPage from './pages/TutorStudentsPage';
 import ExamPage from './pages/ExamPage';
 import ExamsListPage from './pages/ExamsListPage';
 import ExercisesPage from './pages/ExercisesPage';
+import TheoryPage from './pages/TheoryPage';
+import TheoryModulePage from './pages/TheoryModulePage';
 import AdminExamBankPage from './pages/admin/AdminExamBankPage';
 import CertificatesPage from './pages/CertificatesPage';
 import AdminAcademiesPage from './pages/admin/AdminAcademiesPage';
@@ -124,6 +126,10 @@ export default function App() {
 
         {/* Ejercicios generados por IA */}
         <Route path="exercises" element={<ExercisesPage />} />
+
+        {/* Teoría bajo demanda — módulos generados por IA */}
+        <Route path="theory" element={<TheoryPage />} />
+        <Route path="theory/:id" element={<TheoryModulePage />} />
 
         {/* Fase 9 — Certificados */}
         <Route path="certificates" element={<CertificatesPage />} />

--- a/apps/web/src/api/theory.api.ts
+++ b/apps/web/src/api/theory.api.ts
@@ -1,0 +1,22 @@
+import api from '../lib/axios';
+import type {
+  GenerateTheoryRequest,
+  TheoryModuleSummary,
+  TheoryModuleWithLessons,
+} from '@vkbacademy/shared';
+
+export const theoryApi = {
+  generate: (payload: GenerateTheoryRequest) =>
+    api.post<TheoryModuleWithLessons>('/theory/generate', payload).then((r) => r.data),
+
+  listMine: (courseId?: string) =>
+    api
+      .get<TheoryModuleSummary[]>('/theory/mine', {
+        params: courseId ? { courseId } : undefined,
+      })
+      .then((r) => r.data),
+
+  getById: (id: string) => api.get<TheoryModuleWithLessons>(`/theory/${id}`).then((r) => r.data),
+
+  delete: (id: string) => api.delete<void>(`/theory/${id}`).then((r) => r.data),
+};

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -65,6 +65,7 @@ function buildNavLinks(role: Role | undefined): NavLink[] {
     { to: '/courses', label: '📚 Cursos' },
     { to: '/bookings', label: '📅 Clases Particulares' },
     { to: '/exercises', label: '🧮 Ejercicios' },
+    { to: '/theory', label: '📖 Teoría' },
     { to: '/my-exams', label: '🎓 Exámenes' },
     { to: '/challenges', label: '🏆 Retos' },
     { to: '/certificates', label: '📜 Certificados' },

--- a/apps/web/src/pages/TheoryModulePage.tsx
+++ b/apps/web/src/pages/TheoryModulePage.tsx
@@ -1,0 +1,185 @@
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { theoryApi } from '../api/theory.api';
+import type { TheoryLesson, TheoryLessonKind } from '@vkbacademy/shared';
+
+const KIND_ICON: Record<TheoryLessonKind, string> = {
+  INTRO: '🧭',
+  CONTENT: '📚',
+  EXAMPLE: '💡',
+  VIDEO: '▶️',
+};
+
+export default function TheoryModulePage() {
+  const { id = '' } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['theory', id],
+    queryFn: () => theoryApi.getById(id),
+    enabled: !!id,
+  });
+
+  const remove = useMutation({
+    mutationFn: () => theoryApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['theory', 'mine'] });
+      navigate('/theory');
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div style={s.page}>
+        <p style={s.muted}>Cargando temario…</p>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div style={s.page}>
+        <p style={s.muted}>No se encontró el temario.</p>
+        <Link to="/theory" style={s.backLink}>
+          ← Volver a Teoría
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div style={s.page}>
+      <Link to="/theory" style={s.backLink}>
+        ← Volver a Teoría
+      </Link>
+
+      <header style={s.header}>
+        <span style={s.eyebrow}>Tema solicitado: {data.topic}</span>
+        <h1 style={s.title}>{data.title}</h1>
+        <p style={s.summary}>{data.summary}</p>
+      </header>
+
+      <article style={s.article}>
+        {data.lessons.map((lesson) => (
+          <LessonSection key={lesson.id} lesson={lesson} />
+        ))}
+      </article>
+
+      <footer style={s.footer}>
+        <button
+          type="button"
+          onClick={() => {
+            if (window.confirm('¿Borrar este temario de tu biblioteca?')) remove.mutate();
+          }}
+          disabled={remove.isPending}
+          style={s.deleteBtn}
+        >
+          {remove.isPending ? 'Borrando…' : '🗑️ Borrar temario'}
+        </button>
+      </footer>
+    </div>
+  );
+}
+
+function LessonSection({ lesson }: { lesson: TheoryLesson }) {
+  return (
+    <section style={s.section}>
+      <h2 style={s.sectionTitle}>
+        <span aria-hidden>{KIND_ICON[lesson.kind]}</span> {lesson.heading}
+      </h2>
+
+      {lesson.kind === 'VIDEO' ? (
+        lesson.youtubeId ? (
+          <div style={s.videoWrapper}>
+            <iframe
+              style={s.videoIframe}
+              src={`https://www.youtube.com/embed/${lesson.youtubeId}`}
+              title={lesson.heading}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        ) : (
+          <p style={s.muted}>No se encontró un vídeo adecuado para este tema.</p>
+        )
+      ) : (
+        <div style={s.markdown}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{lesson.body ?? ''}</ReactMarkdown>
+        </div>
+      )}
+    </section>
+  );
+}
+
+const s: Record<string, React.CSSProperties> = {
+  page: {
+    maxWidth: 820,
+    margin: '0 auto',
+    padding: '24px 16px 64px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 24,
+  },
+  backLink: {
+    color: '#f97316',
+    fontSize: '0.875rem',
+    textDecoration: 'none',
+    fontWeight: 600,
+  },
+  header: { display: 'flex', flexDirection: 'column', gap: 8 },
+  eyebrow: {
+    fontSize: '0.75rem',
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  title: { fontSize: '2rem', fontWeight: 800, margin: 0, lineHeight: 1.15 },
+  summary: {
+    fontSize: '1.05rem',
+    color: 'var(--color-text-muted)',
+    lineHeight: 1.6,
+    margin: 0,
+  },
+  article: { display: 'flex', flexDirection: 'column', gap: 32 },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 14,
+    padding: 24,
+  },
+  sectionTitle: { fontSize: '1.25rem', fontWeight: 700, margin: 0 },
+  markdown: { fontSize: '1rem', lineHeight: 1.7, color: 'var(--color-text)' },
+  videoWrapper: {
+    position: 'relative',
+    paddingTop: '56.25%',
+    borderRadius: 10,
+    overflow: 'hidden',
+    background: '#000',
+  },
+  videoIframe: {
+    position: 'absolute',
+    inset: 0,
+    width: '100%',
+    height: '100%',
+    border: 0,
+  },
+  muted: { color: 'var(--color-text-muted)', fontSize: '0.95rem', margin: 0 },
+  footer: { display: 'flex', justifyContent: 'flex-end' },
+  deleteBtn: {
+    background: 'transparent',
+    border: '1px solid rgba(220,38,38,0.4)',
+    color: '#dc2626',
+    padding: '10px 18px',
+    borderRadius: 8,
+    fontSize: '0.875rem',
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+};

--- a/apps/web/src/pages/TheoryPage.tsx
+++ b/apps/web/src/pages/TheoryPage.tsx
@@ -1,0 +1,253 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCourses } from '../hooks/useCourses';
+import { theoryApi } from '../api/theory.api';
+import type { TheoryModuleSummary } from '@vkbacademy/shared';
+
+export default function TheoryPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { data: coursesData } = useCourses(1);
+  const courses = coursesData?.data ?? [];
+
+  const [courseId, setCourseId] = useState('');
+  const [topic, setTopic] = useState('');
+
+  const { data: library, isLoading: libraryLoading } = useQuery({
+    queryKey: ['theory', 'mine'],
+    queryFn: () => theoryApi.listMine(),
+  });
+
+  const generate = useMutation({
+    mutationFn: theoryApi.generate,
+    onSuccess: (mod) => {
+      queryClient.invalidateQueries({ queryKey: ['theory', 'mine'] });
+      navigate(`/theory/${mod.id}`);
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: theoryApi.delete,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['theory', 'mine'] }),
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!courseId || !topic.trim()) return;
+    generate.mutate({ courseId, topic: topic.trim() });
+  }
+
+  const apiError = (
+    generate.error as { response?: { data?: { message?: string | string[] } } } | null
+  )?.response?.data?.message;
+  const apiErrorText = Array.isArray(apiError) ? apiError.join(' · ') : apiError;
+
+  // Agrupar la biblioteca por curso
+  const grouped = (library ?? []).reduce<Record<string, TheoryModuleSummary[]>>((acc, mod) => {
+    (acc[mod.courseId] = acc[mod.courseId] ?? []).push(mod);
+    return acc;
+  }, {});
+
+  const courseTitleById = new Map(courses.map((c) => [c.id, c.title] as const));
+
+  return (
+    <div style={s.page}>
+      <header style={s.header}>
+        <h1 style={s.title}>📖 Teoría</h1>
+        <p style={s.subtitle}>
+          Pide un temario sobre cualquier tema de tus cursos. La IA generará un módulo con
+          explicaciones y un vídeo de YouTube, y se guardará en tu biblioteca.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} style={s.form}>
+        <div className="field">
+          <label htmlFor="courseId">Curso</label>
+          <select
+            id="courseId"
+            value={courseId}
+            onChange={(e) => setCourseId(e.target.value)}
+            required
+          >
+            <option value="">Selecciona un curso</option>
+            {courses.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.title}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="field">
+          <label htmlFor="topic">¿Sobre qué tema quieres el temario?</label>
+          <textarea
+            id="topic"
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+            placeholder="Ej: propiedades de logaritmos, el Renacimiento, análisis sintáctico..."
+            rows={3}
+            style={s.textarea}
+            required
+          />
+        </div>
+
+        {apiErrorText && (
+          <div style={s.errorBox}>
+            <strong>!</strong> {apiErrorText}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          className="btn btn-primary"
+          disabled={generate.isPending || !courseId || !topic.trim()}
+          style={{ alignSelf: 'flex-start', padding: '12px 24px' }}
+        >
+          {generate.isPending ? '⏳ Generando temario...' : '✨ Generar temario'}
+        </button>
+      </form>
+
+      <section style={s.results}>
+        <h2 style={s.resultsTitle}>Mi biblioteca</h2>
+
+        {libraryLoading && <p style={s.empty}>Cargando…</p>}
+
+        {!libraryLoading && (library?.length ?? 0) === 0 && (
+          <p style={s.empty}>
+            Aún no has generado ningún temario. Pide el primero arriba para guardarlo aquí.
+          </p>
+        )}
+
+        {Object.entries(grouped).map(([cid, mods]) => (
+          <div key={cid} style={s.group}>
+            <h3 style={s.groupTitle}>{courseTitleById.get(cid) ?? 'Curso'}</h3>
+            <ul style={s.list}>
+              {mods.map((mod) => (
+                <li key={mod.id} style={s.item}>
+                  <Link to={`/theory/${mod.id}`} style={s.itemLink}>
+                    <strong>{mod.title}</strong>
+                    <span style={s.itemMeta}>{mod.summary}</span>
+                    <span style={s.itemDate}>
+                      {new Date(mod.createdAt).toLocaleDateString('es-ES', {
+                        day: '2-digit',
+                        month: 'short',
+                        year: 'numeric',
+                      })}
+                    </span>
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (window.confirm(`¿Borrar "${mod.title}" de tu biblioteca?`)) {
+                        remove.mutate(mod.id);
+                      }
+                    }}
+                    style={s.deleteBtn}
+                    aria-label="Borrar temario"
+                  >
+                    🗑️
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+const s: Record<string, React.CSSProperties> = {
+  page: {
+    maxWidth: 900,
+    margin: '0 auto',
+    padding: '32px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 32,
+  },
+  header: { display: 'flex', flexDirection: 'column', gap: 8 },
+  title: { fontSize: '1.8rem', fontWeight: 800, margin: 0 },
+  subtitle: {
+    color: 'var(--color-text-muted)',
+    fontSize: '0.95rem',
+    lineHeight: 1.5,
+    margin: 0,
+  },
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 14,
+    padding: 24,
+  },
+  textarea: {
+    width: '100%',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 8,
+    color: 'var(--color-text)',
+    padding: '10px 12px',
+    fontSize: '0.95rem',
+    fontFamily: 'inherit',
+    resize: 'vertical',
+  },
+  errorBox: {
+    background: 'rgba(220,38,38,0.15)',
+    borderLeft: '4px solid #dc2626',
+    color: 'var(--color-error)',
+    padding: '12px 14px',
+    borderRadius: 8,
+    fontSize: '0.875rem',
+  },
+  results: { display: 'flex', flexDirection: 'column', gap: 18 },
+  resultsTitle: { fontSize: '1.2rem', fontWeight: 700, margin: 0 },
+  empty: { color: 'var(--color-text-muted)', fontSize: '0.9rem', margin: 0 },
+  group: { display: 'flex', flexDirection: 'column', gap: 8 },
+  groupTitle: {
+    fontSize: '0.85rem',
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    margin: 0,
+  },
+  list: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+  },
+  item: {
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 12,
+    display: 'flex',
+    alignItems: 'stretch',
+    gap: 8,
+  },
+  itemLink: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    padding: '14px 16px',
+    color: 'var(--color-text)',
+    textDecoration: 'none',
+  },
+  itemMeta: { fontSize: '0.875rem', color: 'var(--color-text-muted)', lineHeight: 1.4 },
+  itemDate: { fontSize: '0.75rem', color: 'var(--color-text-muted)', marginTop: 2 },
+  deleteBtn: {
+    background: 'transparent',
+    border: 'none',
+    color: 'var(--color-text-muted)',
+    padding: '0 14px',
+    cursor: 'pointer',
+    fontSize: '1.1rem',
+  },
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,9 @@ export * from './types/certificate.types';
 // Tipos del tutor virtual
 export * from './types/tutor.types';
 
+// Tipos de teoría bajo demanda
+export * from './types/theory.types';
+
 // Utilidades de API
 export * from './types/pagination.types';
 export * from './types/api.types';

--- a/packages/shared/src/types/theory.types.ts
+++ b/packages/shared/src/types/theory.types.ts
@@ -1,0 +1,33 @@
+// Teoría bajo demanda — temarios generados por IA y persistidos
+// en la biblioteca privada del alumno.
+
+export type TheoryLessonKind = 'INTRO' | 'CONTENT' | 'EXAMPLE' | 'VIDEO';
+
+export interface TheoryLesson {
+  id: string;
+  moduleId: string;
+  order: number;
+  kind: TheoryLessonKind;
+  heading: string;
+  body: string | null;
+  youtubeId: string | null;
+}
+
+export interface TheoryModuleSummary {
+  id: string;
+  userId: string;
+  courseId: string;
+  topic: string;
+  title: string;
+  summary: string;
+  createdAt: string;
+}
+
+export interface TheoryModuleWithLessons extends TheoryModuleSummary {
+  lessons: TheoryLesson[];
+}
+
+export interface GenerateTheoryRequest {
+  courseId: string;
+  topic: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,9 +223,15 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
       react-router-dom:
         specifier: ^6.28.0
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       zustand:
         specifier: ^5.0.2
         version: 5.0.11(@types/react@18.3.28)(react@18.3.1)
@@ -1465,7 +1471,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -2591,6 +2597,9 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2599,6 +2608,9 @@ packages:
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2611,6 +2623,9 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -2638,6 +2653,9 @@ packages:
 
   '@types/jsonwebtoken@9.0.5':
     resolution: {integrity: sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -2707,6 +2725,12 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
@@ -2721,6 +2745,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@urql/core@2.3.6':
     resolution: {integrity: sha512-PUxhtBh7/8167HJK6WqBv6Z0piuiaZHQGYbhwpNL9aIQmLROPEdaUYkY4wh45wPQXcTpnd11l0q3Pw+TI11pdw==}
@@ -3093,6 +3120,9 @@ packages:
   badgin@1.2.3:
     resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3256,6 +3286,9 @@ packages:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
     engines: {node: '>=10.0.0'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -3275,6 +3308,18 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
@@ -3403,6 +3448,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   command-exists@1.2.9:
     resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
@@ -3612,6 +3660,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
@@ -3693,6 +3744,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -3869,6 +3923,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -3889,6 +3947,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -4029,6 +4090,9 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -4386,6 +4450,12 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   helmet@8.1.0:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
@@ -4424,6 +4494,9 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html2canvas@1.4.1:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
@@ -4495,6 +4568,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   inquirer@8.2.6:
     resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
     engines: {node: '>=12.0.0'}
@@ -4528,6 +4604,12 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -4578,6 +4660,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-directory@0.3.1:
     resolution: {integrity: sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==}
     engines: {node: '>=0.10.0'}
@@ -4623,6 +4708,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
@@ -4662,6 +4750,10 @@ packages:
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
@@ -5168,6 +5260,9 @@ packages:
     resolution: {integrity: sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==}
     hasBin: true
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -5215,6 +5310,9 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
@@ -5235,6 +5333,51 @@ packages:
 
   md5hex@1.0.0:
     resolution: {integrity: sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -5328,6 +5471,90 @@ packages:
     resolution: {integrity: sha512-1UsH5FzJd9quUsD1qY+zUG4JY3jo3YEMxbMYH9jT6NK3j4iORhlwTK8fYTfAUBhDKjgLfKjAh7aoazNE23oIRA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5666,6 +5893,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
     engines: {node: '>=4'}
@@ -5862,6 +6092,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -5945,6 +6178,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-native-helmet-async@2.0.4:
     resolution: {integrity: sha512-m3CkXWss6B1dd6mCMleLpzDCJJGGaHOLQsUzZv8kAASJmMfmVT4d2fx375iXKTRWT25ThBfae3dECuX5cq/8hg==}
@@ -6072,6 +6311,18 @@ packages:
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   remove-trailing-slash@0.1.1:
     resolution: {integrity: sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==}
@@ -6384,6 +6635,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
@@ -6480,6 +6734,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
@@ -6532,6 +6789,12 @@ packages:
 
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sucrase@3.34.0:
     resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
@@ -6726,9 +6989,15 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   trim-right@1.0.1:
     resolution: {integrity: sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==}
     engines: {node: '>=0.10.0'}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -6937,6 +7206,9 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -6952,6 +7224,21 @@ packages:
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -7031,6 +7318,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -7385,6 +7678,9 @@ packages:
         optional: true
       use-sync-external-store:
         optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -10922,6 +11218,10 @@ snapshots:
 
   '@types/cookiejar@2.1.5': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
@@ -10933,6 +11233,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
@@ -10952,6 +11256,10 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.19.11
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/http-errors@2.0.5': {}
 
@@ -10985,6 +11293,10 @@ snapshots:
   '@types/jsonwebtoken@9.0.5':
     dependencies:
       '@types/node': 22.19.11
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/methods@1.1.4': {}
 
@@ -11067,6 +11379,10 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/validator@13.15.10': {}
 
   '@types/yargs-parser@21.0.3': {}
@@ -11082,6 +11398,8 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@urql/core@2.3.6(graphql@15.8.0)':
     dependencies:
@@ -11556,6 +11874,8 @@ snapshots:
 
   badgin@1.2.3: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.3: {}
@@ -11749,6 +12069,8 @@ snapshots:
       svg-pathdata: 6.0.3
     optional: true
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@2.4.2:
@@ -11765,6 +12087,14 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@0.7.0: {}
 
@@ -11888,6 +12218,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   command-exists@1.2.9: {}
 
@@ -12101,6 +12433,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decode-uri-component@0.2.2: {}
 
   dedent@1.7.1: {}
@@ -12162,6 +12498,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dezalgo@1.0.4:
     dependencies:
@@ -12390,6 +12730,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -12404,6 +12746,8 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -12639,6 +12983,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   external-editor@3.1.0:
     dependencies:
@@ -13061,6 +13407,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   helmet@8.1.0: {}
 
   hermes-estree@0.19.1: {}
@@ -13102,6 +13472,8 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-url-attributes@3.0.1: {}
 
   html2canvas@1.4.1:
     dependencies:
@@ -13181,6 +13553,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.2.7: {}
+
   inquirer@8.2.6:
     dependencies:
       ansi-escapes: 4.3.2
@@ -13252,6 +13626,13 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arguments@1.2.0:
     dependencies:
       call-bound: 1.0.4
@@ -13307,6 +13688,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-directory@0.3.1: {}
 
   is-docker@2.2.1: {}
@@ -13341,6 +13724,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@1.0.0: {}
 
   is-invalid-path@0.1.0:
@@ -13368,6 +13753,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@2.1.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-plain-object@2.0.4:
     dependencies:
@@ -14107,6 +14494,8 @@ snapshots:
       dayjs: 1.11.19
       yargs: 15.4.1
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -14152,6 +14541,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  markdown-table@3.0.4: {}
+
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
@@ -14173,6 +14564,159 @@ snapshots:
       is-buffer: 1.1.6
 
   md5hex@1.0.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
 
@@ -14375,6 +14919,197 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -14682,6 +15417,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@4.0.0:
     dependencies:
       error-ex: 1.3.4
@@ -14860,6 +15605,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  property-information@7.1.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -14947,6 +15694,24 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-markdown@10.1.0(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.28
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-native-helmet-async@2.0.4(react@18.2.0):
     dependencies:
@@ -15136,6 +15901,40 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   remove-trailing-slash@0.1.1: {}
 
@@ -15498,6 +16297,8 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split-on-first@1.1.0: {}
 
   sprintf-js@1.0.3: {}
@@ -15592,6 +16393,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@5.2.0:
     dependencies:
       ansi-regex: 4.1.1
@@ -15629,6 +16435,14 @@ snapshots:
       '@tokenizer/token': 0.3.0
 
   structured-headers@0.4.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   sucrase@3.34.0:
     dependencies:
@@ -15837,7 +16651,11 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trim-lines@3.0.1: {}
+
   trim-right@1.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-algebra@2.0.0: {}
 
@@ -16029,6 +16847,16 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unique-filename@3.0.0:
     dependencies:
       unique-slug: 4.0.0
@@ -16044,6 +16872,29 @@ snapshots:
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universalify@0.1.2: {}
 
@@ -16109,6 +16960,16 @@ snapshots:
   validator@13.15.26: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@6.4.1(@types/node@22.19.11)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
@@ -16429,3 +17290,5 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       react: 18.3.1
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
Closes #24.

## Summary
- Add `Teoría` feature parallel to `Ejercicios`: students request a topic, receive a persistent module with AI-generated text lessons (INTRO/CONTENT/EXAMPLE) + a YouTube video lesson scoped to one of their enrolled courses.
- New `TheoryModule` / `TheoryLesson` tables (private per user, separate from global `Module`/`Lesson` to avoid leaks into course views).
- New endpoints: `POST /theory/generate`, `GET /theory/mine`, `GET /theory/:id`, `DELETE /theory/:id` with owner checks.
- Frontend: `TheoryPage` (form + library grouped by course) + `TheoryModulePage` (long-form view with markdown + embedded YouTube). Sidebar entry added next to "Ejercicios".

## Notes
- Migration SQL was hand-crafted (no Docker locally). Will be applied automatically by the `migrate-pre`/`migrate-prod` pipeline jobs on merge.
- Reuses `AiProviderService` (Gemini → Haiku fallback) and `YoutubeService.findBestVideo`.
- 17 new unit tests in `theory.service.spec.ts`; full API suite stays green (408 tests).

## Test plan
- [ ] CI green (tests + type-check)
- [ ] PRE deploy → generate a module → confirm shows in library, opens, deletes
- [ ] Verify markdown renders correctly (headers, lists, bold)
- [ ] Verify YouTube embed loads
- [ ] Confirm a student can't open another student's theory module (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)