### PR TITLE
feat(exams): student-generated AI exams with persistent banks

### DIFF
--- a/apps/api/prisma/migrations/20260505193355_ai_exam_banks/migration.sql
+++ b/apps/api/prisma/migrations/20260505193355_ai_exam_banks/migration.sql
@@ -1,0 +1,72 @@
+-- AddColumn: trazabilidad de intento desde un banco IA
+ALTER TABLE "ExamAttempt" ADD COLUMN "aiExamBankId" TEXT;
+
+-- CreateTable
+CREATE TABLE "AiExamBank" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "moduleId" TEXT,
+    "topic" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "numQuestions" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AiExamBank_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AiExamQuestion" (
+    "id" TEXT NOT NULL,
+    "bankId" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "type" "QuestionType" NOT NULL,
+    "order" INTEGER NOT NULL,
+    "explanation" TEXT,
+
+    CONSTRAINT "AiExamQuestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AiExamAnswer" (
+    "id" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "isCorrect" BOOLEAN NOT NULL DEFAULT false,
+    "order" INTEGER NOT NULL,
+
+    CONSTRAINT "AiExamAnswer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ExamAttempt_aiExamBankId_idx" ON "ExamAttempt"("aiExamBankId");
+
+-- CreateIndex
+CREATE INDEX "AiExamBank_userId_createdAt_idx" ON "AiExamBank"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AiExamBank_userId_courseId_idx" ON "AiExamBank"("userId", "courseId");
+
+-- CreateIndex
+CREATE INDEX "AiExamQuestion_bankId_order_idx" ON "AiExamQuestion"("bankId", "order");
+
+-- CreateIndex
+CREATE INDEX "AiExamAnswer_questionId_order_idx" ON "AiExamAnswer"("questionId", "order");
+
+-- AddForeignKey
+ALTER TABLE "ExamAttempt" ADD CONSTRAINT "ExamAttempt_aiExamBankId_fkey" FOREIGN KEY ("aiExamBankId") REFERENCES "AiExamBank"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiExamBank" ADD CONSTRAINT "AiExamBank_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiExamBank" ADD CONSTRAINT "AiExamBank_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiExamBank" ADD CONSTRAINT "AiExamBank_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "Module"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiExamQuestion" ADD CONSTRAINT "AiExamQuestion_bankId_fkey" FOREIGN KEY ("bankId") REFERENCES "AiExamBank"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiExamAnswer" ADD CONSTRAINT "AiExamAnswer_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "AiExamQuestion"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -108,6 +108,7 @@ model User {
   tutorMessages     TutorMessage[]
   academyMembers    AcademyMember[]
   theoryModules     TheoryModule[]
+  aiExamBanks       AiExamBank[]
 }
 
 model RefreshToken {
@@ -148,6 +149,7 @@ model Course {
   certificates  Certificate[]  @relation("CourseCertificates")
   tutorMessages TutorMessage[] @relation("TutorMessageCourse")
   theoryModules TheoryModule[] @relation("CourseTheoryModules")
+  aiExamBanks   AiExamBank[]   @relation("CourseAiExamBanks")
 }
 
 // ─────────────────────────────────────────────────────────
@@ -181,6 +183,7 @@ model Module {
   examQuestions ExamQuestion[] @relation("ModuleExamQuestions")
   examAttempts  ExamAttempt[]  @relation("ModuleExamAttempts")
   certificates  Certificate[]  @relation("ModuleCertificates")
+  aiExamBanks   AiExamBank[]   @relation("ModuleAiExamBanks")
 
   @@index([courseId, order])
 }
@@ -505,6 +508,8 @@ model ExamAttempt {
   userId            String
   courseId          String?
   moduleId          String?
+  // Si el intento procede de un banco generado por IA del propio alumno
+  aiExamBankId      String?
   numQuestions      Int
   timeLimit         Int? // segundos; null = sin límite
   onlyOnce          Boolean   @default(false)
@@ -514,13 +519,15 @@ model ExamAttempt {
   startedAt         DateTime  @default(now())
   submittedAt       DateTime?
 
-  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
-  course Course? @relation("CourseExamAttempts", fields: [courseId], references: [id])
-  module Module? @relation("ModuleExamAttempts", fields: [moduleId], references: [id])
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  course     Course?     @relation("CourseExamAttempts", fields: [courseId], references: [id])
+  module     Module?     @relation("ModuleExamAttempts", fields: [moduleId], references: [id])
+  aiExamBank AiExamBank? @relation(fields: [aiExamBankId], references: [id], onDelete: SetNull)
 
   @@index([userId])
   @@index([courseId])
   @@index([moduleId])
+  @@index([aiExamBankId])
 }
 
 // ─────────────────────────────────────────────────────────
@@ -575,13 +582,13 @@ model TheoryModule {
 }
 
 model TheoryLesson {
-  id        String           @id @default(cuid())
-  moduleId  String
-  order     Int
-  kind      TheoryLessonKind
-  heading   String
-  body      String?          @db.Text // markdown; null cuando kind=VIDEO
-  youtubeId String? // primario / fallback para registros antiguos (kind=VIDEO)
+  id              String           @id @default(cuid())
+  moduleId        String
+  order           Int
+  kind            TheoryLessonKind
+  heading         String
+  body            String?          @db.Text // markdown; null cuando kind=VIDEO
+  youtubeId       String? // primario / fallback para registros antiguos (kind=VIDEO)
   /// Lista de candidatos de YouTube cuando kind=VIDEO. Estructura:
   /// [{ youtubeId, title, channelTitle, thumbnailUrl, durationSeconds, viewCount, ... }]
   videoCandidates Json?
@@ -589,4 +596,59 @@ model TheoryLesson {
   module TheoryModule @relation(fields: [moduleId], references: [id], onDelete: Cascade)
 
   @@index([moduleId, order])
+}
+
+// ─────────────────────────────────────────────────────────
+// EXÁMENES GENERADOS POR IA (alumno)
+// ─────────────────────────────────────────────────────────
+// Bancos de preguntas generados por la IA en tiempo de ejecución, scoped
+// al alumno (privacidad por construcción vía userId). Estructura paralela
+// a ExamQuestion/ExamAnswer para no contaminar el banco curado por admin.
+
+model AiExamBank {
+  id           String   @id @default(cuid())
+  userId       String
+  courseId     String
+  moduleId     String? // null si es de curso completo
+  topic        String // input crudo del alumno
+  title        String // título limpio generado por la IA
+  numQuestions Int // 5 o 10 (validado en DTO)
+  createdAt    DateTime @default(now())
+
+  user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  course    Course           @relation("CourseAiExamBanks", fields: [courseId], references: [id], onDelete: Cascade)
+  module    Module?          @relation("ModuleAiExamBanks", fields: [moduleId], references: [id], onDelete: Cascade)
+  questions AiExamQuestion[]
+  attempts  ExamAttempt[]
+
+  @@index([userId, createdAt])
+  @@index([userId, courseId])
+}
+
+model AiExamQuestion {
+  id          String       @id @default(cuid())
+  bankId      String
+  text        String       @db.Text
+  type        QuestionType // reusa enum existente (SINGLE, MULTIPLE, TRUE_FALSE)
+  order       Int
+  /// Explicación pedagógica generada por la IA, mostrada tras submit.
+  explanation String?      @db.Text
+
+  bank    AiExamBank     @relation(fields: [bankId], references: [id], onDelete: Cascade)
+  answers AiExamAnswer[]
+
+  @@index([bankId, order])
+}
+
+model AiExamAnswer {
+  id         String  @id @default(cuid())
+  questionId String
+  text       String
+  /// NUNCA exponer en endpoints de inicio o consulta del banco.
+  isCorrect  Boolean @default(false)
+  order      Int
+
+  question AiExamQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
+
+  @@index([questionId, order])
 }

--- a/apps/api/src/exams/ai-exams.service.spec.ts
+++ b/apps/api/src/exams/ai-exams.service.spec.ts
@@ -1,0 +1,318 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ForbiddenException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { AiExamsService } from './ai-exams.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AiProviderService } from '../ai/ai-provider.service';
+
+// Payload válido devuelto por la IA: 5 preguntas mezclando tipos.
+function validPayload(count: number) {
+  const base = [
+    {
+      text: '¿Cuál es la capital de España?',
+      type: 'SINGLE',
+      answers: [
+        { text: 'Madrid', isCorrect: true },
+        { text: 'Barcelona', isCorrect: false },
+        { text: 'Sevilla', isCorrect: false },
+      ],
+      explanation: 'Madrid es la capital política de España.',
+    },
+    {
+      text: 'Selecciona los planetas rocosos.',
+      type: 'MULTIPLE',
+      answers: [
+        { text: 'Mercurio', isCorrect: true },
+        { text: 'Venus', isCorrect: true },
+        { text: 'Júpiter', isCorrect: false },
+        { text: 'Saturno', isCorrect: false },
+      ],
+      explanation: 'Mercurio y Venus son rocosos; Júpiter y Saturno son gaseosos.',
+    },
+    {
+      text: 'El agua hierve a 100°C a nivel del mar.',
+      type: 'TRUE_FALSE',
+      answers: [
+        { text: 'Verdadero', isCorrect: true },
+        { text: 'Falso', isCorrect: false },
+      ],
+      explanation: 'A 1 atm el punto de ebullición del agua es 100°C.',
+    },
+  ];
+  // Repetimos para llegar a `count`
+  const questions = [];
+  for (let i = 0; i < count; i++) questions.push(base[i % base.length]);
+  return { title: 'Examen de prueba', questions };
+}
+
+describe('AiExamsService', () => {
+  let service: AiExamsService;
+
+  const mockPrisma = {
+    course: { findUnique: jest.fn() },
+    module: { findFirst: jest.fn() },
+    enrollment: { findFirst: jest.fn() },
+    aiExamBank: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+    },
+    examAttempt: {
+      create: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+
+  const mockAi = {
+    generate: jest.fn<Promise<string>, [string, number]>(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AiExamsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: AiProviderService, useValue: mockAi },
+      ],
+    }).compile();
+
+    service = module.get<AiExamsService>(AiExamsService);
+    jest.clearAllMocks();
+  });
+
+  // ─── generate ────────────────────────────────────────────────────────────
+
+  describe('generate', () => {
+    const dto = { courseId: 'c1', topic: 'Logaritmos', numQuestions: 5 as const };
+
+    it('lanza NotFoundException si el curso no existe', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null);
+      await expect(service.generate('user1', dto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza ForbiddenException si el alumno no está matriculado', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', title: 'Mate', schoolYear: null });
+      mockPrisma.enrollment.findFirst.mockResolvedValue(null);
+      await expect(service.generate('user1', dto)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('lanza NotFoundException si el módulo no pertenece al curso', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', title: 'Mate', schoolYear: null });
+      mockPrisma.enrollment.findFirst.mockResolvedValue({ id: 'e1' });
+      mockPrisma.module.findFirst.mockResolvedValue(null);
+      await expect(service.generate('user1', { ...dto, moduleId: 'm1' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('lanza error si la IA devuelve número incorrecto de preguntas', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', title: 'Mate', schoolYear: null });
+      mockPrisma.enrollment.findFirst.mockResolvedValue({ id: 'e1' });
+      mockAi.generate.mockResolvedValue(JSON.stringify(validPayload(3))); // pidió 5
+
+      await expect(service.generate('user1', dto)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('lanza error si SINGLE no tiene exactamente 1 respuesta correcta', async () => {
+      const bad = validPayload(5);
+      bad.questions[0] = {
+        ...bad.questions[0],
+        answers: bad.questions[0].answers.map((a) => ({ ...a, isCorrect: true })),
+      };
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', title: 'Mate', schoolYear: null });
+      mockPrisma.enrollment.findFirst.mockResolvedValue({ id: 'e1' });
+      mockAi.generate.mockResolvedValue(JSON.stringify(bad));
+
+      await expect(service.generate('user1', dto)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('persiste el banco y NO devuelve isCorrect en la respuesta', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', title: 'Mate', schoolYear: null });
+      mockPrisma.enrollment.findFirst.mockResolvedValue({ id: 'e1' });
+      mockAi.generate.mockResolvedValue(JSON.stringify(validPayload(5)));
+
+      const created = {
+        id: 'bank1',
+        title: 'Examen de prueba',
+        topic: 'Logaritmos',
+        numQuestions: 5,
+        createdAt: new Date('2026-05-05T12:00:00Z'),
+        course: { id: 'c1', title: 'Mate' },
+        module: null,
+        questions: [
+          {
+            id: 'q1',
+            text: 'pregunta',
+            type: 'SINGLE',
+            order: 0,
+            explanation: 'expl',
+            answers: [
+              { id: 'a1', text: 'A', isCorrect: true, order: 0 },
+              { id: 'a2', text: 'B', isCorrect: false, order: 1 },
+            ],
+          },
+        ],
+      };
+      mockPrisma.aiExamBank.create.mockResolvedValue(created);
+
+      const result = await service.generate('user1', dto);
+
+      expect(mockPrisma.aiExamBank.create).toHaveBeenCalledTimes(1);
+      const callArgs = mockPrisma.aiExamBank.create.mock.calls[0][0];
+      expect(callArgs.data.userId).toBe('user1');
+      expect(callArgs.data.numQuestions).toBe(5);
+      expect(result.id).toBe('bank1');
+      // Crítico: no exponer isCorrect en la respuesta
+      const resultStr = JSON.stringify(result);
+      expect(resultStr).not.toContain('isCorrect');
+    });
+  });
+
+  // ─── listMyBanks ─────────────────────────────────────────────────────────
+
+  describe('listMyBanks', () => {
+    it('devuelve los bancos del alumno con conteos', async () => {
+      mockPrisma.aiExamBank.findMany.mockResolvedValue([
+        {
+          id: 'bank1',
+          title: 'Examen 1',
+          topic: 'Tema',
+          numQuestions: 5,
+          createdAt: new Date('2026-05-05T12:00:00Z'),
+          course: { id: 'c1', title: 'Mate' },
+          module: null,
+          _count: { attempts: 2, questions: 5 },
+        },
+      ]);
+
+      const result = await service.listMyBanks('user1');
+      expect(result).toHaveLength(1);
+      expect(result[0].attemptCount).toBe(2);
+      expect(result[0].questionCount).toBe(5);
+    });
+  });
+
+  // ─── getBank ─────────────────────────────────────────────────────────────
+
+  describe('getBank', () => {
+    it('lanza NotFoundException si no existe', async () => {
+      mockPrisma.aiExamBank.findUnique.mockResolvedValue(null);
+      await expect(service.getBank('user1', 'x')).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza ForbiddenException si el banco es de otro alumno', async () => {
+      mockPrisma.aiExamBank.findUnique.mockResolvedValue({
+        id: 'bank1',
+        userId: 'user2',
+        title: 't',
+        topic: 't',
+        numQuestions: 5,
+        createdAt: new Date(),
+        course: { id: 'c1', title: 'Mate' },
+        module: null,
+        questions: [],
+      });
+      await expect(service.getBank('user1', 'bank1')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('omite isCorrect en la respuesta', async () => {
+      mockPrisma.aiExamBank.findUnique.mockResolvedValue({
+        id: 'bank1',
+        userId: 'user1',
+        title: 't',
+        topic: 't',
+        numQuestions: 5,
+        createdAt: new Date(),
+        course: { id: 'c1', title: 'Mate' },
+        module: null,
+        questions: [
+          {
+            id: 'q1',
+            text: 'pregunta',
+            type: 'SINGLE',
+            order: 0,
+            explanation: 'expl',
+            answers: [{ id: 'a1', text: 'A', isCorrect: true, order: 0 }],
+          },
+        ],
+      });
+      mockPrisma.examAttempt.count.mockResolvedValue(3);
+
+      const result = await service.getBank('user1', 'bank1');
+      expect(result.attemptCount).toBe(3);
+      expect(JSON.stringify(result)).not.toContain('isCorrect');
+      // Tampoco la explicación se filtra antes del submit
+      expect(JSON.stringify(result)).not.toContain('expl');
+    });
+  });
+
+  // ─── deleteBank ──────────────────────────────────────────────────────────
+
+  describe('deleteBank', () => {
+    it('rechaza eliminar bancos de otros alumnos', async () => {
+      mockPrisma.aiExamBank.findUnique.mockResolvedValue({ id: 'bank1', userId: 'user2' });
+      await expect(service.deleteBank('user1', 'bank1')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('elimina si el banco es del propio alumno', async () => {
+      mockPrisma.aiExamBank.findUnique.mockResolvedValue({ id: 'bank1', userId: 'user1' });
+      mockPrisma.aiExamBank.delete.mockResolvedValue({ id: 'bank1' });
+      const result = await service.deleteBank('user1', 'bank1');
+      expect(result).toEqual({ ok: true });
+      expect(mockPrisma.aiExamBank.delete).toHaveBeenCalledWith({ where: { id: 'bank1' } });
+    });
+  });
+
+  // ─── startAttempt ────────────────────────────────────────────────────────
+
+  describe('startAttempt', () => {
+    it('snapshotiza preguntas y NO expone isCorrect', async () => {
+      mockPrisma.aiExamBank.findUnique.mockResolvedValue({
+        id: 'bank1',
+        userId: 'user1',
+        courseId: 'c1',
+        moduleId: null,
+        title: 't',
+        topic: 't',
+        numQuestions: 5,
+        createdAt: new Date(),
+        course: { id: 'c1', title: 'Mate' },
+        module: null,
+        questions: [
+          {
+            id: 'q1',
+            text: 'pregunta',
+            type: 'SINGLE',
+            order: 0,
+            explanation: 'expl',
+            answers: [
+              { id: 'a1', text: 'A', isCorrect: true, order: 0 },
+              { id: 'a2', text: 'B', isCorrect: false, order: 1 },
+            ],
+          },
+        ],
+      });
+      mockPrisma.examAttempt.create.mockResolvedValue({
+        id: 'att1',
+        startedAt: new Date('2026-05-05T12:00:00Z'),
+      });
+
+      const result = await service.startAttempt('user1', 'bank1');
+
+      expect(result.attemptId).toBe('att1');
+      expect(result.bankId).toBe('bank1');
+      // Las respuestas devueltas al cliente no llevan isCorrect
+      const resultStr = JSON.stringify(result);
+      expect(resultStr).not.toContain('isCorrect');
+
+      // El snapshot persistido SÍ debe incluir isCorrect (corrección server-side)
+      const createCall = mockPrisma.examAttempt.create.mock.calls[0][0];
+      expect(createCall.data.aiExamBankId).toBe('bank1');
+      expect(createCall.data.questionsSnapshot[0].answers[0].isCorrect).toBeDefined();
+    });
+  });
+});

--- a/apps/api/src/exams/ai-exams.service.ts
+++ b/apps/api/src/exams/ai-exams.service.ts
@@ -1,0 +1,442 @@
+import {
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { QuestionType } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AiProviderService } from '../ai/ai-provider.service';
+import { GenerateAiExamDto } from './dto/generate-ai-exam.dto';
+
+// ─── Tipos del payload IA ────────────────────────────────────────────────────
+
+export type AiExamQuestionType = 'SINGLE' | 'MULTIPLE' | 'TRUE_FALSE';
+
+interface AiAnswerPayload {
+  text: string;
+  isCorrect: boolean;
+}
+
+interface AiQuestionPayload {
+  text: string;
+  type: AiExamQuestionType;
+  answers: AiAnswerPayload[];
+  explanation?: string;
+}
+
+interface AiExamPayload {
+  title: string;
+  questions: AiQuestionPayload[];
+}
+
+// ─── Snapshot que vive dentro de ExamAttempt.questionsSnapshot ──────────────
+
+interface QuestionSnapshot {
+  id: string;
+  text: string;
+  type: string;
+  answers: { id: string; text: string; isCorrect: boolean }[];
+}
+
+// Fisher-Yates shuffle
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/**
+ * Servicio de exámenes generados por IA por el propio alumno.
+ *
+ * El alumno elige curso, módulo (opcional), tema libre y nº de preguntas (5 o
+ * 10). La IA produce un banco con preguntas tipo SINGLE/MULTIPLE/TRUE_FALSE
+ * que se persiste scoped a `userId` (similar a TheoryModule). El alumno
+ * puede repetir el banco las veces que quiera; cada toma crea un
+ * `ExamAttempt` enlazado al banco vía `aiExamBankId`.
+ */
+@Injectable()
+export class AiExamsService {
+  private readonly logger = new Logger(AiExamsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ai: AiProviderService,
+  ) {}
+
+  // ─── Generar y persistir un nuevo banco ─────────────────────────────────
+
+  async generate(userId: string, dto: GenerateAiExamDto) {
+    const course = await this.prisma.course.findUnique({
+      where: { id: dto.courseId },
+      include: { schoolYear: true },
+    });
+    if (!course) throw new NotFoundException(`Curso "${dto.courseId}" no encontrado`);
+
+    const enrollment = await this.prisma.enrollment.findFirst({
+      where: { userId, courseId: dto.courseId },
+    });
+    if (!enrollment) throw new ForbiddenException('No estás matriculado en este curso');
+
+    let moduleTitle: string | undefined;
+    if (dto.moduleId) {
+      const module = await this.prisma.module.findFirst({
+        where: { id: dto.moduleId, courseId: dto.courseId },
+        select: { id: true, title: true },
+      });
+      if (!module) {
+        throw new NotFoundException(`Módulo "${dto.moduleId}" no encontrado en este curso`);
+      }
+      moduleTitle = module.title;
+    }
+
+    const prompt = this.buildPrompt(
+      course.title,
+      course.schoolYear?.label ?? '',
+      moduleTitle,
+      dto.topic,
+      dto.numQuestions,
+    );
+
+    this.logger.log(
+      `Generando examen IA: ${dto.numQuestions} preguntas sobre "${dto.topic}" (curso "${course.title}"${moduleTitle ? `, módulo "${moduleTitle}"` : ''})`,
+    );
+
+    const maxTokens = Math.min(8000, 600 + dto.numQuestions * 350);
+    const text = await this.ai.generate(prompt, maxTokens);
+    const payload = this.parseAndValidate(text, dto.numQuestions);
+
+    // Persistir banco + preguntas + respuestas en una transacción
+    const bank = await this.prisma.aiExamBank.create({
+      data: {
+        userId,
+        courseId: dto.courseId,
+        moduleId: dto.moduleId ?? null,
+        topic: dto.topic,
+        title: payload.title.trim().slice(0, 200) || dto.topic,
+        numQuestions: dto.numQuestions,
+        questions: {
+          create: payload.questions.map((q, qIdx) => ({
+            text: q.text,
+            type: q.type as QuestionType,
+            order: qIdx,
+            explanation: q.explanation ?? null,
+            answers: {
+              create: q.answers.map((a, aIdx) => ({
+                text: a.text,
+                isCorrect: a.isCorrect,
+                order: aIdx,
+              })),
+            },
+          })),
+        },
+      },
+      include: this.bankInclude(),
+    });
+
+    return this.serializeBank(bank, { includeIsCorrect: false, attemptCount: 0 });
+  }
+
+  // ─── Listar bancos del alumno ───────────────────────────────────────────
+
+  async listMyBanks(userId: string) {
+    const banks = await this.prisma.aiExamBank.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        course: { select: { id: true, title: true } },
+        module: { select: { id: true, title: true } },
+        _count: { select: { attempts: true, questions: true } },
+      },
+    });
+
+    return banks.map((b) => ({
+      id: b.id,
+      title: b.title,
+      topic: b.topic,
+      numQuestions: b.numQuestions,
+      createdAt: b.createdAt.toISOString(),
+      course: { id: b.course.id, title: b.course.title },
+      module: b.module ? { id: b.module.id, title: b.module.title } : null,
+      questionCount: b._count.questions,
+      attemptCount: b._count.attempts,
+    }));
+  }
+
+  // ─── Detalle de un banco (sin isCorrect) ───────────────────────────────
+
+  async getBank(userId: string, bankId: string) {
+    const bank = await this.prisma.aiExamBank.findUnique({
+      where: { id: bankId },
+      include: this.bankInclude(),
+    });
+    if (!bank) throw new NotFoundException('Banco no encontrado');
+    if (bank.userId !== userId) throw new ForbiddenException('No autorizado');
+
+    const attemptCount = await this.prisma.examAttempt.count({
+      where: { aiExamBankId: bankId, userId },
+    });
+
+    return this.serializeBank(bank, { includeIsCorrect: false, attemptCount });
+  }
+
+  // ─── Eliminar un banco ─────────────────────────────────────────────────
+
+  async deleteBank(userId: string, bankId: string) {
+    const bank = await this.prisma.aiExamBank.findUnique({
+      where: { id: bankId },
+      select: { id: true, userId: true },
+    });
+    if (!bank) throw new NotFoundException('Banco no encontrado');
+    if (bank.userId !== userId) throw new ForbiddenException('No autorizado');
+
+    await this.prisma.aiExamBank.delete({ where: { id: bankId } });
+    return { ok: true };
+  }
+
+  // ─── Iniciar un intento desde un banco ────────────────────────────────
+
+  async startAttempt(userId: string, bankId: string) {
+    const bank = await this.prisma.aiExamBank.findUnique({
+      where: { id: bankId },
+      include: this.bankInclude(),
+    });
+    if (!bank) throw new NotFoundException('Banco no encontrado');
+    if (bank.userId !== userId) throw new ForbiddenException('No autorizado');
+
+    // Snapshot con respuestas barajadas dentro de cada pregunta
+    const questionsSnapshot: QuestionSnapshot[] = bank.questions.map((q) => ({
+      id: q.id,
+      text: q.text,
+      type: q.type,
+      answers: shuffle(q.answers.map((a) => ({ id: a.id, text: a.text, isCorrect: a.isCorrect }))),
+    }));
+
+    const attempt = await this.prisma.examAttempt.create({
+      data: {
+        userId,
+        courseId: bank.courseId,
+        moduleId: bank.moduleId,
+        aiExamBankId: bank.id,
+        numQuestions: bank.numQuestions,
+        questionsSnapshot: questionsSnapshot as object[],
+        answers: [],
+      },
+    });
+
+    return {
+      attemptId: attempt.id,
+      bankId: bank.id,
+      title: bank.title,
+      questions: questionsSnapshot.map((q) => ({
+        id: q.id,
+        text: q.text,
+        type: q.type,
+        answers: q.answers.map((a) => ({ id: a.id, text: a.text })),
+      })),
+      numQuestions: bank.numQuestions,
+      timeLimit: null,
+      onlyOnce: false,
+      startedAt: attempt.startedAt.toISOString(),
+    };
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────────
+
+  private bankInclude() {
+    return {
+      course: { select: { id: true, title: true } },
+      module: { select: { id: true, title: true } },
+      questions: {
+        orderBy: { order: 'asc' as const },
+        include: {
+          answers: { orderBy: { order: 'asc' as const } },
+        },
+      },
+    };
+  }
+
+  private serializeBank(
+    bank: {
+      id: string;
+      title: string;
+      topic: string;
+      numQuestions: number;
+      createdAt: Date;
+      course: { id: string; title: string };
+      module: { id: string; title: string } | null;
+      questions: {
+        id: string;
+        text: string;
+        type: string;
+        order: number;
+        explanation: string | null;
+        answers: { id: string; text: string; isCorrect: boolean; order: number }[];
+      }[];
+    },
+    opts: { includeIsCorrect: boolean; attemptCount: number },
+  ) {
+    return {
+      id: bank.id,
+      title: bank.title,
+      topic: bank.topic,
+      numQuestions: bank.numQuestions,
+      createdAt: bank.createdAt.toISOString(),
+      course: bank.course,
+      module: bank.module,
+      attemptCount: opts.attemptCount,
+      questions: bank.questions.map((q) => ({
+        id: q.id,
+        text: q.text,
+        type: q.type,
+        order: q.order,
+        ...(opts.includeIsCorrect && { explanation: q.explanation }),
+        answers: q.answers.map((a) => ({
+          id: a.id,
+          text: a.text,
+          order: a.order,
+          ...(opts.includeIsCorrect && { isCorrect: a.isCorrect }),
+        })),
+      })),
+    };
+  }
+
+  private parseAndValidate(text: string, expectedCount: number): AiExamPayload {
+    let parsed: unknown;
+    try {
+      const raw = text
+        .trim()
+        .replace(/^```json\n?/, '')
+        .replace(/\n?```$/, '');
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      this.logger.error('Error al parsear JSON de IA (examen):', text);
+      throw new InternalServerErrorException(
+        `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
+      );
+    }
+
+    const p = parsed as Partial<AiExamPayload>;
+    if (!p || typeof p.title !== 'string' || !Array.isArray(p.questions)) {
+      throw new InternalServerErrorException(
+        'La respuesta de la IA no tiene el formato esperado (faltan title o questions)',
+      );
+    }
+    if (p.questions.length !== expectedCount) {
+      throw new InternalServerErrorException(
+        `La IA devolvió ${p.questions.length} preguntas (se esperaban ${expectedCount})`,
+      );
+    }
+
+    const validTypes: AiExamQuestionType[] = ['SINGLE', 'MULTIPLE', 'TRUE_FALSE'];
+    for (const [idx, q] of p.questions.entries()) {
+      if (!q || typeof q.text !== 'string' || q.text.trim().length === 0) {
+        throw new InternalServerErrorException(`Pregunta ${idx + 1}: texto inválido`);
+      }
+      if (!validTypes.includes(q.type)) {
+        throw new InternalServerErrorException(`Pregunta ${idx + 1}: tipo inválido "${q.type}"`);
+      }
+      if (!Array.isArray(q.answers) || q.answers.length < 2) {
+        throw new InternalServerErrorException(
+          `Pregunta ${idx + 1}: necesita al menos 2 respuestas`,
+        );
+      }
+      const correctCount = q.answers.filter((a) => a?.isCorrect === true).length;
+      if (q.type === 'MULTIPLE') {
+        if (correctCount < 2) {
+          throw new InternalServerErrorException(
+            `Pregunta ${idx + 1} (MULTIPLE): debe tener 2 o más respuestas correctas`,
+          );
+        }
+      } else {
+        if (correctCount !== 1) {
+          throw new InternalServerErrorException(
+            `Pregunta ${idx + 1} (${q.type}): debe tener exactamente 1 respuesta correcta`,
+          );
+        }
+      }
+      if (q.type === 'TRUE_FALSE' && q.answers.length !== 2) {
+        throw new InternalServerErrorException(
+          `Pregunta ${idx + 1} (TRUE_FALSE): debe tener exactamente 2 respuestas`,
+        );
+      }
+      for (const [aIdx, a] of q.answers.entries()) {
+        if (!a || typeof a.text !== 'string' || typeof a.isCorrect !== 'boolean') {
+          throw new InternalServerErrorException(
+            `Pregunta ${idx + 1}, respuesta ${aIdx + 1}: formato inválido`,
+          );
+        }
+      }
+    }
+
+    return p as AiExamPayload;
+  }
+
+  private buildPrompt(
+    courseTitle: string,
+    schoolYearLabel: string,
+    moduleTitle: string | undefined,
+    topic: string,
+    count: number,
+  ): string {
+    return `Genera un examen en español sobre el tema "${topic}".
+
+Curso: "${courseTitle}"
+${schoolYearLabel ? `Nivel educativo: "${schoolYearLabel}" (sistema educativo español)` : ''}
+${moduleTitle ? `Módulo: "${moduleTitle}"` : ''}
+Número de preguntas: ${count}
+
+Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, sin explicaciones adicionales fuera del JSON):
+{
+  "title": "Título breve del examen (máx. 80 caracteres)",
+  "questions": [
+    {
+      "text": "Enunciado claro de la pregunta",
+      "type": "SINGLE",
+      "answers": [
+        { "text": "opción A", "isCorrect": true },
+        { "text": "opción B", "isCorrect": false },
+        { "text": "opción C", "isCorrect": false },
+        { "text": "opción D", "isCorrect": false }
+      ],
+      "explanation": "Por qué la opción correcta es la correcta (1-2 frases pedagógicas)"
+    },
+    {
+      "text": "Enunciado de pregunta de respuesta múltiple",
+      "type": "MULTIPLE",
+      "answers": [
+        { "text": "opción A", "isCorrect": true },
+        { "text": "opción B", "isCorrect": true },
+        { "text": "opción C", "isCorrect": false },
+        { "text": "opción D", "isCorrect": false }
+      ],
+      "explanation": "Justificación pedagógica"
+    },
+    {
+      "text": "Afirmación a juzgar como verdadera o falsa",
+      "type": "TRUE_FALSE",
+      "answers": [
+        { "text": "Verdadero", "isCorrect": true },
+        { "text": "Falso", "isCorrect": false }
+      ],
+      "explanation": "Por qué es verdadera (o falsa)"
+    }
+  ]
+}
+
+Reglas estrictas:
+- Devuelve EXACTAMENTE ${count} preguntas — ni una más, ni una menos.
+- Mezcla los tres tipos (SINGLE, MULTIPLE, TRUE_FALSE) cuando el tema lo permita; SINGLE debería ser mayoritario.
+- SINGLE: 3 o 4 opciones, exactamente 1 con isCorrect=true.
+- MULTIPLE: 4 opciones, 2 o 3 con isCorrect=true.
+- TRUE_FALSE: exactamente 2 opciones ["Verdadero", "Falso"], solo una con isCorrect=true.
+- Los enunciados deben ser claros, precisos y adecuados al nivel ${schoolYearLabel || 'del curso'}.
+- Contenido curricular real relacionado con "${topic}".
+- "explanation" pedagógica y breve (1-2 frases) — el alumno la verá tras corregir.
+- Solo devuelve JSON puro, sin markdown ni texto adicional.`;
+  }
+}

--- a/apps/api/src/exams/dto/generate-ai-exam.dto.ts
+++ b/apps/api/src/exams/dto/generate-ai-exam.dto.ts
@@ -1,0 +1,20 @@
+import { IsIn, IsInt, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class GenerateAiExamDto {
+  @IsString()
+  courseId: string;
+
+  @IsString()
+  @IsOptional()
+  moduleId?: string;
+
+  @IsString()
+  @MinLength(3, { message: 'El tema debe tener al menos 3 caracteres' })
+  @MaxLength(500, { message: 'El tema es demasiado largo' })
+  topic: string;
+
+  /// Solo se aceptan 5 o 10 preguntas — fija el alcance del examen.
+  @IsInt()
+  @IsIn([5, 10], { message: 'numQuestions debe ser 5 o 10' })
+  numQuestions: 5 | 10;
+}

--- a/apps/api/src/exams/exams.controller.ts
+++ b/apps/api/src/exams/exams.controller.ts
@@ -1,22 +1,19 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Param,
-  Body,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Body, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { ExamsService } from './exams.service';
+import { AiExamsService } from './ai-exams.service';
 import { StartExamDto } from './dto/start-exam.dto';
 import { SubmitExamDto } from './dto/submit-exam.dto';
+import { GenerateAiExamDto } from './dto/generate-ai-exam.dto';
 
 @Controller('exams')
 @UseGuards(JwtAuthGuard)
 export class ExamsController {
-  constructor(private readonly examsService: ExamsService) {}
+  constructor(
+    private readonly examsService: ExamsService,
+    private readonly aiExamsService: AiExamsService,
+  ) {}
 
   @Get('available')
   getAvailable(@CurrentUser() user: { id: string }) {
@@ -35,6 +32,35 @@ export class ExamsController {
   @Post('start')
   startExam(@Body() dto: StartExamDto, @CurrentUser() user: { id: string }) {
     return this.examsService.startExam(user.id, dto);
+  }
+
+  // ─── Exámenes generados por IA (alumno) ─────────────────────────────────
+  // Las rutas /ai/* van ANTES de :attemptId/submit para que NestJS no las
+  // confunda con un attemptId.
+
+  @Post('ai/generate')
+  generateAiExam(@Body() dto: GenerateAiExamDto, @CurrentUser() user: { id: string }) {
+    return this.aiExamsService.generate(user.id, dto);
+  }
+
+  @Get('ai/my-banks')
+  listMyAiBanks(@CurrentUser() user: { id: string }) {
+    return this.aiExamsService.listMyBanks(user.id);
+  }
+
+  @Get('ai/:bankId')
+  getAiBank(@Param('bankId') bankId: string, @CurrentUser() user: { id: string }) {
+    return this.aiExamsService.getBank(user.id, bankId);
+  }
+
+  @Delete('ai/:bankId')
+  deleteAiBank(@Param('bankId') bankId: string, @CurrentUser() user: { id: string }) {
+    return this.aiExamsService.deleteBank(user.id, bankId);
+  }
+
+  @Post('ai/:bankId/start')
+  startAiAttempt(@Param('bankId') bankId: string, @CurrentUser() user: { id: string }) {
+    return this.aiExamsService.startAttempt(user.id, bankId);
   }
 
   @Post(':attemptId/submit')

--- a/apps/api/src/exams/exams.module.ts
+++ b/apps/api/src/exams/exams.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { ExamsController } from './exams.controller';
 import { ExamsService } from './exams.service';
+import { AiExamsService } from './ai-exams.service';
 import { CertificatesModule } from '../certificates/certificates.module';
 
 @Module({
   imports: [PrismaModule, CertificatesModule],
   controllers: [ExamsController],
-  providers: [ExamsService],
+  providers: [ExamsService, AiExamsService],
 })
 export class ExamsModule {}

--- a/apps/web/src/api/exams.api.ts
+++ b/apps/web/src/api/exams.api.ts
@@ -1,9 +1,5 @@
 import api from '../lib/axios';
-import type {
-  ExamBankInfo,
-  ExamAttemptStarted,
-  ExamAttemptResult,
-} from '@vkbacademy/shared';
+import type { ExamBankInfo, ExamAttemptStarted, ExamAttemptResult } from '@vkbacademy/shared';
 
 export interface StartExamPayload {
   courseId?: string;
@@ -71,9 +67,47 @@ export interface AvailableExams {
   modules: AvailableExamModule[];
 }
 
+// ─── Exámenes generados por IA (alumno) ──────────────────────────────────────
+
+export interface AiExamBankSummary {
+  id: string;
+  title: string;
+  topic: string;
+  numQuestions: 5 | 10;
+  createdAt: string;
+  course: { id: string; title: string };
+  module: { id: string; title: string } | null;
+  questionCount: number;
+  attemptCount: number;
+}
+
+export interface AiExamBankDetail {
+  id: string;
+  title: string;
+  topic: string;
+  numQuestions: 5 | 10;
+  createdAt: string;
+  course: { id: string; title: string };
+  module: { id: string; title: string } | null;
+  attemptCount: number;
+  questions: {
+    id: string;
+    text: string;
+    type: 'SINGLE' | 'MULTIPLE' | 'TRUE_FALSE';
+    order: number;
+    answers: { id: string; text: string; order: number }[];
+  }[];
+}
+
+export interface GenerateAiExamPayload {
+  courseId: string;
+  moduleId?: string;
+  topic: string;
+  numQuestions: 5 | 10;
+}
+
 export const examsApi = {
-  getAvailable: () =>
-    api.get<AvailableExams>('/exams/available').then((r) => r.data),
+  getAvailable: () => api.get<AvailableExams>('/exams/available').then((r) => r.data),
 
   getBankInfo: (params: { courseId?: string; moduleId?: string }) =>
     api.get<ExamBankInfo>('/exams/info', { params }).then((r) => r.data),
@@ -86,4 +120,19 @@ export const examsApi = {
 
   getHistory: (params: { courseId?: string; moduleId?: string }) =>
     api.get<ExamAttemptHistoryItem[]>('/exams/history', { params }).then((r) => r.data),
+
+  // ── IA ──
+  generateAiExam: (payload: GenerateAiExamPayload) =>
+    api.post<AiExamBankDetail>('/exams/ai/generate', payload).then((r) => r.data),
+
+  listMyAiBanks: () => api.get<AiExamBankSummary[]>('/exams/ai/my-banks').then((r) => r.data),
+
+  getAiBank: (bankId: string) =>
+    api.get<AiExamBankDetail>(`/exams/ai/${bankId}`).then((r) => r.data),
+
+  deleteAiBank: (bankId: string) =>
+    api.delete<{ ok: true }>(`/exams/ai/${bankId}`).then((r) => r.data),
+
+  startAiAttempt: (bankId: string) =>
+    api.post<ExamAttemptStarted>(`/exams/ai/${bankId}/start`).then((r) => r.data),
 };

--- a/apps/web/src/hooks/useExams.ts
+++ b/apps/web/src/hooks/useExams.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { examsApi } from '../api/exams.api';
-import type { StartExamPayload, SubmitExamPayload } from '../api/exams.api';
+import type { StartExamPayload, SubmitExamPayload, GenerateAiExamPayload } from '../api/exams.api';
 
 // ─── Hooks alumno ─────────────────────────────────────────────────────────────
 
@@ -52,8 +52,45 @@ export function useSubmitExam(attemptId: string, courseId?: string, moduleId?: s
       const scope = courseId ? `course-${courseId}` : `module-${moduleId}`;
       queryClient.invalidateQueries({ queryKey: ['exam-history', scope] });
       queryClient.invalidateQueries({ queryKey: ['exam-bank', scope] });
+      // Invalidar bancos IA para refrescar attemptCount
+      queryClient.invalidateQueries({ queryKey: ['ai-exam-banks'] });
       // Invalidar certificados para que se recarguen tras el submit
       queryClient.invalidateQueries({ queryKey: ['certificates', 'my'] });
     },
+  });
+}
+
+// ─── Hooks de exámenes generados por IA ─────────────────────────────────────
+
+export function useMyAiExamBanks() {
+  return useQuery({
+    queryKey: ['ai-exam-banks'],
+    queryFn: () => examsApi.listMyAiBanks(),
+  });
+}
+
+export function useGenerateAiExam() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: GenerateAiExamPayload) => examsApi.generateAiExam(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ai-exam-banks'] });
+    },
+  });
+}
+
+export function useDeleteAiExamBank() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (bankId: string) => examsApi.deleteAiBank(bankId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ai-exam-banks'] });
+    },
+  });
+}
+
+export function useStartAiAttempt() {
+  return useMutation({
+    mutationFn: (bankId: string) => examsApi.startAiAttempt(bankId),
   });
 }

--- a/apps/web/src/pages/ExamPage.tsx
+++ b/apps/web/src/pages/ExamPage.tsx
@@ -1,6 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { useExamBankInfo, useStartExam, useSubmitExam, useExamHistory } from '../hooks/useExams';
+import {
+  useExamBankInfo,
+  useStartExam,
+  useSubmitExam,
+  useExamHistory,
+  useStartAiAttempt,
+} from '../hooks/useExams';
 import { useMyCertificates } from '../hooks/useCertificates';
 import { downloadCertificatePdf } from '../utils/certificatePdf';
 import type { ExamAttemptStarted, ExamAttemptResult, ExamQuestionPublic } from '@vkbacademy/shared';
@@ -69,19 +75,30 @@ function ConfigStep({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' as const, gap: 20 }}>
-
       {/* Card de configuracion */}
-      <div
-        className="vkb-card"
-        style={{ padding: '28px' }}
-      >
-        <h3 style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--color-text)', marginBottom: 20 }}>
+      <div className="vkb-card" style={{ padding: '28px' }}>
+        <h3
+          style={{
+            fontSize: '1rem',
+            fontWeight: 700,
+            color: 'var(--color-text)',
+            marginBottom: 20,
+          }}
+        >
           {scopeTitle}
         </h3>
 
         {/* Numero de preguntas */}
         <div style={{ marginBottom: 20 }}>
-          <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-muted)', marginBottom: 8 }}>
+          <label
+            style={{
+              display: 'block',
+              fontSize: '0.85rem',
+              fontWeight: 600,
+              color: 'var(--color-text-muted)',
+              marginBottom: 8,
+            }}
+          >
             Numero de preguntas (maximo: {maxQuestions})
           </label>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
@@ -96,7 +113,14 @@ function ConfigStep({
             <div className="progress-bar" style={{ flex: 1 }}>
               <div className="progress-fill" style={{ width: `${(numQ / maxQuestions) * 100}%` }} />
             </div>
-            <span style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', fontWeight: 600, whiteSpace: 'nowrap' as const }}>
+            <span
+              style={{
+                fontSize: '0.8rem',
+                color: 'var(--color-text-muted)',
+                fontWeight: 600,
+                whiteSpace: 'nowrap' as const,
+              }}
+            >
               {numQ}/{maxQuestions}
             </span>
           </div>
@@ -114,7 +138,9 @@ function ConfigStep({
           <span style={{ fontWeight: 500 }}>Limite de tiempo</span>
         </label>
         {useTimer && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0 12px 26px' }}>
+          <div
+            style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0 12px 26px' }}
+          >
             <input
               type="number"
               min={1}
@@ -152,7 +178,14 @@ function ConfigStep({
       {/* Historial reciente */}
       {recentAttempts.length > 0 && (
         <div className="vkb-card" style={{ padding: '24px' }}>
-          <h4 style={{ fontSize: '0.9rem', fontWeight: 700, color: 'var(--color-text)', marginBottom: 16 }}>
+          <h4
+            style={{
+              fontSize: '0.9rem',
+              fontWeight: 700,
+              color: 'var(--color-text)',
+              marginBottom: 16,
+            }}
+          >
             Intentos recientes
           </h4>
           <div style={{ display: 'flex', flexDirection: 'column' as const, gap: 0 }}>
@@ -203,9 +236,7 @@ function InProgressStep({
   isLoading: boolean;
 }) {
   const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string>>({});
-  const [secondsLeft, setSecondsLeft] = useState<number | null>(
-    attempt.timeLimit ?? null,
-  );
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(attempt.timeLimit ?? null);
 
   const handleSubmit = useCallback(() => {
     const answers = Object.entries(selectedAnswers).map(([questionId, answerId]) => ({
@@ -300,12 +331,16 @@ function InProgressStep({
       {attempt.questions.map((q, idx) => {
         const chosen = selectedAnswers[q.id];
         return (
-          <div
-            key={q.id}
-            className="vkb-card"
-            style={{ padding: '22px 24px', marginBottom: 16 }}
-          >
-            <div style={{ fontWeight: 700, marginBottom: 16, color: 'var(--color-text)', fontSize: '0.975rem', lineHeight: 1.4 }}>
+          <div key={q.id} className="vkb-card" style={{ padding: '22px 24px', marginBottom: 16 }}>
+            <div
+              style={{
+                fontWeight: 700,
+                marginBottom: 16,
+                color: 'var(--color-text)',
+                fontSize: '0.975rem',
+                lineHeight: 1.4,
+              }}
+            >
               <span style={{ color: 'var(--color-primary)', marginRight: 8, fontWeight: 900 }}>
                 {idx + 1}.
               </span>
@@ -331,9 +366,7 @@ function InProgressStep({
                       border: isSelected
                         ? '1.5px solid var(--color-primary)'
                         : '1.5px solid rgba(234,88,12,0.20)',
-                      background: isSelected
-                        ? 'rgba(234,88,12,0.12)'
-                        : 'var(--color-bg)',
+                      background: isSelected ? 'rgba(234,88,12,0.12)' : 'var(--color-bg)',
                       color: isSelected ? 'var(--color-primary)' : 'var(--color-text)',
                       cursor: locked && !isSelected ? 'not-allowed' : 'pointer',
                       opacity: locked && !isSelected ? 0.5 : 1,
@@ -343,14 +376,17 @@ function InProgressStep({
                     }}
                     onMouseEnter={(e) => {
                       if (!isSelected && !(locked && !isSelected)) {
-                        (e.currentTarget as HTMLButtonElement).style.background = 'rgba(234,88,12,0.06)';
-                        (e.currentTarget as HTMLButtonElement).style.borderColor = 'rgba(234,88,12,0.40)';
+                        (e.currentTarget as HTMLButtonElement).style.background =
+                          'rgba(234,88,12,0.06)';
+                        (e.currentTarget as HTMLButtonElement).style.borderColor =
+                          'rgba(234,88,12,0.40)';
                       }
                     }}
                     onMouseLeave={(e) => {
                       if (!isSelected) {
                         (e.currentTarget as HTMLButtonElement).style.background = 'var(--color-bg)';
-                        (e.currentTarget as HTMLButtonElement).style.borderColor = 'rgba(234,88,12,0.20)';
+                        (e.currentTarget as HTMLButtonElement).style.borderColor =
+                          'rgba(234,88,12,0.20)';
                       }
                     }}
                   >
@@ -400,14 +436,17 @@ function ResultsStep({
   moduleId?: string;
   onRepeat: () => void;
   onBack: () => void;
-  historyItems: { attemptId: string; score: number | null; numQuestions: number; submittedAt: string | null }[];
+  historyItems: {
+    attemptId: string;
+    score: number | null;
+    numQuestions: number;
+    submittedAt: string | null;
+  }[];
 }) {
   const { data: certs } = useMyCertificates();
   const examCertType = courseId ? 'COURSE_EXAM' : 'MODULE_EXAM';
   const examScopeId = courseId ?? moduleId;
-  const examCert = certs?.find(
-    (c) => c.scopeId === examScopeId && c.type === examCertType,
-  );
+  const examCert = certs?.find((c) => c.scopeId === examScopeId && c.type === examCertType);
 
   const passed = result.score >= 50;
 
@@ -480,7 +519,14 @@ function ResultsStep({
 
       {/* Correcciones */}
       <div className="vkb-card" style={{ padding: '24px', marginBottom: 20 }}>
-        <h3 style={{ fontWeight: 700, marginBottom: 16, fontSize: '0.95rem', color: 'var(--color-text)' }}>
+        <h3
+          style={{
+            fontWeight: 700,
+            marginBottom: 16,
+            fontSize: '0.95rem',
+            color: 'var(--color-text)',
+          }}
+        >
           Correcciones
         </h3>
         <div style={{ display: 'flex', flexDirection: 'column' as const, gap: 10 }}>
@@ -496,7 +542,15 @@ function ResultsStep({
                 borderLeftWidth: 4,
               }}
             >
-              <div style={{ fontWeight: 600, marginBottom: 6, fontSize: '0.9rem', color: 'var(--color-text)', lineHeight: 1.4 }}>
+              <div
+                style={{
+                  fontWeight: 600,
+                  marginBottom: 6,
+                  fontSize: '0.9rem',
+                  color: 'var(--color-text)',
+                  lineHeight: 1.4,
+                }}
+              >
                 <span style={{ marginRight: 6, fontSize: '0.85rem' }}>
                   {c.isCorrect ? '✓' : '✗'}
                 </span>
@@ -504,15 +558,25 @@ function ResultsStep({
               </div>
 
               {c.selectedAnswerText ? (
-                <div style={{ fontSize: '0.82rem', color: c.isCorrect ? 'var(--color-text-muted)' : '#dc2626', marginBottom: c.isCorrect ? 0 : 4 }}>
+                <div
+                  style={{
+                    fontSize: '0.82rem',
+                    color: c.isCorrect ? 'var(--color-text-muted)' : '#dc2626',
+                    marginBottom: c.isCorrect ? 0 : 4,
+                  }}
+                >
                   Tu respuesta: {c.selectedAnswerText}
                 </div>
               ) : (
-                <div style={{ fontSize: '0.82rem', color: 'var(--color-text-muted)' }}>Sin respuesta</div>
+                <div style={{ fontSize: '0.82rem', color: 'var(--color-text-muted)' }}>
+                  Sin respuesta
+                </div>
               )}
 
               {!c.isCorrect && c.correctAnswerText && (
-                <div style={{ fontSize: '0.82rem', color: '#16a34a', fontWeight: 600, marginTop: 4 }}>
+                <div
+                  style={{ fontSize: '0.82rem', color: '#16a34a', fontWeight: 600, marginTop: 4 }}
+                >
                   Respuesta correcta: {c.correctAnswerText}
                 </div>
               )}
@@ -524,7 +588,14 @@ function ResultsStep({
       {/* Historial */}
       {historyItems.filter((h) => h.submittedAt).length > 1 && (
         <div className="vkb-card" style={{ padding: '24px', marginBottom: 24 }}>
-          <h4 style={{ fontWeight: 700, marginBottom: 14, fontSize: '0.9rem', color: 'var(--color-text)' }}>
+          <h4
+            style={{
+              fontWeight: 700,
+              marginBottom: 14,
+              fontSize: '0.9rem',
+              color: 'var(--color-text)',
+            }}
+          >
             Historial de intentos
           </h4>
           {historyItems
@@ -567,10 +638,7 @@ function ResultsStep({
         <button className="btn btn-primary" onClick={onRepeat}>
           Repetir examen
         </button>
-        <button
-          className="btn btn-ghost"
-          onClick={() => downloadExamPdf(result, scopeTitle)}
-        >
+        <button className="btn btn-ghost" onClick={() => downloadExamPdf(result, scopeTitle)}>
           Descargar PDF examen
         </button>
         {examCert && (
@@ -599,23 +667,53 @@ export default function ExamPage() {
 
   const courseId = searchParams.get('courseId') ?? undefined;
   const moduleId = searchParams.get('moduleId') ?? undefined;
+  const aiBankId = searchParams.get('aiBankId') ?? undefined;
+  const isAiMode = !!aiBankId;
 
-  const [examState, setExamState] = useState<ExamState>('config');
+  const [examState, setExamState] = useState<ExamState>(isAiMode ? 'in-progress' : 'config');
   const [currentAttempt, setCurrentAttempt] = useState<ExamAttemptStarted | null>(null);
   const [result, setResult] = useState<ExamAttemptResult | null>(null);
+  const [aiStartError, setAiStartError] = useState<string | null>(null);
+  const aiStartedRef = useRef(false);
 
-  const { data: bankInfo, isLoading: bankLoading, isError: bankError } = useExamBankInfo(courseId, moduleId);
+  const {
+    data: bankInfo,
+    isLoading: bankLoading,
+    isError: bankError,
+  } = useExamBankInfo(isAiMode ? undefined : courseId, isAiMode ? undefined : moduleId);
   const { data: history } = useExamHistory(courseId, moduleId);
 
   const startMut = useStartExam();
-  const submitMut = useSubmitExam(
-    currentAttempt?.attemptId ?? '',
-    courseId,
-    moduleId,
-  );
+  const startAiMut = useStartAiAttempt();
+  const submitMut = useSubmitExam(currentAttempt?.attemptId ?? '', courseId, moduleId);
+
+  // ── Auto-arranque del examen IA: lanza el primer intento al montar ──
+  useEffect(() => {
+    if (!isAiMode || aiStartedRef.current) return;
+    aiStartedRef.current = true;
+    (async () => {
+      try {
+        const attempt = await startAiMut.mutateAsync(aiBankId!);
+        setCurrentAttempt(attempt);
+      } catch (err) {
+        const message =
+          err && typeof err === 'object' && 'message' in err
+            ? String((err as { message: unknown }).message)
+            : 'No se pudo iniciar el examen';
+        setAiStartError(message);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aiBankId, isAiMode]);
 
   const handleStart = async (numQuestions: number, timeLimit?: number, onlyOnce?: boolean) => {
-    const attempt = await startMut.mutateAsync({ courseId, moduleId, numQuestions, timeLimit, onlyOnce });
+    const attempt = await startMut.mutateAsync({
+      courseId,
+      moduleId,
+      numQuestions,
+      timeLimit,
+      onlyOnce,
+    });
     setCurrentAttempt(attempt);
     setExamState('in-progress');
   };
@@ -627,16 +725,110 @@ export default function ExamPage() {
     setExamState('results');
   };
 
-  const handleRepeat = () => {
+  const handleRepeat = async () => {
+    if (isAiMode) {
+      setResult(null);
+      setCurrentAttempt(null);
+      setExamState('in-progress');
+      try {
+        const attempt = await startAiMut.mutateAsync(aiBankId!);
+        setCurrentAttempt(attempt);
+      } catch (err) {
+        const message =
+          err && typeof err === 'object' && 'message' in err
+            ? String((err as { message: unknown }).message)
+            : 'No se pudo iniciar el examen';
+        setAiStartError(message);
+      }
+      return;
+    }
     setCurrentAttempt(null);
     setResult(null);
     setExamState('config');
   };
 
   const handleBack = () => {
+    if (isAiMode) {
+      navigate('/my-exams');
+      return;
+    }
     if (courseId) navigate(`/courses/${courseId}`);
     else navigate('/courses');
   };
+
+  // ── Camino IA: no carga bankInfo, renderiza in-progress / results directos ──
+  if (isAiMode) {
+    return (
+      <div style={{ maxWidth: 780, margin: '0 auto' }}>
+        <div className="page-hero animate-in">
+          {examState !== 'in-progress' && (
+            <button
+              onClick={handleBack}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: 'rgba(255,255,255,0.50)',
+                cursor: 'pointer',
+                fontSize: '0.85rem',
+                padding: 0,
+                marginBottom: 14,
+              }}
+            >
+              Volver a mis exámenes
+            </button>
+          )}
+          <h1 className="hero-title" style={{ fontSize: '1.6rem' }}>
+            Examen IA
+          </h1>
+          <p className="hero-subtitle">
+            {currentAttempt ? 'Examen generado por IA' : 'Preparando preguntas...'}
+          </p>
+        </div>
+
+        {aiStartError && (
+          <div
+            className="vkb-card"
+            style={{ padding: '24px', borderColor: 'var(--color-error, #dc2626)' }}
+          >
+            <p style={{ color: 'var(--color-error, #dc2626)', margin: 0 }}>{aiStartError}</p>
+            <button
+              className="btn btn-ghost"
+              style={{ marginTop: 14 }}
+              onClick={() => navigate('/my-exams')}
+            >
+              Volver a mis exámenes
+            </button>
+          </div>
+        )}
+
+        {!aiStartError && examState === 'in-progress' && !currentAttempt && (
+          <div className="vkb-card" style={{ padding: '24px' }}>
+            <p style={{ color: 'var(--color-text-muted)', margin: 0 }}>Cargando preguntas...</p>
+          </div>
+        )}
+
+        {examState === 'in-progress' && currentAttempt && (
+          <InProgressStep
+            attempt={currentAttempt}
+            onSubmit={handleSubmit}
+            isLoading={submitMut.isPending}
+          />
+        )}
+
+        {examState === 'results' && result && (
+          <ResultsStep
+            result={result}
+            scopeTitle="Examen IA"
+            courseId={undefined}
+            moduleId={undefined}
+            onRepeat={handleRepeat}
+            onBack={handleBack}
+            historyItems={[]}
+          />
+        )}
+      </div>
+    );
+  }
 
   // ── Estados de carga y error ──
 
@@ -696,17 +888,17 @@ export default function ExamPage() {
 
   // ── Estado del examen: label del paso activo ──
 
-  const stepLabel = examState === 'config'
-    ? 'Configuracion'
-    : examState === 'in-progress'
-    ? 'En progreso'
-    : 'Resultados';
+  const stepLabel =
+    examState === 'config'
+      ? 'Configuracion'
+      : examState === 'in-progress'
+        ? 'En progreso'
+        : 'Resultados';
 
   const stepIndex = examState === 'config' ? 0 : examState === 'in-progress' ? 1 : 2;
 
   return (
     <div style={{ maxWidth: 780, margin: '0 auto' }}>
-
       {/* Hero */}
       <div className="page-hero animate-in">
         {examState !== 'in-progress' && (
@@ -729,7 +921,15 @@ export default function ExamPage() {
           </button>
         )}
 
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' as const }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+            flexWrap: 'wrap' as const,
+          }}
+        >
           <div>
             <h1 className="hero-title" style={{ fontSize: '1.6rem' }}>
               Examen
@@ -749,11 +949,12 @@ export default function ExamPage() {
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    background: idx === stepIndex
-                      ? 'var(--gradient-orange)'
-                      : idx < stepIndex
-                      ? 'rgba(234,88,12,0.35)'
-                      : 'rgba(255,255,255,0.10)',
+                    background:
+                      idx === stepIndex
+                        ? 'var(--gradient-orange)'
+                        : idx < stepIndex
+                          ? 'rgba(234,88,12,0.35)'
+                          : 'rgba(255,255,255,0.10)',
                     fontSize: '0.7rem',
                     fontWeight: 800,
                     color: idx <= stepIndex ? '#fff' : 'rgba(255,255,255,0.40)',
@@ -767,7 +968,8 @@ export default function ExamPage() {
                     style={{
                       width: 24,
                       height: 2,
-                      background: idx < stepIndex ? 'rgba(234,88,12,0.50)' : 'rgba(255,255,255,0.12)',
+                      background:
+                        idx < stepIndex ? 'rgba(234,88,12,0.50)' : 'rgba(255,255,255,0.12)',
                       borderRadius: 1,
                     }}
                   />

--- a/apps/web/src/pages/ExamsListPage.tsx
+++ b/apps/web/src/pages/ExamsListPage.tsx
@@ -1,5 +1,14 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAvailableExams } from '../hooks/useExams';
+import {
+  useAvailableExams,
+  useMyAiExamBanks,
+  useGenerateAiExam,
+  useDeleteAiExamBank,
+  useStartAiAttempt,
+} from '../hooks/useExams';
+import { useCourses, useCourse } from '../hooks/useCourses';
+import type { AiExamBankSummary } from '../api/exams.api';
 
 // ─── Helper: color de score ───────────────────────────────────────────────────
 
@@ -64,7 +73,9 @@ function ExamCard({ title, badge, questionCount, lastAttempt, onStart }: ExamCar
       {/* Info */}
       <div style={{ flex: 1, minWidth: 0 }}>
         {/* Título */}
-        <div style={{ fontWeight: 700, color: 'var(--color-text)', marginBottom: 8, fontSize: '1rem' }}>
+        <div
+          style={{ fontWeight: 700, color: 'var(--color-text)', marginBottom: 8, fontSize: '1rem' }}
+        >
           {title}
         </div>
 
@@ -154,27 +165,406 @@ function SectionLabel({ label }: { label: string }) {
   );
 }
 
+// ─── Card de banco IA ────────────────────────────────────────────────────────
+
+function AiBankCard({
+  bank,
+  onStart,
+  onDelete,
+  isDeleting,
+  isStarting,
+}: {
+  bank: AiExamBankSummary;
+  onStart: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
+  isStarting: boolean;
+}) {
+  return (
+    <div
+      className="vkb-card animate-in"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 16,
+        padding: '20px 24px',
+        flexWrap: 'wrap' as const,
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontWeight: 700,
+            color: 'var(--color-text)',
+            marginBottom: 6,
+            fontSize: '1rem',
+          }}
+        >
+          {bank.title}
+        </div>
+        <div
+          style={{
+            fontSize: '0.8rem',
+            color: 'var(--color-text-muted)',
+            marginBottom: 8,
+            lineHeight: 1.4,
+          }}
+        >
+          {bank.course.title}
+          {bank.module ? ` · ${bank.module.title}` : ''} · Tema: {bank.topic}
+        </div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' as const }}>
+          <span
+            style={{
+              display: 'inline-block',
+              padding: '2px 10px',
+              borderRadius: 999,
+              background: 'rgba(234,88,12,0.10)',
+              color: 'var(--color-primary)',
+              fontSize: '0.72rem',
+              fontWeight: 700,
+              border: '1px solid rgba(234,88,12,0.20)',
+            }}
+          >
+            🤖 IA
+          </span>
+          <span
+            style={{
+              fontSize: '0.78rem',
+              color: 'var(--color-text-muted)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            <span>📋</span>
+            <span>{bank.questionCount} preguntas</span>
+          </span>
+          {bank.attemptCount > 0 && (
+            <span
+              style={{
+                fontSize: '0.78rem',
+                color: 'var(--color-text-muted)',
+              }}
+            >
+              {bank.attemptCount} {bank.attemptCount === 1 ? 'intento' : 'intentos'}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+        <button
+          className="btn btn-ghost"
+          style={{ padding: '8px 14px', fontSize: '0.8rem' }}
+          onClick={onDelete}
+          disabled={isDeleting}
+          title="Eliminar banco"
+        >
+          {isDeleting ? '...' : '🗑'}
+        </button>
+        <button
+          className="btn btn-primary"
+          style={{ padding: '9px 20px', fontSize: '0.875rem' }}
+          onClick={onStart}
+          disabled={isStarting}
+        >
+          {isStarting ? 'Iniciando...' : bank.attemptCount > 0 ? 'Repetir' : 'Empezar'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Modal: crear examen IA ─────────────────────────────────────────────────
+
+function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSuccess: () => void }) {
+  const { data: coursesPage } = useCourses();
+  const [courseId, setCourseId] = useState('');
+  const [moduleId, setModuleId] = useState('');
+  const [topic, setTopic] = useState('');
+  const [numQuestions, setNumQuestions] = useState<5 | 10>(5);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const { data: courseDetail } = useCourse(courseId);
+  const generate = useGenerateAiExam();
+
+  const courses = coursesPage?.data ?? [];
+  const modules = courseDetail?.modules ?? [];
+
+  const canSubmit = courseId && topic.trim().length >= 3 && !generate.isPending;
+
+  const handleSubmit = async () => {
+    setSubmitError(null);
+    try {
+      await generate.mutateAsync({
+        courseId,
+        moduleId: moduleId || undefined,
+        topic: topic.trim(),
+        numQuestions,
+      });
+      onSuccess();
+    } catch (err) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? ((err as { response?: { data?: { message?: string } } }).response?.data?.message ??
+            'No se pudo generar el examen')
+          : 'No se pudo generar el examen';
+      setSubmitError(message);
+    }
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontSize: '0.8rem',
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+    marginBottom: 6,
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '10px 14px',
+    borderRadius: 'var(--radius-sm)',
+    border: '1.5px solid var(--color-border)',
+    background: 'var(--color-bg)',
+    color: 'var(--color-text)',
+    fontSize: '0.95rem',
+    outline: 'none',
+    boxSizing: 'border-box' as const,
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+        padding: 16,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="vkb-card"
+        style={{
+          width: '100%',
+          maxWidth: 520,
+          padding: 28,
+          maxHeight: '92vh',
+          overflowY: 'auto' as const,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 18,
+          }}
+        >
+          <h3
+            style={{ margin: 0, fontSize: '1.1rem', fontWeight: 800, color: 'var(--color-text)' }}
+          >
+            🤖 Crear examen con IA
+          </h3>
+          <button
+            onClick={onClose}
+            aria-label="Cerrar"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: 'var(--color-text-muted)',
+              fontSize: '1.4rem',
+              cursor: 'pointer',
+              padding: 0,
+              lineHeight: 1,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Curso */}
+        <div style={{ marginBottom: 16 }}>
+          <label style={labelStyle}>Curso</label>
+          <select
+            value={courseId}
+            onChange={(e) => {
+              setCourseId(e.target.value);
+              setModuleId('');
+            }}
+            style={inputStyle}
+          >
+            <option value="">Selecciona un curso...</option>
+            {courses.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.title}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Módulo (opcional) */}
+        {courseId && modules.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <label style={labelStyle}>Módulo (opcional)</label>
+            <select
+              value={moduleId}
+              onChange={(e) => setModuleId(e.target.value)}
+              style={inputStyle}
+            >
+              <option value="">Todo el curso</option>
+              {modules.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.title}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Tema */}
+        <div style={{ marginBottom: 16 }}>
+          <label style={labelStyle}>Tema</label>
+          <textarea
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+            placeholder="Ej: Propiedades de los logaritmos"
+            rows={2}
+            style={{ ...inputStyle, resize: 'vertical' as const, fontFamily: 'inherit' }}
+          />
+        </div>
+
+        {/* Nº preguntas: 5 o 10 */}
+        <div style={{ marginBottom: 22 }}>
+          <label style={labelStyle}>Número de preguntas</label>
+          <div style={{ display: 'flex', gap: 10 }}>
+            {([5, 10] as const).map((n) => {
+              const active = numQuestions === n;
+              return (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setNumQuestions(n)}
+                  style={{
+                    flex: 1,
+                    padding: '12px 16px',
+                    borderRadius: 'var(--radius-sm)',
+                    border: active
+                      ? '2px solid var(--color-primary)'
+                      : '1.5px solid var(--color-border)',
+                    background: active ? 'rgba(234,88,12,0.10)' : 'var(--color-bg)',
+                    color: active ? 'var(--color-primary)' : 'var(--color-text)',
+                    fontSize: '0.95rem',
+                    fontWeight: 700,
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                  }}
+                >
+                  {n} preguntas
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {submitError && (
+          <div
+            style={{
+              padding: '10px 14px',
+              borderRadius: 'var(--radius-sm)',
+              background: 'rgba(220,38,38,0.10)',
+              border: '1px solid rgba(220,38,38,0.30)',
+              color: '#dc2626',
+              fontSize: '0.85rem',
+              marginBottom: 14,
+            }}
+          >
+            {submitError}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={onClose}
+            disabled={generate.isPending}
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {generate.isPending ? 'Generando con IA...' : 'Generar examen'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ─── Página principal ─────────────────────────────────────────────────────────
 
 export default function ExamsListPage() {
   const navigate = useNavigate();
   const { data, isLoading } = useAvailableExams();
 
+  // ─── IA ───
+  const { data: aiBanks, isLoading: aiLoading } = useMyAiExamBanks();
+  const deleteMut = useDeleteAiExamBank();
+  const startAiMut = useStartAiAttempt();
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [pendingStartId, setPendingStartId] = useState<string | null>(null);
+
+  const handleStartAiBank = async (bankId: string) => {
+    setPendingStartId(bankId);
+    try {
+      // Empuja al usuario a /exam con aiBankId; ExamPage hará el start interno
+      navigate(`/exam?aiBankId=${bankId}`);
+    } finally {
+      setPendingStartId(null);
+    }
+  };
+
+  const handleDeleteBank = async (bankId: string) => {
+    if (
+      !confirm(
+        '¿Eliminar este banco? Los intentos previos se conservarán pero ya no podrás repetirlo.',
+      )
+    ) {
+      return;
+    }
+    await deleteMut.mutateAsync(bankId);
+  };
+
   const hasCourses = (data?.courses?.length ?? 0) > 0;
   const hasModules = (data?.modules?.length ?? 0) > 0;
-  const isEmpty = !hasCourses && !hasModules;
+  const hasAiBanks = (aiBanks?.length ?? 0) > 0;
+  const isEmpty = !hasCourses && !hasModules && !hasAiBanks;
 
   const totalBanks = (data?.courses?.length ?? 0) + (data?.modules?.length ?? 0);
 
   return (
     <div style={{ maxWidth: 820, margin: '0 auto' }}>
-
       {/* Hero */}
       <div className="page-hero animate-in">
         <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 12 }}>
           <span style={{ fontSize: '2.4rem' }}>🎓</span>
           {!isLoading && totalBanks > 0 && (
-            <div className="stat-card" style={{ padding: '8px 18px', display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+            <div
+              className="stat-card"
+              style={{ padding: '8px 18px', display: 'inline-flex', gap: 6, alignItems: 'center' }}
+            >
               <span
                 style={{
                   fontSize: '1.4rem',
@@ -187,7 +577,9 @@ export default function ExamsListPage() {
               >
                 {totalBanks}
               </span>
-              <span style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', fontWeight: 500 }}>
+              <span
+                style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', fontWeight: 500 }}
+              >
                 {totalBanks === 1 ? 'banco disponible' : 'bancos disponibles'}
               </span>
             </div>
@@ -199,10 +591,76 @@ export default function ExamsListPage() {
         </p>
       </div>
 
+      {/* Sección: Mis exámenes IA */}
+      <div style={{ marginTop: 28 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            marginBottom: 14,
+          }}
+        >
+          <span style={{ fontWeight: 700, fontSize: '0.9rem', color: 'var(--color-text)' }}>
+            🤖 Mis exámenes IA
+          </span>
+          <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
+          <button
+            className="btn btn-primary"
+            style={{ padding: '8px 16px', fontSize: '0.85rem' }}
+            onClick={() => setShowCreateModal(true)}
+          >
+            + Crear examen con IA
+          </button>
+        </div>
+
+        {aiLoading && (
+          <div style={{ display: 'flex', flexDirection: 'column' as const, gap: 14 }}>
+            <SkeletonCard />
+          </div>
+        )}
+
+        {!aiLoading && hasAiBanks && (
+          <div style={{ display: 'flex', flexDirection: 'column' as const, gap: 14 }}>
+            {aiBanks!.map((b) => (
+              <AiBankCard
+                key={b.id}
+                bank={b}
+                onStart={() => handleStartAiBank(b.id)}
+                onDelete={() => handleDeleteBank(b.id)}
+                isDeleting={deleteMut.isPending && deleteMut.variables === b.id}
+                isStarting={
+                  pendingStartId === b.id || (startAiMut.isPending && startAiMut.variables === b.id)
+                }
+              />
+            ))}
+          </div>
+        )}
+
+        {!aiLoading && !hasAiBanks && (
+          <div
+            style={{
+              padding: '24px 20px',
+              borderRadius: 'var(--radius-lg)',
+              border: '1.5px dashed var(--color-border)',
+              textAlign: 'center' as const,
+              fontSize: '0.875rem',
+              color: 'var(--color-text-muted)',
+              lineHeight: 1.5,
+            }}
+          >
+            Aún no has creado ningún examen con IA. Genera el primero con un tema a tu elección y 5
+            o 10 preguntas.
+          </div>
+        )}
+      </div>
+
       {/* Skeletons de carga */}
       {isLoading && (
         <div style={{ display: 'flex', flexDirection: 'column' as const, gap: 14 }}>
-          {[1, 2, 3].map((i) => <SkeletonCard key={i} />)}
+          {[1, 2, 3].map((i) => (
+            <SkeletonCard key={i} />
+          ))}
         </div>
       )}
 
@@ -219,11 +677,26 @@ export default function ExamsListPage() {
           }}
         >
           <div style={{ fontSize: '4rem', marginBottom: 16 }}>📭</div>
-          <div style={{ fontWeight: 700, fontSize: '1.1rem', color: 'var(--color-text)', marginBottom: 8 }}>
+          <div
+            style={{
+              fontWeight: 700,
+              fontSize: '1.1rem',
+              color: 'var(--color-text)',
+              marginBottom: 8,
+            }}
+          >
             No hay examenes disponibles
           </div>
-          <div style={{ fontSize: '0.9rem', color: 'var(--color-text-muted)', maxWidth: 380, margin: '0 auto', lineHeight: 1.6 }}>
-            Cuando el administrador anada preguntas a un banco, aparecera aqui.
+          <div
+            style={{
+              fontSize: '0.9rem',
+              color: 'var(--color-text-muted)',
+              maxWidth: 380,
+              margin: '0 auto',
+              lineHeight: 1.6,
+            }}
+          >
+            Crea tu primer examen con IA o espera a que el administrador añada preguntas a un banco.
           </div>
         </div>
       )}
@@ -264,6 +737,14 @@ export default function ExamsListPage() {
             ))}
           </div>
         </>
+      )}
+
+      {/* Modal de creación de examen IA */}
+      {showCreateModal && (
+        <CreateAiExamModal
+          onClose={() => setShowCreateModal(false)}
+          onSuccess={() => setShowCreateModal(false)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Permite a los alumnos generar sus propios exámenes con IA desde `/my-exams`, sin que el admin tenga que añadir preguntas. Los exámenes se persisten como bancos por alumno (similar al patrón de Teoría on-demand) y se pueden repetir las veces que quieran. La submission, corrección y emisión de certificados reutilizan el pipeline existente de \`ExamAttempt\` con \`questionsSnapshot\`.

## Cómo funciona
1. Alumno entra en \`/my-exams\` → nueva sección **🤖 Mis exámenes IA** con botón "+ Crear examen con IA".
2. Modal: selecciona curso, módulo (opcional), tema libre, y **5 o 10 preguntas**.
3. Backend valida matrícula → llama a \`AiProviderService\` (Gemini → Haiku fallback) → valida payload (nº exacto, isCorrect counts por tipo) → persiste \`AiExamBank\` + \`AiExamQuestion\` + \`AiExamAnswer\`.
4. Click "Empezar" → \`POST /exams/ai/:bankId/start\` crea \`ExamAttempt\` con snapshot del banco → \`/exam?aiBankId=...\` lanza directamente el modo en-progreso.
5. Submit reutiliza \`POST /exams/:attemptId/submit\` (snapshot-based grading).

## Schema
- 3 modelos nuevos scoped por \`userId\`: \`AiExamBank\`, \`AiExamQuestion\`, \`AiExamAnswer\`.
- \`ExamAttempt.aiExamBankId\` (FK opcional) para trazabilidad.
- Reusa el enum \`QuestionType\` existente.

## Endpoints nuevos (todos protegidos por JwtAuthGuard)
- \`POST   /exams/ai/generate\` — \`{ courseId, moduleId?, topic, numQuestions: 5|10 }\`
- \`GET    /exams/ai/my-banks\`
- \`GET    /exams/ai/:bankId\` (sin \`isCorrect\`)
- \`DELETE /exams/ai/:bankId\`
- \`POST   /exams/ai/:bankId/start\` — crea \`ExamAttempt\`

## Seguridad
- \`isCorrect\` nunca sale del backend antes de submit (verificado en 3 tests).
- Validación de matrícula reutilizada para \`generate\`.
- \`getBank\` / \`deleteBank\` / \`startAttempt\` rechazan accesos cross-user con \`ForbiddenException\`.

## Validación del payload IA
- Nº exacto de preguntas (rechaza si la IA devuelve más/menos).
- SINGLE/TRUE_FALSE: exactamente 1 \`isCorrect\`.
- MULTIPLE: 2+ \`isCorrect\`.
- TRUE_FALSE: exactamente 2 opciones.

## Test plan
- [x] \`pnpm --filter @vkbacademy/api test\` — 424/424 ✅ (13 tests nuevos para \`AiExamsService\`)
- [x] \`pnpm --filter @vkbacademy/web exec tsc --noEmit\` — limpio ✅
- [ ] Aplicar migración en PRE — \`pnpm --filter @vkbacademy/api prisma migrate deploy\` (BD Neon PRE)
- [ ] Smoke manual en PRE: crear examen IA con 5 preguntas, completarlo, ver resultados
- [ ] Smoke manual en PRE: repetir el mismo banco con 10 preguntas
- [ ] Smoke manual en PRE: eliminar banco
- [ ] Verificar que el dropdown de cursos muestra solo los del nivel del alumno

🤖 Generated with [Claude Code](https://claude.com/claude-code)