### PR TITLE
feat(theory): didactic callouts, entry animations, and "Nuevo temario" shortcut

### DIFF
--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -233,6 +233,12 @@ Reglas:
 - VIDEO: campo "ytQuery" obligatorio. NO incluir "body".
 - El markdown puede usar **negritas**, *cursivas*, listas con guiones, encabezados con ##.
 - Para fórmulas matemáticas USA SIEMPRE LaTeX: inline con $...$ (ej. $\\log_a b = c$) y bloques con $$...$$ para derivaciones o ecuaciones destacadas. NO escribas fórmulas en texto plano (NUNCA "log_a b = c"; SIEMPRE "$\\log_a b = c$").
+- **DIDÁCTICA — incluye callouts pedagógicos** intercalados en el body para hacer la lectura más activa. Formato OBLIGATORIO con blockquote markdown, emoji al inicio, etiqueta en negrita:
+  - \`> 💡 **Tip:** consejo práctico que ayude a recordar o aplicar el concepto.\`
+  - \`> 🧠 **Recuerda:** dato/fórmula/regla clave que el alumno debe memorizar.\`
+  - \`> ⚠️ **Cuidado:** error común a evitar o trampa habitual del tema.\`
+  - \`> ❓ **Pregunta:** pregunta retórica para que el alumno se pare a pensar antes de seguir.\`
+  Mete entre 2 y 4 callouts en CADA lección INTRO/CONTENT/EXAMPLE, mezclando tipos. Cada callout en su propio párrafo (separado por línea en blanco). NO los pongas todos juntos al final — repártelos donde encajen pedagógicamente.
 - Contenido curricular real y riguroso, adaptado al nivel ${schoolYearLabel || 'del curso'}.
 - "ytQuery" debe ser una búsqueda específica y descriptiva (ej. "demostración propiedades logaritmos bachillerato").
 - Solo devuelve JSON puro, sin markdown alrededor del JSON.`;

