### PR TITLE
feat(tutors): tutor-managed enrollments + clean student UI

### DIFF
--- a/apps/api/src/tutors/tutors.controller.ts
+++ b/apps/api/src/tutors/tutors.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { IsString } from 'class-validator';
 import { Role } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -6,6 +7,11 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { TutorsService } from './tutors.service';
 import { User } from '@prisma/client';
+
+class EnrollDto {
+  @IsString()
+  courseId!: string;
+}
 
 @Controller('tutors')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -20,10 +26,7 @@ export class TutorsController {
 
   @Get('my-students/:studentId/courses')
   @Roles(Role.TUTOR, Role.ADMIN)
-  getStudentCourses(
-    @Param('studentId') studentId: string,
-    @CurrentUser() user: User,
-  ) {
+  getStudentCourses(@Param('studentId') studentId: string, @CurrentUser() user: User) {
     return this.tutorsService.getStudentCourses(user.id, studentId);
   }
 
@@ -41,5 +44,31 @@ export class TutorsController {
       from ? new Date(from) : undefined,
       to ? new Date(to) : undefined,
     );
+  }
+
+  @Get('my-students/:studentId/available-courses')
+  @Roles(Role.TUTOR, Role.ADMIN)
+  getAvailableCourses(@Param('studentId') studentId: string, @CurrentUser() user: User) {
+    return this.tutorsService.getAvailableCoursesForStudent(user.id, studentId);
+  }
+
+  @Post('my-students/:studentId/enrollments')
+  @Roles(Role.TUTOR, Role.ADMIN)
+  enroll(
+    @Param('studentId') studentId: string,
+    @Body() body: EnrollDto,
+    @CurrentUser() user: User,
+  ) {
+    return this.tutorsService.enrollStudent(user.id, studentId, body.courseId);
+  }
+
+  @Delete('my-students/:studentId/enrollments/:courseId')
+  @Roles(Role.TUTOR, Role.ADMIN)
+  unenroll(
+    @Param('studentId') studentId: string,
+    @Param('courseId') courseId: string,
+    @CurrentUser() user: User,
+  ) {
+    return this.tutorsService.unenrollStudent(user.id, studentId, courseId);
   }
 }

