### PR TITLE
feat(theory): KaTeX math + 5 YouTube candidates per VIDEO lesson

### DIFF
--- a/apps/api/prisma/migrations/20260504152045_theory_video_candidates/migration.sql
+++ b/apps/api/prisma/migrations/20260504152045_theory_video_candidates/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TheoryLesson" ADD COLUMN "videoCandidates" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -581,7 +581,10 @@ model TheoryLesson {
   kind      TheoryLessonKind
   heading   String
   body      String?          @db.Text // markdown; null cuando kind=VIDEO
-  youtubeId String? // solo cuando kind=VIDEO
+  youtubeId String? // primario / fallback para registros antiguos (kind=VIDEO)
+  /// Lista de candidatos de YouTube cuando kind=VIDEO. Estructura:
+  /// [{ youtubeId, title, channelTitle, thumbnailUrl, durationSeconds, viewCount, ... }]
+  videoCandidates Json?
 
   module TheoryModule @relation(fields: [moduleId], references: [id], onDelete: Cascade)
 

--- a/apps/api/src/theory/theory.service.spec.ts
+++ b/apps/api/src/theory/theory.service.spec.ts
@@ -1,5 +1,5 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { TheoryLessonKind } from '@prisma/client';
+import { Prisma, TheoryLessonKind } from '@prisma/client';
 import { TheoryService } from './theory.service';
 
 describe('TheoryService', () => {
@@ -14,7 +14,7 @@ describe('TheoryService', () => {
     };
   };
   let ai: { generate: jest.Mock };
-  let youtube: { findBestVideo: jest.Mock };
+  let youtube: { findCandidates: jest.Mock };
   let service: TheoryService;
 
   const baseCourse = {
@@ -62,7 +62,7 @@ describe('TheoryService', () => {
       },
     };
     ai = { generate: jest.fn() };
-    youtube = { findBestVideo: jest.fn() };
+    youtube = { findCandidates: jest.fn() };
     service = new TheoryService(prisma as never, ai as never, youtube as never);
   });
 
@@ -71,7 +71,14 @@ describe('TheoryService', () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
       prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
-      youtube.findBestVideo.mockResolvedValue({ youtubeId: 'abc123' });
+      const five = Array.from({ length: 5 }, (_, i) => ({
+        youtubeId: `vid${i}`,
+        title: `Vídeo ${i}`,
+        channelTitle: 'Canal X',
+        thumbnailUrl: `https://img/${i}.jpg`,
+        durationSeconds: 600,
+      }));
+      youtube.findCandidates.mockResolvedValue(five);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
 
       await service.generate('user-1', {
@@ -89,6 +96,7 @@ describe('TheoryService', () => {
         kind: TheoryLessonKind;
         body: string | null;
         youtubeId: string | null;
+        videoCandidates: unknown;
       }>;
       expect(created).toHaveLength(4);
       expect(created.map((l) => l.kind)).toEqual([
@@ -98,16 +106,31 @@ describe('TheoryService', () => {
         TheoryLessonKind.VIDEO,
       ]);
       expect(created[0].order).toBe(0);
-      expect(created[3].youtubeId).toBe('abc123');
+      expect(created[3].youtubeId).toBe('vid0');
+      expect(created[3].videoCandidates).toEqual(five);
       expect(created[3].body).toBeNull();
       expect(created[0].body).toContain('logaritmo');
     });
 
-    it('persiste lección VIDEO con youtubeId=null si YouTube no encuentra resultados', async () => {
+    it('pide 5 candidatos a YoutubeService para la lección VIDEO', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
       prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
-      youtube.findBestVideo.mockResolvedValue(null);
+      youtube.findCandidates.mockResolvedValue([]);
+      prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
+
+      await service.generate('user-1', { courseId: 'course-1', topic: 't' });
+
+      expect(youtube.findCandidates).toHaveBeenCalledWith(expect.any(String), '3º ESO', {
+        limit: 5,
+      });
+    });
+
+    it('persiste lección VIDEO con candidates=null y youtubeId=null si YouTube no encuentra resultados', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
+      youtube.findCandidates.mockResolvedValue([]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
 
       await service.generate('user-1', { courseId: 'course-1', topic: 't' });
@@ -115,6 +138,7 @@ describe('TheoryService', () => {
       const created = prisma.theoryModule.create.mock.calls[0][0].data.lessons.create;
       expect(created[3].kind).toBe(TheoryLessonKind.VIDEO);
       expect(created[3].youtubeId).toBeNull();
+      expect(created[3].videoCandidates).toBe(Prisma.DbNull);
     });
 
     it('lanza NotFoundException si el curso no existe', async () => {
@@ -138,7 +162,7 @@ describe('TheoryService', () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
       prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(`\`\`\`json\n${JSON.stringify(validAiPayload)}\n\`\`\``);
-      youtube.findBestVideo.mockResolvedValue({ youtubeId: 'xyz' });
+      youtube.findCandidates.mockResolvedValue([{ youtubeId: 'xyz' }]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
 
       await service.generate('user-1', { courseId: 'course-1', topic: 't' });
@@ -185,7 +209,7 @@ describe('TheoryService', () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
       prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
-      youtube.findBestVideo.mockResolvedValue(null);
+      youtube.findCandidates.mockResolvedValue([]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
 
       await service.generate('user-1', {

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -215,7 +215,8 @@ Reglas:
 - Estructura recomendada: 1 INTRO + 1-3 CONTENT + 1 EXAMPLE + 1 VIDEO (último).
 - INTRO/CONTENT/EXAMPLE: campo "body" obligatorio en markdown. NO incluir "ytQuery".
 - VIDEO: campo "ytQuery" obligatorio. NO incluir "body".
-- El markdown puede usar **negritas**, *cursivas*, listas con guiones, encabezados con ##, fórmulas LaTeX inline con $...$.
+- El markdown puede usar **negritas**, *cursivas*, listas con guiones, encabezados con ##.
+- Para fórmulas matemáticas USA SIEMPRE LaTeX: inline con $...$ (ej. $\\log_a b = c$) y bloques con $$...$$ para derivaciones o ecuaciones destacadas. NO escribas fórmulas en texto plano (NUNCA "log_a b = c"; SIEMPRE "$\\log_a b = c$").
 - Contenido curricular real y riguroso, adaptado al nivel ${schoolYearLabel || 'del curso'}.
 - "ytQuery" debe ser una búsqueda específica y descriptiva (ej. "demostración propiedades logaritmos bachillerato").
 - Solo devuelve JSON puro, sin markdown alrededor del JSON.`;

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { TheoryLessonKind, type TheoryModule, type TheoryLesson } from '@prisma/client';
+import { Prisma, TheoryLessonKind, type TheoryModule, type TheoryLesson } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AiProviderService } from '../ai/ai-provider.service';
 import { YoutubeService } from '../youtube/youtube.service';
@@ -74,13 +74,22 @@ export class TheoryService {
     const text = await this.ai.generate(prompt, 4000);
     const payload = this.parseAi(text);
 
-    // Resolver vídeo de YouTube para lecciones VIDEO (puede haber varias o ninguna)
+    // Resolver vídeo de YouTube para lecciones VIDEO. Para cada VIDEO pedimos
+    // hasta 5 candidatos (ordenados por engagement+whitelist) y los guardamos
+    // todos para que el alumno pueda elegir; el primero es el que se embebe
+    // por defecto (y se persiste también en youtubeId por compat).
     const lessonsWithVideo = await Promise.all(
       payload.lessons.map(async (lesson) => {
-        if (lesson.kind !== TheoryLessonKind.VIDEO) return { ...lesson, youtubeId: null };
+        if (lesson.kind !== TheoryLessonKind.VIDEO) {
+          return { ...lesson, youtubeId: null, videoCandidates: null };
+        }
         const query = lesson.ytQuery ?? `${dto.topic} ${course.title}`;
-        const candidate = await this.youtube.findBestVideo(query, schoolYearLabel);
-        return { ...lesson, youtubeId: candidate?.youtubeId ?? null };
+        const candidates = await this.youtube.findCandidates(query, schoolYearLabel, { limit: 5 });
+        return {
+          ...lesson,
+          youtubeId: candidates[0]?.youtubeId ?? null,
+          videoCandidates: candidates.length > 0 ? candidates : null,
+        };
       }),
     );
 
@@ -92,13 +101,20 @@ export class TheoryService {
         title: payload.title,
         summary: payload.summary,
         lessons: {
-          create: lessonsWithVideo.map((lesson, idx) => ({
-            order: idx,
-            kind: lesson.kind,
-            heading: lesson.heading,
-            body: lesson.kind === TheoryLessonKind.VIDEO ? null : (lesson.body ?? ''),
-            youtubeId: lesson.kind === TheoryLessonKind.VIDEO ? lesson.youtubeId : null,
-          })),
+          create: lessonsWithVideo.map((lesson, idx) => {
+            const isVideo = lesson.kind === TheoryLessonKind.VIDEO;
+            return {
+              order: idx,
+              kind: lesson.kind,
+              heading: lesson.heading,
+              body: isVideo ? null : (lesson.body ?? ''),
+              youtubeId: isVideo ? lesson.youtubeId : null,
+              videoCandidates:
+                isVideo && lesson.videoCandidates
+                  ? (lesson.videoCandidates as unknown as Prisma.InputJsonValue)
+                  : Prisma.DbNull,
+            };
+          }),
         },
       },
       include: { lessons: { orderBy: { order: 'asc' } } },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,11 +14,14 @@
     "@vkbacademy/shared": "workspace:*",
     "axios": "^1.7.9",
     "jspdf": "^4.2.0",
+    "katex": "^0.16.45",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.28.0",
+    "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "zustand": "^5.0.2"
   },
   "devDependencies": {

--- a/apps/web/src/pages/TheoryModulePage.tsx
+++ b/apps/web/src/pages/TheoryModulePage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import ReactMarkdown from 'react-markdown';
@@ -6,7 +7,7 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
 import { theoryApi } from '../api/theory.api';
-import type { TheoryLesson, TheoryLessonKind } from '@vkbacademy/shared';
+import type { TheoryLesson, TheoryLessonKind, TheoryVideoCandidate } from '@vkbacademy/shared';
 
 const KIND_ICON: Record<TheoryLessonKind, string> = {
   INTRO: '🧭',
@@ -95,19 +96,7 @@ function LessonSection({ lesson }: { lesson: TheoryLesson }) {
       </h2>
 
       {lesson.kind === 'VIDEO' ? (
-        lesson.youtubeId ? (
-          <div style={s.videoWrapper}>
-            <iframe
-              style={s.videoIframe}
-              src={`https://www.youtube.com/embed/${lesson.youtubeId}`}
-              title={lesson.heading}
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowFullScreen
-            />
-          </div>
-        ) : (
-          <p style={s.muted}>No se encontró un vídeo adecuado para este tema.</p>
-        )
+        <VideoLesson lesson={lesson} />
       ) : (
         <div style={s.markdown}>
           <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
@@ -117,6 +106,86 @@ function LessonSection({ lesson }: { lesson: TheoryLesson }) {
       )}
     </section>
   );
+}
+
+function VideoLesson({ lesson }: { lesson: TheoryLesson }) {
+  // Compat: si la lección es de antes de añadir candidates, solo tiene youtubeId.
+  const candidates: TheoryVideoCandidate[] =
+    lesson.videoCandidates && lesson.videoCandidates.length > 0
+      ? lesson.videoCandidates
+      : lesson.youtubeId
+        ? [
+            {
+              youtubeId: lesson.youtubeId,
+              title: lesson.heading,
+              channelTitle: '',
+              durationSeconds: 0,
+              thumbnailUrl: `https://img.youtube.com/vi/${lesson.youtubeId}/mqdefault.jpg`,
+            },
+          ]
+        : [];
+
+  const [selected, setSelected] = useState(0);
+
+  if (candidates.length === 0) {
+    return <p style={s.muted}>No se encontró un vídeo adecuado para este tema.</p>;
+  }
+
+  const current = candidates[Math.min(selected, candidates.length - 1)];
+
+  return (
+    <div style={s.videoBlock}>
+      <div style={s.videoWrapper}>
+        <iframe
+          key={current.youtubeId}
+          style={s.videoIframe}
+          src={`https://www.youtube.com/embed/${current.youtubeId}`}
+          title={current.title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+
+      {candidates.length > 1 && (
+        <>
+          <p style={s.candidatesLabel}>{candidates.length} vídeos sugeridos — pulsa para cambiar</p>
+          <ul style={s.candidatesList}>
+            {candidates.map((c, idx) => {
+              const isActive = idx === selected;
+              return (
+                <li key={c.youtubeId}>
+                  <button
+                    type="button"
+                    onClick={() => setSelected(idx)}
+                    style={{
+                      ...s.candidate,
+                      ...(isActive ? s.candidateActive : {}),
+                    }}
+                    aria-pressed={isActive}
+                  >
+                    <img src={c.thumbnailUrl} alt="" style={s.candidateThumb} loading="lazy" />
+                    <span style={s.candidateMeta}>
+                      <span style={s.candidateTitle}>{c.title}</span>
+                      <span style={s.candidateChannel}>
+                        {c.channelTitle}
+                        {c.durationSeconds > 0 && ` · ${formatDuration(c.durationSeconds)}`}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
 const s: Record<string, React.CSSProperties> = {
@@ -176,6 +245,59 @@ const s: Record<string, React.CSSProperties> = {
     border: 0,
   },
   muted: { color: 'var(--color-text-muted)', fontSize: '0.95rem', margin: 0 },
+  videoBlock: { display: 'flex', flexDirection: 'column', gap: 12 },
+  candidatesLabel: {
+    fontSize: '0.8rem',
+    color: 'var(--color-text-muted)',
+    margin: '4px 0 0',
+  },
+  candidatesList: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+    gap: 10,
+  },
+  candidate: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+    padding: 8,
+    background: 'var(--color-bg)',
+    border: '1.5px solid var(--color-border)',
+    borderRadius: 10,
+    cursor: 'pointer',
+    textAlign: 'left',
+    width: '100%',
+    color: 'var(--color-text)',
+    transition: 'border-color 0.15s, transform 0.15s',
+  },
+  candidateActive: {
+    borderColor: '#f97316',
+    background: 'rgba(234,88,12,0.08)',
+  },
+  candidateThumb: {
+    width: '100%',
+    aspectRatio: '16 / 9',
+    objectFit: 'cover',
+    borderRadius: 6,
+    background: '#000',
+  },
+  candidateMeta: { display: 'flex', flexDirection: 'column', gap: 2 },
+  candidateTitle: {
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    lineHeight: 1.3,
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  },
+  candidateChannel: {
+    fontSize: '0.7rem',
+    color: 'var(--color-text-muted)',
+  },
   footer: { display: 'flex', justifyContent: 'flex-end' },
   deleteBtn: {
     background: 'transparent',

--- a/apps/web/src/pages/TheoryModulePage.tsx
+++ b/apps/web/src/pages/TheoryModulePage.tsx
@@ -2,6 +2,9 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import 'katex/dist/katex.min.css';
 import { theoryApi } from '../api/theory.api';
 import type { TheoryLesson, TheoryLessonKind } from '@vkbacademy/shared';
 
@@ -107,7 +110,9 @@ function LessonSection({ lesson }: { lesson: TheoryLesson }) {
         )
       ) : (
         <div style={s.markdown}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{lesson.body ?? ''}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
+            {lesson.body ?? ''}
+          </ReactMarkdown>
         </div>
       )}
     </section>

--- a/packages/shared/src/types/theory.types.ts
+++ b/packages/shared/src/types/theory.types.ts
@@ -3,6 +3,20 @@
 
 export type TheoryLessonKind = 'INTRO' | 'CONTENT' | 'EXAMPLE' | 'VIDEO';
 
+export interface TheoryVideoCandidate {
+  youtubeId: string;
+  title: string;
+  channelTitle: string;
+  channelId?: string;
+  durationSeconds: number;
+  viewCount?: number;
+  likeCount?: number;
+  engagementRatio?: number;
+  isWhitelisted?: boolean;
+  publishedAt?: string;
+  thumbnailUrl: string;
+}
+
 export interface TheoryLesson {
   id: string;
   moduleId: string;
@@ -11,6 +25,7 @@ export interface TheoryLesson {
   heading: string;
   body: string | null;
   youtubeId: string | null;
+  videoCandidates: TheoryVideoCandidate[] | null;
 }
 
 export interface TheoryModuleSummary {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       jspdf:
         specifier: ^4.2.0
         version: 4.2.0
+      katex:
+        specifier: ^0.16.45
+        version: 0.16.45
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -229,9 +232,15 @@ importers:
       react-router-dom:
         specifier: ^6.28.0
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rehype-katex:
+        specifier: ^7.0.1
+        version: 7.0.1
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-math:
+        specifier: ^6.0.0
+        version: 6.0.0
       zustand:
         specifier: ^5.0.2
         version: 5.0.11(@types/react@18.3.28)(react@18.3.1)
@@ -2654,6 +2663,9 @@ packages:
   '@types/jsonwebtoken@9.0.5':
     resolution: {integrity: sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -3465,6 +3477,10 @@ packages:
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
@@ -4450,11 +4466,35 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   helmet@8.1.0:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
@@ -5114,6 +5154,10 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
+
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -5358,6 +5402,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
@@ -5495,6 +5542,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -5908,6 +5958,9 @@ packages:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
     engines: {node: '>=10'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -6312,8 +6365,14 @@ packages:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
 
+  rehype-katex@7.0.1:
+    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -7225,11 +7284,17 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -7318,6 +7383,9 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -7428,6 +7496,9 @@ packages:
 
   web-encoding@1.1.5:
     resolution: {integrity: sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -11294,6 +11365,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
 
+  '@types/katex@0.16.8': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -12228,6 +12301,8 @@ snapshots:
   commander@4.1.1: {}
 
   commander@7.2.0: {}
+
+  commander@8.3.0: {}
 
   commander@9.5.0: {}
 
@@ -13407,6 +13482,47 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -13427,9 +13543,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   helmet@8.1.0: {}
 
@@ -14380,6 +14511,10 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
+
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
@@ -14643,6 +14778,18 @@ snapshots:
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -14995,6 +15142,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.45
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -15442,6 +15599,10 @@ snapshots:
   parse-png@2.1.0:
     dependencies:
       pngjs: 3.4.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.0:
     dependencies:
@@ -15902,6 +16063,16 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  rehype-katex@7.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/katex': 0.16.8
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      katex: 0.16.45
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -15909,6 +16080,15 @@ snapshots:
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -16873,6 +17053,11 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -16880,6 +17065,11 @@ snapshots:
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -16961,6 +17151,11 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -17039,6 +17234,8 @@ snapshots:
       util: 0.12.5
     optionalDependencies:
       '@zxing/text-encoding': 0.9.0
+
+  web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
Follow-up to #25.

## Summary
- **Math rendering (KaTeX)**: theory lessons frequently include formulas (e.g. \`\$\log_a b = c\$\`), but the previous markdown setup only handled CommonMark + GFM, leaving raw \`\$...\$\` visible. Wires up \`remark-math\` + \`rehype-katex\` so inline \`\$...\$\` and block \`\$\$...\$\$\` render properly. Tightens the AI prompt so theory lessons always emit formulas in LaTeX.
- **5 YouTube candidates per VIDEO lesson**: instead of returning the single best-ranked video, the service now stores the top 5 (via \`YoutubeService.findCandidates\` with \`limit: 5\`) so the student can switch between them. The first is the default embed and is also persisted in \`youtubeId\` for backward compat with rows already in PRE.
- New \`videoCandidates Json?\` column on \`TheoryLesson\` (+ migration). Frontend renders a thumbnail picker below the embed; clicking swaps the iframe.

## Test plan
- [ ] CI green
- [ ] PRE: regenerate a math-heavy temario (logaritmos, ecuaciones, derivadas) and verify formulas render typeset
- [ ] PRE: open a newly generated temario, verify 5 thumbnail candidates appear under the video, click each to confirm the iframe swaps
- [ ] PRE: open a temario from before the migration — single video still embeds (legacy fallback)
- [ ] Verify migration runs cleanly in the \`migrate-pre\` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)