### PR TITLE
feat(auth): simplify tutor registration — auto-generate student emails

### DIFF
--- a/apps/api/src/auth/auth-register-tutor.service.spec.ts
+++ b/apps/api/src/auth/auth-register-tutor.service.spec.ts
@@ -37,7 +37,7 @@ const fakeTutor = {
 
 const fakeStudent1 = {
   id: 'student-uuid-1',
-  email: 'alumno1@vkbacademy.es',
+  email: 'alumno-uno@vkbacademy.com',
   name: 'Alumno Uno',
   role: 'STUDENT',
   passwordHash: '$2b$10$hashed_student1',
@@ -50,7 +50,7 @@ const fakeStudent1 = {
 
 const fakeStudent2 = {
   id: 'student-uuid-2',
-  email: 'alumno2@vkbacademy.es',
+  email: 'alumno-dos@vkbacademy.com',
   name: 'Alumno Dos',
   role: 'STUDENT',
   passwordHash: '$2b$10$hashed_student2',
@@ -63,7 +63,7 @@ const fakeStudent2 = {
 
 const fakeStudent3 = {
   id: 'student-uuid-3',
-  email: 'alumno3@vkbacademy.es',
+  email: 'alumno-tres@vkbacademy.com',
   name: 'Alumno Tres',
   role: 'STUDENT',
   passwordHash: '$2b$10$hashed_student3',
@@ -98,12 +98,13 @@ describe('AuthService.registerTutor', () => {
   let mockJwt: { sign: jest.Mock };
   let mockConfig: { get: jest.Mock };
   let mockNotifications: {
-    sendWelcomeTutor: jest.Mock;
-    sendWelcomeStudent: jest.Mock;
+    sendTutorWelcomeWithStudents: jest.Mock;
     sendPasswordReset: jest.Mock;
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     mockPrisma = {
       user: {
         findUnique: jest.fn(),
@@ -133,8 +134,7 @@ describe('AuthService.registerTutor', () => {
       }),
     };
     mockNotifications = {
-      sendWelcomeTutor: jest.fn().mockResolvedValue(undefined),
-      sendWelcomeStudent: jest.fn().mockResolvedValue(undefined),
+      sendTutorWelcomeWithStudents: jest.fn().mockResolvedValue(undefined),
       sendPasswordReset: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -162,7 +162,7 @@ describe('AuthService.registerTutor', () => {
       email: 'tutor@vkbacademy.es',
       password: 'password123',
       academySlug: 'vallekas-basket',
-      students: [{ name: 'Alumno Uno', email: 'alumno1@vkbacademy.es', schoolYearId: 'sy1' }],
+      students: [{ name: 'Alumno Uno', schoolYearId: 'sy1' }],
     };
 
     beforeEach(() => {
@@ -196,6 +196,13 @@ describe('AuthService.registerTutor', () => {
       expect(studentCreateCall.data.role).toBe('STUDENT');
     });
 
+    it('el alumno se crea con email autogenerado @vkbacademy.com', async () => {
+      await service.registerTutor(dto);
+
+      const studentCreateCall = mockPrisma.user.create.mock.calls[1][0];
+      expect(studentCreateCall.data.email).toBe('alumno-uno@vkbacademy.com');
+    });
+
     it('el alumno tiene tutorId apuntando al tutor', async () => {
       await service.registerTutor(dto);
 
@@ -219,7 +226,6 @@ describe('AuthService.registerTutor', () => {
     it('se crean membresías de academia para tutor y alumno', async () => {
       await service.registerTutor(dto);
 
-      // tutor y alumno se crean con academyMembers.create dentro de user.create
       const tutorCreateCall = mockPrisma.user.create.mock.calls[0][0];
       expect(tutorCreateCall.data.academyMembers.create.academyId).toBe(fakeAcademy.id);
 
@@ -227,24 +233,20 @@ describe('AuthService.registerTutor', () => {
       expect(studentCreateCall.data.academyMembers.create.academyId).toBe(fakeAcademy.id);
     });
 
-    it('envía email de bienvenida al tutor', async () => {
+    it('envía un único email consolidado al tutor con sus credenciales y las del alumno', async () => {
       await service.registerTutor(dto);
 
-      expect(mockNotifications.sendWelcomeTutor).toHaveBeenCalledWith(
-        expect.objectContaining({ email: fakeTutor.email }),
-      );
+      expect(mockNotifications.sendTutorWelcomeWithStudents).toHaveBeenCalledTimes(1);
+      const call = mockNotifications.sendTutorWelcomeWithStudents.mock.calls[0][0];
+      expect(call.tutorEmail).toBe(fakeTutor.email);
+      expect(call.tutorPassword).toBe(dto.password);
+      expect(call.students).toHaveLength(1);
+      expect(call.students[0].email).toBe(fakeStudent1.email);
+      expect(typeof call.students[0].password).toBe('string');
+      expect(call.students[0].password.length).toBeGreaterThanOrEqual(8);
     });
 
-    it('envía email de bienvenida al alumno con contraseña generada', async () => {
-      await service.registerTutor(dto);
-
-      expect(mockNotifications.sendWelcomeStudent).toHaveBeenCalledTimes(1);
-      expect(mockNotifications.sendWelcomeStudent).toHaveBeenCalledWith(
-        expect.objectContaining({ email: fakeStudent1.email }),
-      );
-    });
-
-    it('ejecuta todo dentro de una transacción Prisma', async () => {
+    it('ejecuta la creación de usuarios dentro de una transacción Prisma', async () => {
       await service.registerTutor(dto);
 
       expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
@@ -260,9 +262,9 @@ describe('AuthService.registerTutor', () => {
       password: 'password123',
       academySlug: 'vallekas-basket',
       students: [
-        { name: 'Alumno Uno', email: 'alumno1@vkbacademy.es', schoolYearId: 'sy1' },
-        { name: 'Alumno Dos', email: 'alumno2@vkbacademy.es', schoolYearId: 'sy1' },
-        { name: 'Alumno Tres', email: 'alumno3@vkbacademy.es', schoolYearId: 'sy2' },
+        { name: 'Alumno Uno', schoolYearId: 'sy1' },
+        { name: 'Alumno Dos', schoolYearId: 'sy1' },
+        { name: 'Alumno Tres', schoolYearId: 'sy2' },
       ],
     };
 
@@ -282,10 +284,12 @@ describe('AuthService.registerTutor', () => {
       expect(mockPrisma.user.create).toHaveBeenCalledTimes(4);
     });
 
-    it('envía 3 emails de bienvenida a los alumnos', async () => {
+    it('envía un único email consolidado con los 3 alumnos en la tabla', async () => {
       await service.registerTutor(dto);
 
-      expect(mockNotifications.sendWelcomeStudent).toHaveBeenCalledTimes(3);
+      expect(mockNotifications.sendTutorWelcomeWithStudents).toHaveBeenCalledTimes(1);
+      const call = mockNotifications.sendTutorWelcomeWithStudents.mock.calls[0][0];
+      expect(call.students).toHaveLength(3);
     });
 
     it('cada alumno tiene tutorId del tutor recién creado', async () => {
@@ -320,7 +324,7 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@test.es',
           password: 'password123',
           academySlug: 'academia-inexistente',
-          students: [{ name: 'Alumno', email: 'alumno@test.es' }],
+          students: [{ name: 'Alumno' }],
         }),
       ).rejects.toThrow(NotFoundException);
     });
@@ -334,14 +338,13 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@test.es',
           password: 'password123',
           academySlug: 'vallekas-basket',
-          students: [{ name: 'Alumno', email: 'alumno@test.es' }],
+          students: [{ name: 'Alumno' }],
         }),
       ).rejects.toThrow(BadRequestException);
     });
 
     it('lanza ConflictException si el email del tutor ya está registrado', async () => {
       mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
-      // El tutor ya existe
       mockPrisma.user.findUnique.mockResolvedValueOnce(fakeTutor);
 
       await expect(
@@ -350,31 +353,13 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@vkbacademy.es',
           password: 'password123',
           academySlug: 'vallekas-basket',
-          students: [{ name: 'Alumno', email: 'alumno@test.es' }],
+          students: [{ name: 'Alumno' }],
         }),
       ).rejects.toThrow(ConflictException);
     });
 
-    it('lanza ConflictException si el email de un alumno ya está registrado', async () => {
-      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
-      // Tutor no existe, pero alumno sí
-      mockPrisma.user.findUnique
-        .mockResolvedValueOnce(null) // tutor email → libre
-        .mockResolvedValueOnce(fakeStudent1); // alumno email → duplicado
-
-      await expect(
-        service.registerTutor({
-          name: 'Tutor',
-          email: 'tutor@nuevo.es',
-          password: 'password123',
-          academySlug: 'vallekas-basket',
-          students: [{ name: 'Alumno', email: 'alumno1@vkbacademy.es' }],
-        }),
-      ).rejects.toThrow(ConflictException);
-    });
-
-    it('no crea ningún usuario si alguna validación falla (rollback implícito con mock de transaction)', async () => {
-      mockPrisma.academy.findUnique.mockResolvedValue(null); // academia inexistente
+    it('no crea ningún usuario si alguna validación falla (rollback implícito)', async () => {
+      mockPrisma.academy.findUnique.mockResolvedValue(null);
 
       try {
         await service.registerTutor({
@@ -382,7 +367,7 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@test.es',
           password: 'password123',
           academySlug: 'inexistente',
-          students: [{ name: 'Alumno', email: 'alumno@test.es' }],
+          students: [{ name: 'Alumno' }],
         });
       } catch {
         // esperado
@@ -392,53 +377,104 @@ describe('AuthService.registerTutor', () => {
     });
   });
 
-  // ─── Generación de contraseña para alumnos ──────────────────────────────────
+  // ─── Auto-generación de email + contraseña ──────────────────────────────────
 
-  describe('generación de contraseña para alumnos', () => {
+  describe('auto-generación de email y contraseña para alumnos', () => {
     beforeEach(() => {
-      jest.clearAllMocks();
-      // Restaurar los valores por defecto tras limpiar los mocks
-      mockJwt.sign.mockReturnValue('mocked_token');
-      mockConfig.get.mockImplementation((key: string, fallback?: string) => {
-        if (key === 'JWT_REFRESH_SECRET') return 'test_refresh_secret';
-        if (key === 'JWT_REFRESH_EXPIRES_IN') return fallback ?? '7d';
-        if (key === 'FRONTEND_URL') return 'http://localhost:5173';
-        return undefined;
-      });
-      mockedBcrypt.hash.mockResolvedValue('$2b$10$hashed' as never);
-      mockPrisma.refreshToken.create.mockResolvedValue({});
-
       mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
       mockPrisma.user.findUnique.mockResolvedValue(null);
-      mockPrisma.user.create.mockResolvedValueOnce(fakeTutor).mockResolvedValueOnce(fakeStudent1);
     });
 
-    it('hashea la contraseña del alumno antes de persistir', async () => {
+    it('slugifica nombres con tildes y ñ a ASCII', async () => {
+      mockPrisma.user.create
+        .mockResolvedValueOnce(fakeTutor)
+        .mockResolvedValueOnce({ ...fakeStudent1, email: 'maria-perez-garcia@vkbacademy.com' });
+
       await service.registerTutor({
         name: 'Tutor',
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'Alumno', email: 'alumno1@vkbacademy.es', schoolYearId: 'sy1' }],
+        students: [{ name: 'María Pérez García' }],
+      });
+
+      const studentCreateCall = mockPrisma.user.create.mock.calls[1][0];
+      expect(studentCreateCall.data.email).toBe('maria-perez-garcia@vkbacademy.com');
+    });
+
+    it('añade sufijo numérico cuando el email base ya existe en BD', async () => {
+      // Primera comprobación (email del tutor en findUnique): libre.
+      // Segunda comprobación (email base del alumno juan-garcia): ocupado.
+      // Tercera comprobación (juan-garcia-2): libre.
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce(null) // tutor
+        .mockResolvedValueOnce({ id: 'otro' }) // juan-garcia@ ocupado
+        .mockResolvedValueOnce(null); // juan-garcia-2@ libre
+      mockPrisma.user.create
+        .mockResolvedValueOnce(fakeTutor)
+        .mockResolvedValueOnce({ ...fakeStudent1, email: 'juan-garcia-2@vkbacademy.com' });
+
+      await service.registerTutor({
+        name: 'Tutor',
+        email: 'tutor@test.es',
+        password: 'password123',
+        academySlug: 'vallekas-basket',
+        students: [{ name: 'Juan García' }],
+      });
+
+      const studentCreateCall = mockPrisma.user.create.mock.calls[1][0];
+      expect(studentCreateCall.data.email).toBe('juan-garcia-2@vkbacademy.com');
+    });
+
+    it('desambigua dos alumnos con el mismo nombre dentro del mismo registro', async () => {
+      mockPrisma.user.create
+        .mockResolvedValueOnce(fakeTutor)
+        .mockResolvedValueOnce({ ...fakeStudent1, email: 'juan-garcia@vkbacademy.com' })
+        .mockResolvedValueOnce({ ...fakeStudent2, email: 'juan-garcia-2@vkbacademy.com' });
+
+      await service.registerTutor({
+        name: 'Tutor',
+        email: 'tutor@test.es',
+        password: 'password123',
+        academySlug: 'vallekas-basket',
+        students: [{ name: 'Juan García' }, { name: 'Juan García' }],
+      });
+
+      expect(mockPrisma.user.create.mock.calls[1][0].data.email).toBe('juan-garcia@vkbacademy.com');
+      expect(mockPrisma.user.create.mock.calls[2][0].data.email).toBe(
+        'juan-garcia-2@vkbacademy.com',
+      );
+    });
+
+    it('hashea la contraseña del alumno antes de persistir', async () => {
+      mockPrisma.user.create.mockResolvedValueOnce(fakeTutor).mockResolvedValueOnce(fakeStudent1);
+
+      await service.registerTutor({
+        name: 'Tutor',
+        email: 'tutor@test.es',
+        password: 'password123',
+        academySlug: 'vallekas-basket',
+        students: [{ name: 'Alumno', schoolYearId: 'sy1' }],
       });
 
       // bcrypt.hash se llama exactamente 2 veces: una para el tutor y otra para el alumno
       expect(mockedBcrypt.hash).toHaveBeenCalledTimes(2);
     });
 
-    it('la contraseña generada para el alumno se envía por email en texto plano', async () => {
+    it('la contraseña generada para el alumno se envía en texto plano dentro del email consolidado', async () => {
+      mockPrisma.user.create.mockResolvedValueOnce(fakeTutor).mockResolvedValueOnce(fakeStudent1);
+
       await service.registerTutor({
         name: 'Tutor',
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'Alumno', email: 'alumno1@vkbacademy.es', schoolYearId: 'sy1' }],
+        students: [{ name: 'Alumno', schoolYearId: 'sy1' }],
       });
 
-      const studentEmailCall = mockNotifications.sendWelcomeStudent.mock.calls[0][0];
-      // La contraseña generada debe ser una cadena no vacía de al menos 8 caracteres
-      expect(typeof studentEmailCall.password).toBe('string');
-      expect(studentEmailCall.password.length).toBeGreaterThanOrEqual(8);
+      const call = mockNotifications.sendTutorWelcomeWithStudents.mock.calls[0][0];
+      expect(typeof call.students[0].password).toBe('string');
+      expect(call.students[0].password.length).toBeGreaterThanOrEqual(8);
     });
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -94,11 +94,9 @@ export class AuthService {
   /**
    * Registro de tutor con alumnos.
    *
-   * COSTE DE EMAILS (Resend):
-   *   - Plan gratuito: 100 emails/día, 3 000/mes
-   *   - Cada registro envía N+1 emails (1 tutor + N alumnos)
-   *   - Estimación: 100 academias × 10 registros/día × 2 emails promedio ≈ 2 000 emails/día
-   *     → Supera el plan gratuito; se necesita Resend Pro (~20 $/mes, 50 000/mes)
+   * Los alumnos no aportan email — se autogenera del nombre (slug + dominio
+   * fijo) y la contraseña se genera aleatoriamente. Todas las credenciales
+   * (las del tutor y las de cada alumno) se envían en un único email al tutor.
    *
    * Todo se ejecuta dentro de una transacción Prisma: si algo falla,
    * ningún usuario ni membresía queda persistido.
@@ -113,26 +111,24 @@ export class AuthService {
       throw new BadRequestException(`La academia "${dto.academySlug}" no está activa`);
     }
 
-    // 2. Verificar que ningún email (tutor + alumnos) está ya registrado
-    const allEmails = [dto.email, ...dto.students.map((s) => s.email)];
-    for (const email of allEmails) {
-      const exists = await this.prisma.user.findUnique({ where: { email } });
-      if (exists) {
-        throw new ConflictException(`El email "${email}" ya está registrado`);
-      }
+    // 2. Verificar que el email del tutor no está ya registrado
+    const tutorExists = await this.prisma.user.findUnique({ where: { email: dto.email } });
+    if (tutorExists) {
+      throw new ConflictException(`El email "${dto.email}" ya está registrado`);
     }
 
-    // 3. Crear tutor y alumnos en transacción
-    const tutorPasswordHash = await bcrypt.hash(dto.password, 10);
+    // 3. Generar email único para cada alumno (slug del nombre + sufijo si colisiona)
+    const studentEmails = await this.allocateStudentEmails(dto.students.map((s) => s.name));
 
-    // Generar contraseñas aleatorias para cada alumno (8 chars alfanuméricos)
+    // 4. Hashes de contraseñas
+    const tutorPasswordHash = await bcrypt.hash(dto.password, 10);
     const studentPasswords = dto.students.map(() => this.generatePassword());
     const studentPasswordHashes = await Promise.all(
       studentPasswords.map((pw) => bcrypt.hash(pw, 10)),
     );
 
+    // 5. Crear tutor y alumnos en transacción
     const { tutor, students } = await this.prisma.$transaction(async (tx) => {
-      // Crear tutor con rol TUTOR y membresía de academia
       const createdTutor = await tx.user.create({
         data: {
           email: dto.email,
@@ -144,12 +140,11 @@ export class AuthService {
         include: { schoolYear: true },
       });
 
-      // Crear cada alumno con rol STUDENT, tutorId y membresía de academia
       const createdStudents = await Promise.all(
         dto.students.map((studentDto, index) =>
           tx.user.create({
             data: {
-              email: studentDto.email,
+              email: studentEmails[index],
               passwordHash: studentPasswordHashes[index],
               name: studentDto.name,
               role: 'STUDENT',
@@ -165,31 +160,26 @@ export class AuthService {
       return { tutor: createdTutor, students: createdStudents };
     });
 
-    // 4. Enviar emails de bienvenida (fuera de la transacción para no bloquearla)
+    // 6. Enviar UN email consolidado al tutor con todas las credenciales
     const frontendUrl = this.config
       .get<string>('FRONTEND_URL', 'http://localhost:5173')
       .split(',')[0];
     const loginUrl = `${frontendUrl}/login`;
 
-    void this.notifications.sendWelcomeTutor({
-      email: tutor.email,
-      name: tutor.name,
-      password: dto.password,
+    void this.notifications.sendTutorWelcomeWithStudents({
+      tutorEmail: tutor.email,
+      tutorName: tutor.name,
+      tutorPassword: dto.password,
+      students: students.map((student, index) => ({
+        name: student.name,
+        email: student.email,
+        password: studentPasswords[index],
+      })),
       academyName: academy.name,
       loginUrl,
     });
 
-    students.forEach((student, index) => {
-      void this.notifications.sendWelcomeStudent({
-        email: student.email,
-        name: student.name,
-        password: studentPasswords[index],
-        academyName: academy.name,
-        loginUrl,
-      });
-    });
-
-    // 5. Auto-login del tutor: generar tokens y devolver respuesta
+    // 7. Auto-login del tutor: generar tokens y devolver respuesta
     const tokens = await this.generateTokens({
       sub: tutor.id,
       email: tutor.email,
@@ -206,6 +196,54 @@ export class AuthService {
     return Array.from({ length: 8 }, () => chars[Math.floor(Math.random() * chars.length)]).join(
       '',
     );
+  }
+
+  /**
+   * Convierte un nombre en slug ASCII apto para email.
+   * "María Pérez García" → "maria-perez-garcia".
+   */
+  private slugifyName(name: string): string {
+    return (
+      name
+        .normalize('NFD')
+        // Marca de diacríticos: U+0300 a U+036F (tildes, virgulillas, etc.)
+        .replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '')
+    );
+  }
+
+  /**
+   * Genera un email único @vkbacademy.com para cada nombre de alumno.
+   * Resuelve colisiones con sufijo incremental (-2, -3, ...).
+   */
+  private async allocateStudentEmails(names: string[]): Promise<string[]> {
+    const STUDENT_EMAIL_DOMAIN = 'vkbacademy.com';
+    const used = new Set<string>();
+    const result: string[] = [];
+
+    for (const name of names) {
+      const base = this.slugifyName(name) || 'alumno';
+      let candidate = `${base}@${STUDENT_EMAIL_DOMAIN}`;
+      let suffix = 1;
+
+      while (
+        used.has(candidate) ||
+        (await this.prisma.user.findUnique({ where: { email: candidate } }))
+      ) {
+        suffix++;
+        candidate = `${base}-${suffix}@${STUDENT_EMAIL_DOMAIN}`;
+      }
+
+      used.add(candidate);
+      result.push(candidate);
+    }
+
+    return result;
   }
 
   async login(dto: LoginDto): Promise<AuthResponse> {

--- a/apps/api/src/auth/dto/register-tutor.dto.ts
+++ b/apps/api/src/auth/dto/register-tutor.dto.ts
@@ -16,9 +16,6 @@ export class RegisterStudentDto {
   @MaxLength(100)
   name: string;
 
-  @IsEmail({}, { message: 'Email del alumno inválido' })
-  email: string;
-
   @IsOptional()
   @IsString()
   schoolYearId?: string;

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -136,68 +136,65 @@ export class NotificationsService {
   }
 
   /**
-   * Bienvenida al tutor: incluye sus credenciales y enlace de acceso.
-   * Se envía automáticamente al completar el registro de tutor+alumnos.
+   * Email único al tutor con TODAS las credenciales: las suyas + las de cada
+   * alumno (email autogenerado + contraseña aleatoria). Los alumnos no
+   * reciben email propio porque a esta edad no suelen tener cuenta personal.
    */
-  async sendWelcomeTutor(params: {
-    email: string;
-    name: string;
-    password: string;
+  async sendTutorWelcomeWithStudents(params: {
+    tutorEmail: string;
+    tutorName: string;
+    tutorPassword: string;
+    students: Array<{ name: string; email: string; password: string }>;
     academyName: string;
     loginUrl: string;
   }) {
-    await this.sendEmail(
-      params.email,
-      `Bienvenido a ${params.academyName} — VKB Academy`,
-      `<h2>¡Bienvenido a ${params.academyName}!</h2>
-       <p>Hola <strong>${params.name}</strong>, tu cuenta de tutor ha sido creada correctamente.</p>
-       <p>Aquí tienes tus credenciales de acceso:</p>
-       <table style="border-collapse:collapse;margin:1rem 0">
-         <tr><td style="padding:4px 12px 4px 0;color:#666">Email:</td><td><strong>${params.email}</strong></td></tr>
-         <tr><td style="padding:4px 12px 4px 0;color:#666">Contraseña:</td><td><strong>${params.password}</strong></td></tr>
-       </table>
-       <p style="margin:1.5rem 0">
-         <a href="${params.loginUrl}" style="background:#ea580c;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">
-           Acceder a la plataforma
-         </a>
-       </p>
-       <p style="color:#666;font-size:0.875rem">Te recomendamos cambiar tu contraseña tras el primer acceso.</p>`,
-    );
-  }
+    const studentRows = params.students
+      .map(
+        (s) => `
+         <tr>
+           <td style="padding:8px 14px;border-bottom:1px solid #eee">${s.name}</td>
+           <td style="padding:8px 14px;border-bottom:1px solid #eee"><code>${s.email}</code></td>
+           <td style="padding:8px 14px;border-bottom:1px solid #eee"><code>${s.password}</code></td>
+         </tr>`,
+      )
+      .join('');
 
-  /**
-   * Bienvenida al alumno: incluye contraseña generada automáticamente y enlace de acceso.
-   * Se envía automáticamente al completar el registro de tutor+alumnos.
-   *
-   * NOTA SOBRE COSTE DE EMAILS (Resend):
-   * - Plan gratuito: 100 emails/día, 3 000/mes
-   * - Cada registro de tutor envía N+1 emails (1 tutor + N alumnos)
-   * - Estimación: 100 academias × 10 registros/día × 2 emails promedio = ~2 000/día
-   *   → Se supera el plan gratuito; se necesita Resend Pro (~20 $/mes, 50 000/mes)
-   */
-  async sendWelcomeStudent(params: {
-    email: string;
-    name: string;
-    password: string;
-    academyName: string;
-    loginUrl: string;
-  }) {
+    const studentsBlock =
+      params.students.length > 0
+        ? `<h3 style="margin-top:2rem">Credenciales de tus alumnos</h3>
+       <p>Cada alumno entra con su propio usuario y contraseña — guárdalas o compártelas con ellos:</p>
+       <table style="border-collapse:collapse;margin:1rem 0;width:100%;max-width:560px">
+         <thead>
+           <tr style="background:#f8fafc">
+             <th style="padding:10px 14px;text-align:left;color:#475569;font-size:0.85rem">Alumno</th>
+             <th style="padding:10px 14px;text-align:left;color:#475569;font-size:0.85rem">Usuario</th>
+             <th style="padding:10px 14px;text-align:left;color:#475569;font-size:0.85rem">Contraseña</th>
+           </tr>
+         </thead>
+         <tbody>${studentRows}</tbody>
+       </table>`
+        : '';
+
     await this.sendEmail(
-      params.email,
+      params.tutorEmail,
       `Bienvenido a ${params.academyName} — VKB Academy`,
       `<h2>¡Bienvenido a ${params.academyName}!</h2>
-       <p>Hola <strong>${params.name}</strong>, tu cuenta de alumno ha sido creada por tu tutor.</p>
-       <p>Aquí tienes tus credenciales de acceso:</p>
+       <p>Hola <strong>${params.tutorName}</strong>, tu cuenta de tutor y la de tus alumnos se han creado correctamente.</p>
+
+       <h3>Tus credenciales</h3>
        <table style="border-collapse:collapse;margin:1rem 0">
-         <tr><td style="padding:4px 12px 4px 0;color:#666">Email:</td><td><strong>${params.email}</strong></td></tr>
-         <tr><td style="padding:4px 12px 4px 0;color:#666">Contraseña:</td><td><strong>${params.password}</strong></td></tr>
+         <tr><td style="padding:4px 12px 4px 0;color:#666">Email:</td><td><strong>${params.tutorEmail}</strong></td></tr>
+         <tr><td style="padding:4px 12px 4px 0;color:#666">Contraseña:</td><td><strong>${params.tutorPassword}</strong></td></tr>
        </table>
+
+       ${studentsBlock}
+
        <p style="margin:1.5rem 0">
          <a href="${params.loginUrl}" style="background:#ea580c;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700">
            Acceder a la plataforma
          </a>
        </p>
-       <p style="color:#666;font-size:0.875rem">Te recomendamos cambiar tu contraseña tras el primer acceso.</p>`,
+       <p style="color:#666;font-size:0.875rem">Os recomendamos cambiar las contraseñas tras el primer acceso.</p>`,
     );
   }
 

--- a/apps/web/src/api/auth.api.ts
+++ b/apps/web/src/api/auth.api.ts
@@ -22,7 +22,6 @@ export interface RegisterPayload {
 
 export interface RegisterStudentPayload {
   name: string;
-  email: string;
   schoolYearId?: string;
 }
 

--- a/apps/web/src/pages/RegisterPage.tsx
+++ b/apps/web/src/pages/RegisterPage.tsx
@@ -1,58 +1,44 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
 import { useRegisterTutor } from '../hooks/useAuth';
 import { useSchoolYears } from '../hooks/useCourses';
 import { useAcademyDomain } from '../contexts/AcademyContext';
-import api from '../lib/axios';
 
 /** Valida formato de email: x@y.z */
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
-interface PublicAcademy {
-  id: string;
-  slug: string;
-  name: string;
-  logoUrl: string | null;
-  primaryColor: string | null;
-}
+/** Academia por defecto cuando no estamos en un dominio de academia específica. */
+const DEFAULT_ACADEMY_SLUG = 'vallekas-basket';
 
 interface StudentForm {
   name: string;
-  email: string;
   schoolYearId: string;
 }
 
-const emptyStudent = (): StudentForm => ({ name: '', email: '', schoolYearId: '' });
+const emptyStudent = (): StudentForm => ({ name: '', schoolYearId: '' });
 
 export default function RegisterPage() {
   const [searchParams] = useSearchParams();
   const { academy: domainAcademy } = useAcademyDomain();
-  const preselectedAcademy = domainAcademy?.slug ?? searchParams.get('academy') ?? '';
+  // El slug se resuelve sin pedirlo al usuario: dominio de academia → query
+  // string → default fijo (Vallekas Basket Academy).
+  const academySlug = domainAcademy?.slug ?? searchParams.get('academy') ?? DEFAULT_ACADEMY_SLUG;
 
   // Paso 1: datos del tutor
   const [step, setStep] = useState<1 | 2>(1);
   const [tutorName, setTutorName] = useState('');
   const [tutorEmail, setTutorEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [academySlug, setAcademySlug] = useState(preselectedAcademy);
   const [passwordError, setPasswordError] = useState('');
   const [tutorEmailError, setTutorEmailError] = useState('');
 
   // Paso 2: datos de los alumnos
   const [students, setStudents] = useState<StudentForm[]>([emptyStudent()]);
-  const [studentEmailErrors, setStudentEmailErrors] = useState<string[]>([]);
 
   const { mutate, isPending, error } = useRegisterTutor();
   const { data: schoolYears = [] } = useSchoolYears();
-  const { data: academies = [] } = useQuery<PublicAcademy[]>({
-    queryKey: ['academies-public'],
-    queryFn: () => api.get('/academies/public').then((r) => r.data),
-  });
-
-  const selectedAcademy = academies.find((a) => a.slug === academySlug);
 
   function handleStep1(e: FormEvent) {
     e.preventDefault();
@@ -65,9 +51,6 @@ export default function RegisterPage() {
     }
     if (password.length < 8) {
       setPasswordError('La contraseña debe tener al menos 8 caracteres');
-      return;
-    }
-    if (!academySlug) {
       return;
     }
     setStep(2);
@@ -88,17 +71,7 @@ export default function RegisterPage() {
 
   function handleStep2(e: FormEvent) {
     e.preventDefault();
-    // Validar que todos los alumnos tengan nombre y email válido
-    const errors = students.map((s) =>
-      !s.email.trim()
-        ? 'Email requerido'
-        : !isValidEmail(s.email.trim())
-          ? 'Email inválido — formato requerido: x@y.z'
-          : '',
-    );
-    setStudentEmailErrors(errors);
-
-    const valid = students.every((s) => s.name.trim() && isValidEmail(s.email.trim()));
+    const valid = students.every((s) => s.name.trim().length > 0);
     if (!valid) return;
 
     mutate({
@@ -108,7 +81,6 @@ export default function RegisterPage() {
       academySlug,
       students: students.map((s) => ({
         name: s.name.trim(),
-        email: s.email.trim(),
         ...(s.schoolYearId ? { schoolYearId: s.schoolYearId } : {}),
       })),
     });
@@ -130,10 +102,10 @@ export default function RegisterPage() {
           <h1 style={s.title}>{step === 1 ? 'Crear cuenta de tutor' : 'Añadir alumnos'}</h1>
           <p style={s.subtitle}>
             {step === 1
-              ? selectedAcademy
-                ? `Regístrate como tutor en ${selectedAcademy.name}`
-                : 'Regístrate como tutor de la academia'
-              : `Añade los datos de tus alumnos (mínimo 1)`}
+              ? domainAcademy
+                ? `Regístrate como tutor en ${domainAcademy.name}`
+                : 'Regístrate como tutor'
+              : 'Añade los datos de tus alumnos (mínimo 1)'}
           </p>
           {/* Indicador de paso */}
           <div style={s.steps}>
@@ -200,25 +172,6 @@ export default function RegisterPage() {
               {passwordError && <span style={s.fieldError}>{passwordError}</span>}
             </div>
 
-            {academies.length > 0 && (
-              <div className="field field-dark">
-                <label htmlFor="academy">Academia</label>
-                <select
-                  id="academy"
-                  value={academySlug}
-                  onChange={(e) => setAcademySlug(e.target.value)}
-                  required
-                >
-                  <option value="">Selecciona tu academia</option>
-                  {academies.map((a) => (
-                    <option key={a.id} value={a.slug}>
-                      {a.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-
             <button
               type="submit"
               className="btn btn-primary btn-full"
@@ -253,28 +206,8 @@ export default function RegisterPage() {
                     placeholder="Juan García"
                     required
                   />
-                </div>
-
-                <div className="field field-dark">
-                  <label htmlFor={`student-email-${i}`}>Email del alumno</label>
-                  <input
-                    id={`student-email-${i}`}
-                    type="email"
-                    value={student.email}
-                    onChange={(e) => {
-                      updateStudent(i, 'email', e.target.value);
-                      setStudentEmailErrors((prev) => prev.map((err, j) => (j === i ? '' : err)));
-                    }}
-                    placeholder="alumno@email.com"
-                    className={studentEmailErrors[i] ? 'error' : ''}
-                    style={studentEmailErrors[i] ? { borderColor: '#dc2626' } : {}}
-                    required
-                  />
-                  {studentEmailErrors[i] && (
-                    <span style={s.fieldError}>{studentEmailErrors[i]}</span>
-                  )}
                   <span style={s.fieldHint}>
-                    Recibirá un email con su contraseña generada automáticamente.
+                    Le crearemos un usuario y contraseña automáticos. Te llegarán por email.
                   </span>
                 </div>
 


### PR DESCRIPTION
Tutors register without a per-student email field (kids rarely have a personal one). The system auto-generates a slugified vkbacademy.com email and a random password for each student, and sends a single consolidated welcome email to the tutor with all credentials.

The academy dropdown is hidden in the registration form: the slug is resolved from the academy domain or defaults to vallekas-basket.

Backend (apps/api):
- RegisterStudentDto: drop required email field.
- AuthService.registerTutor: allocate per-student email by slugifying the name (NFD-normalized ASCII, ñ→n) and suffixing -2/-3 on collision (both within the batch and against the database). Replace the per- recipient welcome emails (1 tutor + N students) with a single consolidated email to the tutor.
- NotificationsService: replace sendWelcomeTutor + sendWelcomeStudent with sendTutorWelcomeWithStudents (HTML table listing each student's generated user + password).
- Update auth-register-tutor.service.spec: 23 tests covering the new flow (email generation, slugify with diacritics, batch + DB collisions, consolidated email contents).

Frontend (apps/web):
- RegisterPage: remove the academy <select>; resolve slug from domain/query/default. Drop the student email input + validation; step 2 asks only for name + optional schoolYearId. Hint informs the tutor that credentials will arrive by email.
- auth.api.ts: drop email from RegisterStudentPayload.