--- a/apps/api/src/tutors/tutors.service.ts
+++ b/apps/api/src/tutors/tutors.service.ts
@@ -1,9 +1,24 @@
-import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Injectable, ForbiddenException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class TutorsService {
   constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Verifica que el alumno pertenece al tutor y devuelve sus campos básicos.
+   * Lanza ForbiddenException si no existe o no es del tutor.
+   */
+  private async getStudentForTutor(tutorId: string, studentId: string) {
+    const student = await this.prisma.user.findUnique({
+      where: { id: studentId },
+      select: { id: true, tutorId: true, schoolYearId: true },
+    });
+    if (!student || student.tutorId !== tutorId) {
+      throw new ForbiddenException('No tienes acceso a este alumno');
+    }
+    return student;
+  }
 
   /** Devuelve la lista de alumnos asignados a un tutor */
   async getMyStudents(tutorId: string) {
@@ -38,7 +53,11 @@ export class TutorsService {
       where: { userId: studentId },
       select: {
         course: {
-          select: { id: true, title: true, schoolYear: { select: { id: true, name: true, label: true } } },
+          select: {
+            id: true,
+            title: true,
+            schoolYear: { select: { id: true, name: true, label: true } },
+          },
         },
       },
       orderBy: { createdAt: 'asc' },
@@ -52,12 +71,7 @@ export class TutorsService {
    * `from` y `to` filtran el período de las métricas de actividad.
    * Los datos de gamificación (puntos, racha) son siempre all-time.
    */
-  async getStudentStats(
-    tutorId: string,
-    studentId: string,
-    from?: Date,
-    to?: Date,
-  ) {
+  async getStudentStats(tutorId: string, studentId: string, from?: Date, to?: Date) {
     // 1. Verificar que el alumno pertenece al tutor
     const student = await this.prisma.user.findUnique({
       where: { id: studentId },
@@ -299,5 +313,87 @@ export class TutorsService {
       courses,
       activity,
     };
+  }
+
+  // ─── Matrículas gestionadas por el tutor ───────────────────────────────────
+
+  /**
+   * Cursos disponibles para matricular a un alumno: publicados y del mismo
+   * nivel (schoolYearId) que el alumno. Cada item incluye `enrolled`.
+   */
+  async getAvailableCoursesForStudent(tutorId: string, studentId: string) {
+    const student = await this.getStudentForTutor(tutorId, studentId);
+
+    if (!student.schoolYearId) {
+      return [];
+    }
+
+    const [courses, enrollments] = await Promise.all([
+      this.prisma.course.findMany({
+        where: { published: true, schoolYearId: student.schoolYearId },
+        select: {
+          id: true,
+          title: true,
+          subject: true,
+          coverUrl: true,
+          schoolYear: { select: { id: true, name: true, label: true } },
+        },
+        orderBy: [{ subject: 'asc' }, { title: 'asc' }],
+      }),
+      this.prisma.enrollment.findMany({
+        where: { userId: studentId },
+        select: { courseId: true },
+      }),
+    ]);
+
+    const enrolledIds = new Set(enrollments.map((e) => e.courseId));
+
+    return courses.map((c) => ({ ...c, enrolled: enrolledIds.has(c.id) }));
+  }
+
+  /** Matricula al alumno en un curso. Idempotente. Valida nivel coincidente. */
+  async enrollStudent(tutorId: string, studentId: string, courseId: string) {
+    const student = await this.getStudentForTutor(tutorId, studentId);
+
+    if (!student.schoolYearId) {
+      throw new BadRequestException('El alumno no tiene nivel asignado');
+    }
+
+    const course = await this.prisma.course.findUnique({
+      where: { id: courseId },
+      select: { id: true, schoolYearId: true, published: true },
+    });
+    if (!course) {
+      throw new BadRequestException('Curso no encontrado');
+    }
+    if (course.schoolYearId !== student.schoolYearId) {
+      throw new ForbiddenException('El curso no corresponde al nivel del alumno');
+    }
+
+    return this.prisma.enrollment.upsert({
+      where: { userId_courseId: { userId: studentId, courseId } },
+      update: {},
+      create: { userId: studentId, courseId },
+      include: {
+        course: {
+          select: {
+            id: true,
+            title: true,
+            subject: true,
+            coverUrl: true,
+            schoolYear: { select: { id: true, name: true, label: true } },
+          },
+        },
+      },
+    });
+  }
+
+  /** Desmatricula al alumno de un curso. Idempotente. */
+  async unenrollStudent(tutorId: string, studentId: string, courseId: string) {
+    await this.getStudentForTutor(tutorId, studentId);
+    await this.prisma.enrollment.deleteMany({
+      where: { userId: studentId, courseId },
+    });
+    return { message: 'Matrícula eliminada' };
   }
 }

--- a/apps/web/src/api/tutors.api.ts
+++ b/apps/web/src/api/tutors.api.ts
@@ -78,9 +78,17 @@ export interface StudentStats {
   activity: ActivityDay[];
 }
 
+export interface AvailableCourse {
+  id: string;
+  title: string;
+  subject: string | null;
+  coverUrl: string | null;
+  schoolYear: { id: string; name: string; label: string } | null;
+  enrolled: boolean;
+}
+
 export const tutorsApi = {
-  getMyStudents: () =>
-    api.get<StudentSummary[]>('/tutors/my-students').then((r) => r.data),
+  getMyStudents: () => api.get<StudentSummary[]>('/tutors/my-students').then((r) => r.data),
 
   getStudentCourses: (studentId: string) =>
     api.get<EnrolledCourse[]>(`/tutors/my-students/${studentId}/courses`).then((r) => r.data),
@@ -91,4 +99,15 @@ export const tutorsApi = {
         params: { ...(from ? { from } : {}), ...(to ? { to } : {}) },
       })
       .then((r) => r.data),
+
+  getAvailableCourses: (studentId: string) =>
+    api
+      .get<AvailableCourse[]>(`/tutors/my-students/${studentId}/available-courses`)
+      .then((r) => r.data),
+
+  enroll: (studentId: string, courseId: string) =>
+    api.post(`/tutors/my-students/${studentId}/enrollments`, { courseId }).then((r) => r.data),
+
+  unenroll: (studentId: string, courseId: string) =>
+    api.delete(`/tutors/my-students/${studentId}/enrollments/${courseId}`).then((r) => r.data),
 };

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -62,7 +62,6 @@ function buildNavLinks(role: Role | undefined): NavLink[] {
   // STUDENT por defecto
   return [
     ...base,
-    { to: '/courses', label: '📚 Cursos' },
     { to: '/bookings', label: '📅 Clases Particulares' },
     { to: '/exercises', label: '🧮 Ejercicios' },
     { to: '/theory', label: '📖 Teoría' },

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,9 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../store/auth.store';
 import { Role } from '@vkbacademy/shared';
-import { useRecentLessons } from '../hooks/useCourses';
 import { useChallengeSummary } from '../hooks/useChallenges';
-import { LessonType } from '@vkbacademy/shared';
 
 const ROLE_LABELS: Record<string, string> = {
   [Role.STUDENT]: 'Estudiante',
@@ -12,7 +10,7 @@ const ROLE_LABELS: Record<string, string> = {
 };
 
 const ROLE_DESCRIPTION: Record<string, string> = {
-  [Role.STUDENT]: 'Accede a tus cursos, completa tests y reserva clases con los profesores.',
+  [Role.STUDENT]: 'Practica con teoría y ejercicios bajo demanda, y reserva clases particulares.',
   [Role.TEACHER]: 'Gestiona tus cursos, sube contenido y consulta las reservas de tus alumnos.',
   [Role.ADMIN]: 'Administra usuarios, cursos y visualiza las métricas globales de la plataforma.',
 };
@@ -21,7 +19,6 @@ export default function DashboardPage() {
   const user = useAuthStore((s) => s.user);
   const navigate = useNavigate();
   const isStudent = user?.role === Role.STUDENT;
-  const { data: recentLessons = [] } = useRecentLessons();
   const { data: summary } = useChallengeSummary();
 
   if (!user) return null;
@@ -29,8 +26,19 @@ export default function DashboardPage() {
   const quickActions =
     user.role === Role.STUDENT
       ? [
-          { emoji: '📚', label: 'Mis cursos', desc: 'Continúa donde lo dejaste', to: '/courses' },
-          { emoji: '📅', label: 'Reservar clase', desc: 'Elige horario con un profesor', to: '/bookings' },
+          { emoji: '📖', label: 'Teoría', desc: 'Genera un temario a tu medida', to: '/theory' },
+          {
+            emoji: '🧮',
+            label: 'Ejercicios',
+            desc: 'Practica con ejercicios al instante',
+            to: '/exercises',
+          },
+          {
+            emoji: '📅',
+            label: 'Reservar clase',
+            desc: 'Elige horario con un profesor',
+            to: '/bookings',
+          },
         ]
       : user.role === Role.TEACHER
         ? [
@@ -56,15 +64,14 @@ export default function DashboardPage() {
       <div className="page-hero animate-in">
         <div style={S.heroInner}>
           {/* Avatar */}
-          <div style={S.avatar}>
-            {user.name.charAt(0).toUpperCase()}
-          </div>
+          <div style={S.avatar}>{user.name.charAt(0).toUpperCase()}</div>
           <div style={S.heroText}>
-            <h1 className="hero-title">
-              ¡Hola, {user.name.split(' ')[0]}! 👋
-            </h1>
+            <h1 className="hero-title">¡Hola, {user.name.split(' ')[0]}! 👋</h1>
             <p className="hero-subtitle" style={{ marginTop: 6 }}>
-              <span className={`role-badge ${user.role}`} style={{ marginRight: 8, verticalAlign: 'middle' }}>
+              <span
+                className={`role-badge ${user.role}`}
+                style={{ marginRight: 8, verticalAlign: 'middle' }}
+              >
                 {ROLE_LABELS[user.role]}
               </span>
               {ROLE_DESCRIPTION[user.role]}
@@ -86,11 +93,6 @@ export default function DashboardPage() {
             <p style={S.statValue}>{summary?.currentStreak ?? '—'}</p>
             <p style={S.statLabel}>Racha (semanas)</p>
           </div>
-          <div className="stat-card" style={S.statCardInner}>
-            <span style={S.statEmoji}>✅</span>
-            <p style={S.statValue}>{summary?.completedCount ?? '—'}</p>
-            <p style={S.statLabel}>Lecciones completadas</p>
-          </div>
         </div>
       )}
 
@@ -99,12 +101,7 @@ export default function DashboardPage() {
         <h2 style={S.sectionTitle}>Accesos rápidos</h2>
         <div style={S.grid}>
           {quickActions.map(({ emoji, label, desc, to }) => (
-            <div
-              key={label}
-              className="vkb-card"
-              style={S.quickCard}
-              onClick={() => navigate(to)}
-            >
+            <div key={label} className="vkb-card" style={S.quickCard} onClick={() => navigate(to)}>
               <span style={S.cardEmoji}>{emoji}</span>
               <p style={S.cardLabel}>{label}</p>
               <p style={S.cardDesc}>{desc}</p>
@@ -128,75 +125,29 @@ export default function DashboardPage() {
     </>
   );
 
-  return (
-    <div style={isStudent ? S.layout : S.page}>
-      <div style={isStudent ? S.main : undefined}>
-        {mainContent}
-      </div>
-
-      {/* Sidebar de lecciones recientes — solo para STUDENT */}
-      {isStudent && (
-        <aside style={S.sidebar}>
-          <h2 style={S.sectionTitle}>Últimas lecciones</h2>
-          {recentLessons.length === 0 ? (
-            <p style={S.emptyMsg}>Aún no has completado ninguna lección.</p>
-          ) : (
-            <div style={S.recentList}>
-              {recentLessons.map((item) => (
-                <div
-                  key={item.lessonId}
-                  className="vkb-card"
-                  style={S.recentCard}
-                  onClick={() => navigate(`/courses/${item.courseId}`)}
-                >
-                  <span style={S.recentTypeIcon}>
-                    {item.lessonType === LessonType.VIDEO ? '🎬' : item.lessonType === LessonType.QUIZ ? '📝' : '💪'}
-                  </span>
-                  <div style={S.recentInfo}>
-                    <p style={S.recentTitle}>{item.lessonTitle}</p>
-                    <p style={S.recentMeta}>{item.courseTitle}</p>
-                    {item.completedAt && (
-                      <p style={S.recentDate}>
-                        {new Date(item.completedAt).toLocaleDateString('es-ES', {
-                          day: 'numeric', month: 'short',
-                        })}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </aside>
-      )}
-    </div>
-  );
+  return <div style={S.page}>{mainContent}</div>;
 }
 
 function Row({ label, value }: { label: string; value: string }) {
   return (
-    <div style={{
-      display: 'flex',
-      justifyContent: 'space-between',
-      padding: '14px 0',
-      borderBottom: '1px solid var(--color-border)',
-    }}>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '14px 0',
+        borderBottom: '1px solid var(--color-border)',
+      }}
+    >
       <span style={{ color: 'var(--color-text-muted)', fontSize: '0.875rem' }}>{label}</span>
-      <span style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--color-text)' }}>{value}</span>
+      <span style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--color-text)' }}>
+        {value}
+      </span>
     </div>
   );
 }
 
 const S: Record<string, React.CSSProperties> = {
-  // Layout de dos columnas (student) vs columna única (otros roles)
-  layout: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 280px',
-    gap: 32,
-    alignItems: 'start',
-  },
   page: { display: 'flex', flexDirection: 'column', gap: 32, maxWidth: 820 },
-  main: { display: 'flex', flexDirection: 'column', gap: 32 },
 
   // Hero interior
   heroInner: {
@@ -235,7 +186,7 @@ const S: Record<string, React.CSSProperties> = {
   // Stats grid
   statsGrid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(3, 1fr)',
+    gridTemplateColumns: 'repeat(2, 1fr)',
     gap: 16,
   },
   statCardInner: {
@@ -288,48 +239,4 @@ const S: Record<string, React.CSSProperties> = {
   cardEmoji: { fontSize: '2.5rem', lineHeight: 1, marginBottom: 4 },
   cardLabel: { fontWeight: 700, fontSize: '0.9375rem', color: 'var(--color-text)', margin: 0 },
   cardDesc: { fontSize: '0.8125rem', color: 'var(--color-text-muted)', margin: 0 },
-
-  // Sidebar
-  sidebar: { display: 'flex', flexDirection: 'column', gap: 0 },
-  recentList: { display: 'flex', flexDirection: 'column', gap: 10 },
-  recentCard: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    gap: 12,
-    padding: '14px 16px',
-    cursor: 'pointer',
-  },
-  recentTypeIcon: { fontSize: 22, flexShrink: 0, marginTop: 1 },
-  recentInfo: { flex: 1, minWidth: 0 },
-  recentTitle: {
-    fontWeight: 600,
-    fontSize: '0.875rem',
-    color: 'var(--color-text)',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    margin: 0,
-  },
-  recentMeta: {
-    fontSize: '0.78rem',
-    color: 'var(--color-text-muted)',
-    marginTop: 2,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    marginBottom: 0,
-  },
-  recentDate: {
-    fontSize: '0.72rem',
-    color: 'var(--color-primary)',
-    marginTop: 4,
-    fontWeight: 700,
-    margin: 0,
-  },
-  emptyMsg: {
-    fontSize: '0.875rem',
-    color: 'var(--color-text-muted)',
-    padding: '16px 0',
-    margin: 0,
-  },
 };

--- a/apps/web/src/pages/TutorStudentsPage.tsx
+++ b/apps/web/src/pages/TutorStudentsPage.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { tutorsApi, type StudentSummary, type StudentStats, type ActivityDay } from '../api/tutors.api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  tutorsApi,
+  type StudentSummary,
+  type StudentStats,
+  type ActivityDay,
+} from '../api/tutors.api';
 
 // ─── Constantes ────────────────────────────────────────────────────────────────
 
@@ -208,7 +213,13 @@ const S: Record<string, React.CSSProperties> = {
     gap: 10,
     marginTop: 6,
   },
-  progressPct: { fontSize: '0.75rem', fontWeight: 700, color: '#475569', minWidth: 32, textAlign: 'right' as const },
+  progressPct: {
+    fontSize: '0.75rem',
+    fontWeight: 700,
+    color: '#475569',
+    minWidth: 32,
+    textAlign: 'right' as const,
+  },
 };
 
 // ─── Mini gráfico de actividad (SVG) ──────────────────────────────────────────
@@ -227,7 +238,10 @@ function ActivityChart({ activity, days }: { activity: ActivityDay[]; days: numb
   }
 
   const actMap = new Map(activity.map((a) => [a.date, a]));
-  const maxVal = Math.max(...dateRange.map((d) => (actMap.get(d)?.lessons ?? 0) + (actMap.get(d)?.quizzes ?? 0)), 1);
+  const maxVal = Math.max(
+    ...dateRange.map((d) => (actMap.get(d)?.lessons ?? 0) + (actMap.get(d)?.quizzes ?? 0)),
+    1,
+  );
 
   const W = 580;
   const H = 80;
@@ -236,10 +250,24 @@ function ActivityChart({ activity, days }: { activity: ActivityDay[]; days: numb
 
   return (
     <div className="vkb-card">
-      <div style={{ fontSize: '0.72rem', fontWeight: 700, color: '#94a3b8', letterSpacing: '0.04em', textTransform: 'uppercase', marginBottom: 12 }}>
+      <div
+        style={{
+          fontSize: '0.72rem',
+          fontWeight: 700,
+          color: '#94a3b8',
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
+          marginBottom: 12,
+        }}
+      >
         Actividad diaria (lecciones + quizzes)
       </div>
-      <svg width="100%" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ display: 'block' }}>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        style={{ display: 'block' }}
+      >
         {dateRange.map((date, i) => {
           const entry = actMap.get(date);
           const lessons = entry?.lessons ?? 0;
@@ -254,7 +282,15 @@ function ActivityChart({ activity, days }: { activity: ActivityDay[]; days: numb
           return (
             <g key={date}>
               {quizH > 0 && (
-                <rect x={x} y={H - barH} width={barW} height={quizH} rx={1} fill="#fbbf24" opacity={0.8} />
+                <rect
+                  x={x}
+                  y={H - barH}
+                  width={barW}
+                  height={quizH}
+                  rx={1}
+                  fill="#fbbf24"
+                  opacity={0.8}
+                />
               )}
               {lessonH > 0 && (
                 <rect x={x} y={H - lessonH} width={barW} height={lessonH} rx={1} fill={ORANGE} />
@@ -263,13 +299,31 @@ function ActivityChart({ activity, days }: { activity: ActivityDay[]; days: numb
           );
         })}
       </svg>
-      <div style={{ display: 'flex', gap: 16, marginTop: 10, fontSize: '0.72rem', color: '#64748b' }}>
+      <div
+        style={{ display: 'flex', gap: 16, marginTop: 10, fontSize: '0.72rem', color: '#64748b' }}
+      >
         <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <span style={{ width: 10, height: 10, borderRadius: 2, background: ORANGE, display: 'inline-block' }} />
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 2,
+              background: ORANGE,
+              display: 'inline-block',
+            }}
+          />
           Lecciones
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <span style={{ width: 10, height: 10, borderRadius: 2, background: '#fbbf24', display: 'inline-block' }} />
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 2,
+              background: '#fbbf24',
+              display: 'inline-block',
+            }}
+          />
           Quizzes
         </span>
       </div>
@@ -298,16 +352,23 @@ function useStudentStats(studentId: string | null, from?: string, to?: string) {
 
 function StudentDetail({ student, periodDays }: { student: StudentSummary; periodDays: number }) {
   const now = new Date();
-  const from = periodDays > 0
-    ? new Date(now.getTime() - periodDays * 86400000).toISOString()
-    : undefined;
+  const from =
+    periodDays > 0 ? new Date(now.getTime() - periodDays * 86400000).toISOString() : undefined;
   const to = periodDays > 0 ? now.toISOString() : undefined;
 
   const { data: stats, isLoading, isError } = useStudentStats(student.id, from, to);
 
   if (isLoading) {
     return (
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 200, color: '#94a3b8' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: 200,
+          color: '#94a3b8',
+        }}
+      >
         Cargando métricas...
       </div>
     );
@@ -315,7 +376,16 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
 
   if (isError) {
     return (
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 200, color: '#dc2626', fontSize: '0.9rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: 200,
+          color: '#dc2626',
+          fontSize: '0.9rem',
+        }}
+      >
         Error al cargar las métricas. Inténtalo de nuevo.
       </div>
     );
@@ -325,7 +395,9 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
 
   const { lessons, quizzes, exams, certificates, sessions } = stats;
   const memberSince = new Date(stats.student.createdAt).toLocaleDateString('es-ES', {
-    day: 'numeric', month: 'long', year: 'numeric',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
   });
 
   return (
@@ -344,9 +416,25 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
             {` · Miembro desde ${memberSince}`}
           </div>
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'flex-end', position: 'relative', zIndex: 1 }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 6,
+            alignItems: 'flex-end',
+            position: 'relative',
+            zIndex: 1,
+          }}
+        >
           <span style={S.streakBadge}>🔥 {stats.student.currentStreak} sem. racha</span>
-          <span style={{ ...S.streakBadge, background: 'rgba(99,102,241,0.2)', borderColor: 'rgba(99,102,241,0.4)', color: '#a5b4fc' }}>
+          <span
+            style={{
+              ...S.streakBadge,
+              background: 'rgba(99,102,241,0.2)',
+              borderColor: 'rgba(99,102,241,0.4)',
+              color: '#a5b4fc',
+            }}
+          >
             🏆 {stats.student.totalPoints} pts
           </span>
         </div>
@@ -354,7 +442,12 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
 
       {/* KPI Grid */}
       <div style={S.kpiGrid}>
-        <KpiCard emoji="📚" value={lessons.completedInPeriod} label="Lecciones" sub={`${lessons.completedAllTime} en total`} />
+        <KpiCard
+          emoji="📚"
+          value={lessons.completedInPeriod}
+          label="Lecciones"
+          sub={`${lessons.completedAllTime} en total`}
+        />
         <KpiCard emoji="📅" value={lessons.activeDays} label="Días activos" sub="en el período" />
         <KpiCard
           emoji="🎯"
@@ -368,10 +461,38 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
           label="Exámenes aprobados"
           sub={`de ${exams.attempts} · media ${exams.avgScore ?? '—'}%`}
         />
-        <KpiCard emoji="📜" value={certificates.total} label="Certificados" sub={certsByTypeSummary(certificates.byType)} />
-        <KpiCard emoji="🏆" value={stats.student.totalPoints} label="Puntos totales" sub={`Racha más larga: ${stats.student.longestStreak} sem.`} />
-        <KpiCard emoji="📅" value={sessions.confirmed} label="Clases confirmadas" sub={`${sessions.totalHours}h en total`} />
-        <KpiCard emoji="🔥" value={stats.student.currentStreak} label="Racha actual" sub="semanas consecutivas" />
+        <KpiCard
+          emoji="📜"
+          value={certificates.total}
+          label="Certificados"
+          sub={certsByTypeSummary(certificates.byType)}
+        />
+        <KpiCard
+          emoji="🏆"
+          value={stats.student.totalPoints}
+          label="Puntos totales"
+          sub={`Racha más larga: ${stats.student.longestStreak} sem.`}
+        />
+        <KpiCard
+          emoji="📅"
+          value={sessions.confirmed}
+          label="Clases confirmadas"
+          sub={`${sessions.totalHours}h en total`}
+        />
+        <KpiCard
+          emoji="🔥"
+          value={stats.student.currentStreak}
+          label="Racha actual"
+          sub="semanas consecutivas"
+        />
+      </div>
+
+      {/* Gestión de matrículas — el tutor matricula/desmatricula al alumno */}
+      <div style={S.section}>
+        <div style={S.sectionTitle}>
+          Matrículas {stats.student.schoolYear ? `· ${stats.student.schoolYear.label}` : ''}
+        </div>
+        <EnrollmentsSection studentId={student.id} hasLevel={!!stats.student.schoolYear} />
       </div>
 
       {/* Gráfico de actividad */}
@@ -380,7 +501,10 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
           <ActivityChart activity={stats.activity} days={periodDays} />
         </div>
       ) : (
-        <div className="vkb-card" style={{ color: '#94a3b8', fontSize: '0.875rem', marginBottom: '1.25rem' }}>
+        <div
+          className="vkb-card"
+          style={{ color: '#94a3b8', fontSize: '0.875rem', marginBottom: '1.25rem' }}
+        >
           Sin actividad registrada en el período seleccionado.
         </div>
       )}
@@ -391,10 +515,18 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
           <div style={S.sectionTitle}>Certificados obtenidos</div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
             {Object.entries(certificates.byType).map(([type, count]) => (
-              <span key={type} style={{
-                background: '#f0fdf4', color: '#166534', border: '1px solid #bbf7d0',
-                borderRadius: 8, padding: '4px 12px', fontSize: '0.78rem', fontWeight: 600,
-              }}>
+              <span
+                key={type}
+                style={{
+                  background: '#f0fdf4',
+                  color: '#166534',
+                  border: '1px solid #bbf7d0',
+                  borderRadius: 8,
+                  padding: '4px 12px',
+                  fontSize: '0.78rem',
+                  fontWeight: 600,
+                }}
+              >
                 {CERT_LABELS[type] ?? type} ×{count}
               </span>
             ))}
@@ -418,13 +550,33 @@ function StudentDetail({ student, periodDays }: { student: StudentSummary; perio
 // ─── Sub-componentes ───────────────────────────────────────────────────────────
 
 function KpiCard({
-  emoji, value, label, sub,
-}: { emoji: string; value: string | number; label: string; sub?: string }) {
+  emoji,
+  value,
+  label,
+  sub,
+}: {
+  emoji: string;
+  value: string | number;
+  label: string;
+  sub?: string;
+}) {
   return (
     <div className="stat-card" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       <div style={{ fontSize: '1.4rem', lineHeight: 1 }}>{emoji}</div>
-      <div style={{ fontSize: '1.6rem', fontWeight: 800, color: '#0f172a', lineHeight: 1.1 }}>{value}</div>
-      <div style={{ fontSize: '0.72rem', fontWeight: 600, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.04em' }}>{label}</div>
+      <div style={{ fontSize: '1.6rem', fontWeight: 800, color: '#0f172a', lineHeight: 1.1 }}>
+        {value}
+      </div>
+      <div
+        style={{
+          fontSize: '0.72rem',
+          fontWeight: 600,
+          color: '#64748b',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+        }}
+      >
+        {label}
+      </div>
       {sub && <div style={{ fontSize: '0.72rem', color: '#94a3b8', marginTop: 2 }}>{sub}</div>}
     </div>
   );
@@ -438,21 +590,31 @@ function CourseProgressCard({ course }: { course: StudentStats['courses'][0] }) 
   return (
     <div className="vkb-card" style={{ marginBottom: 8 }}>
       <div
-        style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: course.modules.length > 0 ? 'pointer' : 'default' }}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: course.modules.length > 0 ? 'pointer' : 'default',
+        }}
         onClick={() => course.modules.length > 0 && setExpanded((e) => !e)}
       >
         <div style={{ flex: 1 }}>
           <div style={{ fontSize: '0.875rem', fontWeight: 700, color: '#0f172a', marginBottom: 4 }}>
             {course.title}
             {course.schoolYear && (
-              <span style={{ marginLeft: 8, fontSize: '0.7rem', color: '#64748b', fontWeight: 500 }}>
+              <span
+                style={{ marginLeft: 8, fontSize: '0.7rem', color: '#64748b', fontWeight: 500 }}
+              >
                 {course.schoolYear.label}
               </span>
             )}
           </div>
           <div style={S.progressBarWrap}>
             <div className="progress-bar" style={{ flex: 1 }}>
-              <div className="progress-fill" style={{ width: `${pct}%`, background: fill === '#16a34a' ? fill : undefined }} />
+              <div
+                className="progress-fill"
+                style={{ width: `${pct}%`, background: fill === '#16a34a' ? fill : undefined }}
+              />
             </div>
             <span style={S.progressPct}>{pct}%</span>
             <span style={{ fontSize: '0.7rem', color: '#94a3b8' }}>
@@ -468,21 +630,36 @@ function CourseProgressCard({ course }: { course: StudentStats['courses'][0] }) 
       </div>
 
       {expanded && (
-        <div style={{ marginTop: 12, borderTop: '1px solid #f1f5f9', paddingTop: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div
+          style={{
+            marginTop: 12,
+            borderTop: '1px solid #f1f5f9',
+            paddingTop: 12,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
           {course.modules.map((mod) => {
-            const mPct = mod.totalLessons > 0
-              ? Math.round((mod.completedLessons / mod.totalLessons) * 100)
-              : 0;
+            const mPct =
+              mod.totalLessons > 0
+                ? Math.round((mod.completedLessons / mod.totalLessons) * 100)
+                : 0;
             return (
               <div key={mod.id}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
-                  <span style={{ fontSize: '0.78rem', color: '#475569', fontWeight: 500 }}>{mod.title}</span>
+                  <span style={{ fontSize: '0.78rem', color: '#475569', fontWeight: 500 }}>
+                    {mod.title}
+                  </span>
                   <span style={{ fontSize: '0.72rem', color: '#94a3b8' }}>
                     {mod.completedLessons}/{mod.totalLessons}
                   </span>
                 </div>
                 <div className="progress-bar" style={{ height: 5 }}>
-                  <div className="progress-fill" style={{ width: `${mPct}%`, background: mPct === 100 ? '#16a34a' : undefined }} />
+                  <div
+                    className="progress-fill"
+                    style={{ width: `${mPct}%`, background: mPct === 100 ? '#16a34a' : undefined }}
+                  />
                 </div>
               </div>
             );
@@ -490,6 +667,146 @@ function CourseProgressCard({ course }: { course: StudentStats['courses'][0] }) 
         </div>
       )}
     </div>
+  );
+}
+
+// ─── Sección: gestión de matrículas del alumno ─────────────────────────────────
+
+function EnrollmentsSection({ studentId, hasLevel }: { studentId: string; hasLevel: boolean }) {
+  const qc = useQueryClient();
+
+  const {
+    data: courses,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['tutor', 'available-courses', studentId],
+    queryFn: () => tutorsApi.getAvailableCourses(studentId),
+    enabled: hasLevel,
+  });
+
+  const invalidate = () => {
+    void qc.invalidateQueries({ queryKey: ['tutor', 'available-courses', studentId] });
+    void qc.invalidateQueries({ queryKey: ['tutor', 'stats', studentId] });
+    void qc.invalidateQueries({ queryKey: ['tutor', 'students'] });
+  };
+
+  const enrollMut = useMutation({
+    mutationFn: (courseId: string) => tutorsApi.enroll(studentId, courseId),
+    onSuccess: invalidate,
+  });
+
+  const unenrollMut = useMutation({
+    mutationFn: (courseId: string) => tutorsApi.unenroll(studentId, courseId),
+    onSuccess: invalidate,
+  });
+
+  if (!hasLevel) {
+    return (
+      <div className="vkb-card" style={{ color: '#94a3b8', fontSize: '0.875rem' }}>
+        Asigna un nivel educativo al alumno para gestionar sus matrículas.
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="vkb-card" style={{ color: '#94a3b8', fontSize: '0.875rem' }}>
+        Cargando asignaturas…
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="vkb-card" style={{ color: '#dc2626', fontSize: '0.875rem' }}>
+        Error al cargar las asignaturas.
+      </div>
+    );
+  }
+
+  if (!courses || courses.length === 0) {
+    return (
+      <div className="vkb-card" style={{ color: '#94a3b8', fontSize: '0.875rem' }}>
+        No hay asignaturas disponibles para el nivel de este alumno.
+      </div>
+    );
+  }
+
+  const isPending = enrollMut.isPending || unenrollMut.isPending;
+  const enrolledCount = courses.filter((c) => c.enrolled).length;
+
+  return (
+    <>
+      <div style={{ fontSize: '0.78rem', color: '#64748b', marginBottom: 8 }}>
+        {enrolledCount} de {courses.length} asignaturas matriculadas
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {courses.map((c) => (
+          <div
+            key={c.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
+              padding: '12px 14px',
+              borderRadius: 12,
+              border: `1.5px solid ${c.enrolled ? 'rgba(234,88,12,0.3)' : 'var(--color-border)'}`,
+              background: c.enrolled ? 'rgba(234,88,12,0.06)' : '#fff',
+            }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+              {c.subject && (
+                <span
+                  style={{
+                    fontSize: '0.68rem',
+                    fontWeight: 700,
+                    color: ORANGE,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  {c.subject}
+                </span>
+              )}
+              <span
+                style={{
+                  fontSize: '0.875rem',
+                  fontWeight: 700,
+                  color: '#0f172a',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {c.title}
+              </span>
+            </div>
+            <button
+              onClick={() => (c.enrolled ? unenrollMut.mutate(c.id) : enrollMut.mutate(c.id))}
+              disabled={isPending}
+              style={{
+                flexShrink: 0,
+                padding: '6px 14px',
+                borderRadius: 8,
+                border: 'none',
+                cursor: isPending ? 'wait' : 'pointer',
+                fontWeight: 700,
+                fontSize: '0.78rem',
+                color: '#fff',
+                background: c.enrolled
+                  ? '#ef4444'
+                  : 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
+                opacity: isPending ? 0.7 : 1,
+              }}
+            >
+              {c.enrolled ? 'Quitar' : 'Matricular'}
+            </button>
+          </div>
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -521,7 +838,9 @@ export default function TutorStudentsPage() {
 
         <div style={S.studentList}>
           {!isLoading && students?.length === 0 && (
-            <div style={{ padding: '1.25rem', fontSize: '0.8rem', color: 'rgba(255,255,255,0.35)' }}>
+            <div
+              style={{ padding: '1.25rem', fontSize: '0.8rem', color: 'rgba(255,255,255,0.35)' }}
+            >
               Aún no tienes alumnos asignados.
             </div>
           )}
@@ -547,10 +866,10 @@ export default function TutorStudentsPage() {
               <div style={S.studentAvatar}>{st.name.charAt(0).toUpperCase()}</div>
               <div style={{ minWidth: 0 }}>
                 <div style={S.studentName}>{st.name}</div>
-                <div style={S.studentLevel}>
-                  {st.schoolYear?.label ?? 'Sin nivel'}
+                <div style={S.studentLevel}>{st.schoolYear?.label ?? 'Sin nivel'}</div>
+                <div style={S.studentPts}>
+                  🏆 {st.totalPoints} pts · 🔥 {st.currentStreak}sem
                 </div>
-                <div style={S.studentPts}>🏆 {st.totalPoints} pts · 🔥 {st.currentStreak}sem</div>
               </div>
             </div>
           ))}
@@ -573,9 +892,10 @@ export default function TutorStudentsPage() {
                 key={p.label}
                 style={{
                   ...S.periodBtn,
-                  background: i === periodIdx
-                    ? 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)'
-                    : '#f1f5f9',
+                  background:
+                    i === periodIdx
+                      ? 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)'
+                      : '#f1f5f9',
                   color: i === periodIdx ? '#fff' : '#475569',
                   boxShadow: i === periodIdx ? '0 4px 12px rgba(234,88,12,0.3)' : 'none',
                 }}
@@ -586,7 +906,11 @@ export default function TutorStudentsPage() {
             ))}
           </div>
 
-          <StudentDetail key={`${selected.id}-${period.days}`} student={selected} periodDays={period.days} />
+          <StudentDetail
+            key={`${selected.id}-${period.days}`}
+            student={selected}
+            periodDays={period.days}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Move course enrollment management from admin-only to **tutor**: tutors can enroll/unenroll their assigned students into any subject of the student's school year.
- Remove the unused **"Cursos"** section from the student menu and dashboard, aligning the student experience with the on-demand theory/exercises model.

### Backend (`apps/api/src/tutors`)

- `TutorsService`: new methods
  - `getAvailableCoursesForStudent(tutorId, studentId)` — published courses of the student's `schoolYearId`, each with `enrolled: boolean`.
  - `enrollStudent(tutorId, studentId, courseId)` — idempotent upsert. Validates tutor-student relationship and `course.schoolYearId === student.schoolYearId`.
  - `unenrollStudent(tutorId, studentId, courseId)` — idempotent delete.
  - Private helper `getStudentForTutor` for shared validation.
- `TutorsController`: 3 new endpoints (TUTOR, ADMIN)
  - `GET    /tutors/my-students/:id/available-courses`
  - `POST   /tutors/my-students/:id/enrollments` `{ courseId }`
  - `DELETE /tutors/my-students/:id/enrollments/:courseId`

### Frontend

- `tutors.api.ts`: add `getAvailableCourses`, `enroll`, `unenroll` + `AvailableCourse` type.
- `AppLayout.tsx`: remove `📚 Cursos` link from STUDENT navigation.
- `TutorStudentsPage.tsx`: new **"Matrículas"** section in the student detail panel — lists every subject of the student's level with a per-row Matricular/Quitar button and `X de Y matriculadas` counter. Empty state when the student has no level.
- `DashboardPage.tsx`: STUDENT cleanup
  - Drop "Mis cursos" quick action (link was dead).
  - Drop "Últimas lecciones" sidebar (linked into the deprecated lesson UI).
  - Drop "Lecciones completadas" stat card.
  - Replace with on-demand quick actions (**Teoría**, **Ejercicios**, **Reservar clase**).
  - Collapse the two-column STUDENT layout into a single column matching other roles.

## Test plan

- [x] `pnpm --filter @vkbacademy/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @vkbacademy/api test -- --testPathPattern=tutors` — 20/20 passing
- [ ] Manual: TUTOR opens "Mis alumnos" → selects student → "Matrículas" section shows subjects of the student's level; Matricular toggles to Matriculado, persists on reload.
- [ ] Manual: TUTOR cannot enroll a student into a course of a different `schoolYearId` (server returns 403).
- [ ] Manual: STUDENT login no longer shows "Cursos" in sidebar; dashboard shows Teoría/Ejercicios/Reservar clase quick actions; on-demand theory/exercises still gated by enrollment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)