--- a/apps/web/src/pages/TheoryModulePage.tsx
+++ b/apps/web/src/pages/TheoryModulePage.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
@@ -56,6 +56,7 @@ export default function TheoryModulePage() {
 
   return (
     <div style={s.page}>
+      <style>{ANIMATIONS}</style>
       <Link to="/theory" style={s.backLink}>
         ← Volver a Teoría
       </Link>
@@ -67,8 +68,8 @@ export default function TheoryModulePage() {
       </header>
 
       <article style={s.article}>
-        {data.lessons.map((lesson) => (
-          <LessonSection key={lesson.id} lesson={lesson} />
+        {data.lessons.map((lesson, idx) => (
+          <LessonSection key={lesson.id} lesson={lesson} index={idx} />
         ))}
       </article>
 
@@ -88,9 +89,15 @@ export default function TheoryModulePage() {
   );
 }
 
-function LessonSection({ lesson }: { lesson: TheoryLesson }) {
+function LessonSection({ lesson, index }: { lesson: TheoryLesson; index: number }) {
   return (
-    <section style={s.section}>
+    <section
+      className="theory-section"
+      style={{
+        ...s.section,
+        animationDelay: `${index * 90}ms`,
+      }}
+    >
       <h2 style={s.sectionTitle}>
         <span aria-hidden>{KIND_ICON[lesson.kind]}</span> {lesson.heading}
       </h2>
@@ -99,7 +106,11 @@ function LessonSection({ lesson }: { lesson: TheoryLesson }) {
         <VideoLesson lesson={lesson} />
       ) : (
         <div style={s.markdown}>
-          <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkMath]}
+            rehypePlugins={[rehypeKatex]}
+            components={MARKDOWN_COMPONENTS}
+          >
             {lesson.body ?? ''}
           </ReactMarkdown>
         </div>
@@ -107,6 +118,94 @@ function LessonSection({ lesson }: { lesson: TheoryLesson }) {
     </section>
   );
 }
+
+// ── Callouts didácticos ──────────────────────────────────────────────
+// La IA emite tips/recuerda/cuidado/pregunta como blockquotes de markdown
+// con un emoji al inicio. Detectamos el emoji para estilar el bloque.
+
+type CalloutKind = 'tip' | 'remember' | 'warning' | 'question' | 'default';
+
+const CALLOUT_RULES: Array<{ test: RegExp; kind: CalloutKind; icon: string; label: string }> = [
+  { test: /^\s*💡/, kind: 'tip', icon: '💡', label: 'Tip' },
+  { test: /^\s*🧠/, kind: 'remember', icon: '🧠', label: 'Recuerda' },
+  { test: /^\s*⚠️|^\s*⚠/, kind: 'warning', icon: '⚠️', label: 'Cuidado' },
+  { test: /^\s*❓/, kind: 'question', icon: '❓', label: 'Pregunta' },
+];
+
+function flattenText(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(flattenText).join('');
+  if (typeof node === 'object' && 'props' in node) {
+    return flattenText((node as { props: { children?: ReactNode } }).props.children);
+  }
+  return '';
+}
+
+function detectCalloutKind(text: string): CalloutKind {
+  for (const rule of CALLOUT_RULES) {
+    if (rule.test.test(text)) return rule.kind;
+  }
+  return 'default';
+}
+
+const MARKDOWN_COMPONENTS: Components = {
+  blockquote: ({ children }) => {
+    const kind = detectCalloutKind(flattenText(children));
+    return <aside className={`theory-callout theory-callout-${kind}`}>{children}</aside>;
+  },
+};
+
+const ANIMATIONS = `
+  @keyframes theory-fade-in-up {
+    from { opacity: 0; transform: translateY(16px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes theory-callout-pop {
+    0%   { opacity: 0; transform: scale(0.96); }
+    60%  { opacity: 1; transform: scale(1.01); }
+    100% { transform: scale(1); }
+  }
+  .theory-section {
+    animation: theory-fade-in-up 0.55s cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
+  }
+  .theory-callout {
+    margin: 1.1rem 0;
+    padding: 14px 16px 14px 52px;
+    border-radius: 12px;
+    border-left: 4px solid;
+    position: relative;
+    line-height: 1.55;
+    animation: theory-callout-pop 0.45s ease-out backwards;
+  }
+  .theory-callout > p:first-child { margin-top: 0; }
+  .theory-callout > p:last-child  { margin-bottom: 0; }
+  .theory-callout::before {
+    position: absolute;
+    left: 14px;
+    top: 12px;
+    font-size: 1.4rem;
+    line-height: 1;
+  }
+  .theory-callout-tip       { background: rgba(234,179,8,0.10);  border-left-color: #eab308; }
+  .theory-callout-tip::before       { content: '💡'; }
+  .theory-callout-remember  { background: rgba(99,102,241,0.10); border-left-color: #6366f1; }
+  .theory-callout-remember::before  { content: '🧠'; }
+  .theory-callout-warning   { background: rgba(220,38,38,0.10);  border-left-color: #dc2626; }
+  .theory-callout-warning::before   { content: '⚠️'; }
+  .theory-callout-question  { background: rgba(20,184,166,0.10); border-left-color: #14b8a6; }
+  .theory-callout-question::before  { content: '❓'; }
+  .theory-callout-default   {
+    background: var(--color-bg);
+    border-left-color: var(--color-border);
+    padding-left: 16px;
+  }
+  .theory-callout-default::before { content: ''; }
+  @media (prefers-reduced-motion: reduce) {
+    .theory-section,
+    .theory-callout { animation: none; }
+  }
+`;
 
 function VideoLesson({ lesson }: { lesson: TheoryLesson }) {
   // Compat: si la lección es de antes de añadir candidates, solo tiene youtubeId.

--- a/apps/web/src/pages/TheoryModulePage.tsx
+++ b/apps/web/src/pages/TheoryModulePage.tsx
@@ -76,6 +76,14 @@ export default function TheoryModulePage() {
       <footer style={s.footer}>
         <button
           type="button"
+          onClick={() => navigate('/theory')}
+          className="btn btn-primary"
+          style={s.newBtn}
+        >
+          ✨ Nuevo temario
+        </button>
+        <button
+          type="button"
           onClick={() => {
             if (window.confirm('¿Borrar este temario de tu biblioteca?')) remove.mutate();
           }}
@@ -397,7 +405,12 @@ const s: Record<string, React.CSSProperties> = {
     fontSize: '0.7rem',
     color: 'var(--color-text-muted)',
   },
-  footer: { display: 'flex', justifyContent: 'flex-end' },
+  footer: { display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' },
+  newBtn: {
+    padding: '10px 18px',
+    fontSize: '0.875rem',
+    fontWeight: 600,
+  },
   deleteBtn: {
     background: 'transparent',
     border: '1px solid rgba(220,38,38,0.4)',


### PR DESCRIPTION
Builds on #25 / #26. Supersedes #27 (closed in favor of this single PR).

## Summary
Theory modules used to feel like walls of text. This PR makes them visually richer and adds a quick path back to the request form:

- **Didactic callouts**: the AI prompt now scatters 2-4 pedagogical asides per INTRO/CONTENT/EXAMPLE lesson using markdown blockquotes prefixed with an emoji + bold label:
  - \`> 💡 **Tip:** ...\`
  - \`> 🧠 **Recuerda:** ...\`
  - \`> ⚠️ **Cuidado:** ...\`
  - \`> ❓ **Pregunta:** ...\`
- **Render**: overrides the ReactMarkdown \`blockquote\` component to detect the leading emoji and render the block as a styled \`<aside>\` with a colored left border, soft tinted background, and large icon.
- **Animations**: each lesson section fades in from below with a per-section stagger (~90ms); each callout pops in. Honors \`prefers-reduced-motion\`.
- **\"Nuevo temario\" shortcut**: primary CTA on the footer next to the existing delete action; navigates back to \`/theory\` so the student can request another temario without going through the sidebar.

No schema changes — content stays as plain markdown, so older temarios still render fine and just gain the new look wherever the AI happened to use blockquotes.

## Test plan
- [ ] CI green
- [ ] PRE: regenerate a temario, verify Tip/Recuerda/Cuidado/Pregunta show as styled boxes with the right color and icon
- [ ] Verify sections fade in on first load (stagger visible)
- [ ] Click \"✨ Nuevo temario\" — form page loads
- [ ] Open an old temario — should still render fine, callouts unstyled unless body had emoji-prefixed blockquotes
- [ ] OS \`prefers-reduced-motion: reduce\` → animations disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)