### PR TITLE
feat: tutor student credentials dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_S3_BUCKET
 AWS_SIGNED_URL_EXPIRES=3600
 RESEND_API_KEY / EMAIL_FROM
 YOUTUBE_API_KEY                          # secret "YT" en GCP Secret Manager
+STUDENT_PASSWORD_ENC_KEY                 # 32 bytes hex; cifra contraseñas visibles para tutor
 PORT=3001
 FRONTEND_URL="http://localhost:5173"     # acepta múltiples separados por coma
 NODE_ENV=development

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -28,6 +28,10 @@ DAILY_API_KEY=""
 # pero las lecciones VIDEO se crean con youtubeId=null).
 YOUTUBE_API_KEY=""
 
+# Clave de cifrado (AES-256-GCM) para contraseñas visibles de alumnos por su tutor.
+# Generar con: openssl rand -hex 32
+STUDENT_PASSWORD_ENC_KEY=""
+
 # App
 PORT=3001
 FRONTEND_URL="http://localhost:5173"

--- a/apps/api/prisma/migrations/20260507183157_add_user_viewable_password/migration.sql
+++ b/apps/api/prisma/migrations/20260507183157_add_user_viewable_password/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "viewablePassword" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -73,6 +73,7 @@ model User {
   id           String   @id @default(cuid())
   email        String   @unique
   passwordHash String
+  viewablePassword String?  // AES-256-GCM (iv:tag:ciphertext). Solo poblado para STUDENT con tutorId.
   role         Role     @default(STUDENT)
   name         String
   avatarUrl    String?

--- a/apps/api/src/admin/admin.service.spec.ts
+++ b/apps/api/src/admin/admin.service.spec.ts
@@ -4,6 +4,7 @@ import * as bcrypt from 'bcrypt';
 import { AdminService } from './admin.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { YoutubeService } from '../youtube/youtube.service';
+import { CryptoService } from '../crypto/crypto.service';
 
 // Mockear bcrypt para evitar el coste de rondas reales en los tests
 jest.mock('bcrypt');
@@ -25,6 +26,7 @@ describe('AdminService', () => {
       deleteMany: jest.Mock;
     };
   };
+  let mockCrypto: { encrypt: jest.Mock; decrypt: jest.Mock };
 
   const fakeUser = {
     id: 'user-1',
@@ -61,11 +63,17 @@ describe('AdminService', () => {
       },
     };
 
+    mockCrypto = {
+      encrypt: jest.fn((plain: string) => `enc(${plain})`),
+      decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminService,
         { provide: PrismaService, useValue: mockPrisma },
         { provide: YoutubeService, useValue: { findCandidates: jest.fn() } },
+        { provide: CryptoService, useValue: mockCrypto },
       ],
     }).compile();
 
@@ -220,6 +228,56 @@ describe('AdminService', () => {
       const updateData = mockPrisma.user.update.mock.calls[0][0].data;
       expect(updateData).toHaveProperty('passwordHash');
       expect(updateData).not.toHaveProperty('password');
+    });
+
+    // ─── viewablePassword sync ─────────────────────────────────────────────
+
+    it('actualiza viewablePassword cuando target es STUDENT con tutor y dto trae password', async () => {
+      const student = { ...fakeUser, role: 'STUDENT', tutorId: 'tut1' };
+      mockPrisma.user.findUnique.mockResolvedValue(student);
+      mockPrisma.user.update.mockResolvedValue(student);
+
+      await service.updateUser('user-1', { password: 'secret' });
+
+      expect(mockCrypto.encrypt).toHaveBeenCalledWith('secret');
+      const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+      expect(updateData).toHaveProperty('viewablePassword', 'enc(secret)');
+    });
+
+    it('NO toca viewablePassword cuando target NO es STUDENT', async () => {
+      const teacher = { ...fakeUser, role: 'TEACHER', tutorId: null };
+      mockPrisma.user.findUnique.mockResolvedValue(teacher);
+      mockPrisma.user.update.mockResolvedValue(teacher);
+
+      await service.updateUser('user-1', { password: 'secret' });
+
+      expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+      const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+      expect(updateData).not.toHaveProperty('viewablePassword');
+    });
+
+    it('NO toca viewablePassword cuando target es STUDENT sin tutor', async () => {
+      const orphan = { ...fakeUser, role: 'STUDENT', tutorId: null };
+      mockPrisma.user.findUnique.mockResolvedValue(orphan);
+      mockPrisma.user.update.mockResolvedValue(orphan);
+
+      await service.updateUser('user-1', { password: 'secret' });
+
+      expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+      const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+      expect(updateData).not.toHaveProperty('viewablePassword');
+    });
+
+    it('NO toca viewablePassword cuando dto NO trae password', async () => {
+      const student = { ...fakeUser, role: 'STUDENT', tutorId: 'tut1' };
+      mockPrisma.user.findUnique.mockResolvedValue(student);
+      mockPrisma.user.update.mockResolvedValue(student);
+
+      await service.updateUser('user-1', { name: 'Otro Nombre' });
+
+      expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+      const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+      expect(updateData).not.toHaveProperty('viewablePassword');
     });
   });
 

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -16,6 +16,7 @@ import { UpdateChallengeDto } from './dto/update-challenge.dto';
 import { CreateExamQuestionDto, UpdateExamQuestionDto } from './dto/create-exam-question.dto';
 import { YoutubeService } from '../youtube/youtube.service';
 import type { YoutubeCandidate } from '../youtube/dto/youtube-candidate.dto';
+import { CryptoService } from '../crypto/crypto.service';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
@@ -23,6 +24,7 @@ export class AdminService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly youtube: YoutubeService,
+    private readonly crypto: CryptoService,
   ) {}
 
   async getUsers(academyId?: string | null) {
@@ -126,7 +128,12 @@ export class AdminService {
     if (dto.name !== undefined) data.name = dto.name;
     if (dto.email !== undefined) data.email = dto.email;
     if ('schoolYearId' in dto) data.schoolYearId = dto.schoolYearId ?? null;
-    if (dto.password) data.passwordHash = await bcrypt.hash(dto.password, 10);
+    if (dto.password) {
+      data.passwordHash = await bcrypt.hash(dto.password, 10);
+      if (user.role === 'STUDENT' && user.tutorId) {
+        data.viewablePassword = this.crypto.encrypt(dto.password);
+      }
+    }
 
     return this.prisma.user.update({
       where: { id: userId },

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -26,6 +26,7 @@ import { HealthModule } from './health/health.module';
 import { AiModule } from './ai/ai.module';
 import { ExercisesModule } from './exercises/exercises.module';
 import { TheoryModule } from './theory/theory.module';
+import { CryptoModule } from './crypto/crypto.module';
 
 @Module({
   imports: [
@@ -49,6 +50,9 @@ import { TheoryModule } from './theory/theory.module';
 
     // Base de datos
     PrismaModule,
+
+    // Cifrado simétrico (AES-256-GCM) — disponible globalmente
+    CryptoModule,
 
     // Módulos de dominio
     AuthModule,

--- a/apps/api/src/auth/auth-register-tutor.service.spec.ts
+++ b/apps/api/src/auth/auth-register-tutor.service.spec.ts
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { CryptoService } from '../crypto/crypto.service';
 import { RegisterTutorDto } from './dto/register-tutor.dto';
 
 // Mockear bcrypt para evitar el coste de rondas reales en los tests
@@ -101,6 +102,7 @@ describe('AuthService.registerTutor', () => {
     sendTutorWelcomeWithStudents: jest.Mock;
     sendPasswordReset: jest.Mock;
   };
+  let mockCrypto: { encrypt: jest.Mock; decrypt: jest.Mock };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -137,6 +139,10 @@ describe('AuthService.registerTutor', () => {
       sendTutorWelcomeWithStudents: jest.fn().mockResolvedValue(undefined),
       sendPasswordReset: jest.fn().mockResolvedValue(undefined),
     };
+    mockCrypto = {
+      encrypt: jest.fn((plain: string) => `enc(${plain})`),
+      decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
+    };
 
     mockedBcrypt.hash.mockResolvedValue('$2b$10$hashed' as never);
     mockPrisma.refreshToken.create.mockResolvedValue({});
@@ -148,6 +154,7 @@ describe('AuthService.registerTutor', () => {
         { provide: JwtService, useValue: mockJwt },
         { provide: ConfigService, useValue: mockConfig },
         { provide: NotificationsService, useValue: mockNotifications },
+        { provide: CryptoService, useValue: mockCrypto },
       ],
     }).compile();
 
@@ -475,6 +482,74 @@ describe('AuthService.registerTutor', () => {
       const call = mockNotifications.sendTutorWelcomeWithStudents.mock.calls[0][0];
       expect(typeof call.students[0].password).toBe('string');
       expect(call.students[0].password.length).toBeGreaterThanOrEqual(8);
+    });
+  });
+
+  // ─── Cifrado de viewablePassword ────────────────────────────────────────────
+
+  describe('cifra y guarda viewablePassword para cada alumno', () => {
+    beforeEach(() => {
+      mockPrisma.academy.findUnique.mockResolvedValue(fakeAcademy);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+    });
+
+    it('llama a crypto.encrypt una vez por alumno con la contraseña en plano generada', async () => {
+      mockPrisma.user.create
+        .mockResolvedValueOnce(fakeTutor)
+        .mockResolvedValueOnce(fakeStudent1)
+        .mockResolvedValueOnce(fakeStudent2);
+
+      await service.registerTutor({
+        name: 'Tutor',
+        email: 'tutor@test.es',
+        password: 'password123',
+        academySlug: 'vallekas-basket',
+        students: [{ name: 'Alumno Uno' }, { name: 'Alumno Dos' }],
+      });
+
+      expect(mockCrypto.encrypt).toHaveBeenCalledTimes(2);
+      // El argumento debe ser la misma contraseña en plano que se envía en el email
+      const emailCall = mockNotifications.sendTutorWelcomeWithStudents.mock.calls[0][0];
+      expect(mockCrypto.encrypt).toHaveBeenNthCalledWith(1, emailCall.students[0].password);
+      expect(mockCrypto.encrypt).toHaveBeenNthCalledWith(2, emailCall.students[1].password);
+    });
+
+    it('cada tx.user.create de un alumno recibe viewablePassword cifrada', async () => {
+      mockPrisma.user.create
+        .mockResolvedValueOnce(fakeTutor)
+        .mockResolvedValueOnce(fakeStudent1)
+        .mockResolvedValueOnce(fakeStudent2);
+
+      await service.registerTutor({
+        name: 'Tutor',
+        email: 'tutor@test.es',
+        password: 'password123',
+        academySlug: 'vallekas-basket',
+        students: [{ name: 'Alumno Uno' }, { name: 'Alumno Dos' }],
+      });
+
+      const studentCreateCalls = mockPrisma.user.create.mock.calls.filter(
+        ([arg]: [{ data: { role: string } }]) => arg.data.role === 'STUDENT',
+      );
+      expect(studentCreateCalls).toHaveLength(2);
+      for (const [arg] of studentCreateCalls) {
+        expect(arg.data.viewablePassword).toMatch(/^enc\(.+\)$/);
+      }
+    });
+
+    it('el create del tutor NO incluye viewablePassword', async () => {
+      mockPrisma.user.create.mockResolvedValueOnce(fakeTutor).mockResolvedValueOnce(fakeStudent1);
+
+      await service.registerTutor({
+        name: 'Tutor',
+        email: 'tutor@test.es',
+        password: 'password123',
+        academySlug: 'vallekas-basket',
+        students: [{ name: 'Alumno' }],
+      });
+
+      const tutorCreateCall = mockPrisma.user.create.mock.calls[0][0];
+      expect(tutorCreateCall.data).not.toHaveProperty('viewablePassword');
     });
   });
 });

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -18,6 +18,7 @@ describe('AuthService', () => {
     user: {
       findUnique: jest.Mock;
       create: jest.Mock;
+      update: jest.Mock;
       findUniqueOrThrow: jest.Mock;
     };
     refreshToken: {
@@ -27,8 +28,9 @@ describe('AuthService', () => {
       updateMany: jest.Mock;
     };
   };
-  let mockJwt: { sign: jest.Mock };
+  let mockJwt: { sign: jest.Mock; decode: jest.Mock; verify: jest.Mock };
   let mockConfig: { get: jest.Mock };
+  let mockCrypto: { encrypt: jest.Mock; decrypt: jest.Mock };
 
   // Usuario de ejemplo con todos los campos necesarios
   const fakeUser = {
@@ -48,6 +50,7 @@ describe('AuthService', () => {
       user: {
         findUnique: jest.fn(),
         create: jest.fn(),
+        update: jest.fn(),
         findUniqueOrThrow: jest.fn(),
       },
       refreshToken: {
@@ -57,8 +60,16 @@ describe('AuthService', () => {
         updateMany: jest.fn(),
       },
     };
-    mockJwt = { sign: jest.fn().mockReturnValue('mocked_access_token') };
+    mockJwt = {
+      sign: jest.fn().mockReturnValue('mocked_access_token'),
+      decode: jest.fn(),
+      verify: jest.fn(),
+    };
     mockConfig = { get: jest.fn() };
+    mockCrypto = {
+      encrypt: jest.fn((plain: string) => `enc(${plain})`),
+      decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -70,13 +81,7 @@ describe('AuthService', () => {
           provide: NotificationsService,
           useValue: { sendPasswordReset: jest.fn().mockResolvedValue(undefined) },
         },
-        {
-          provide: CryptoService,
-          useValue: {
-            encrypt: jest.fn((plain: string) => `enc(${plain})`),
-            decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
-          },
-        },
+        { provide: CryptoService, useValue: mockCrypto },
       ],
     }).compile();
 
@@ -86,6 +91,7 @@ describe('AuthService', () => {
     // Valores por defecto para las dependencias
     mockJwt.sign.mockReturnValue('mocked_token');
     mockConfig.get.mockImplementation((key: string, fallback?: string) => {
+      if (key === 'JWT_SECRET') return 'test_secret';
       if (key === 'JWT_REFRESH_SECRET') return 'test_refresh_secret';
       if (key === 'JWT_REFRESH_EXPIRES_IN') return fallback ?? '7d';
       return undefined;
@@ -381,6 +387,88 @@ describe('AuthService', () => {
       const result = await service.logout('token');
 
       expect(result.message).toContain('cerrada');
+    });
+  });
+
+  // ─── resetPassword: sincronización viewablePassword ─────────────────────────
+
+  describe('resetPassword viewablePassword sync', () => {
+    beforeEach(() => {
+      mockedBcrypt.hash.mockResolvedValue('newhash' as never);
+      mockJwt.verify.mockReturnValue({ sub: 'u1', purpose: 'reset' });
+    });
+
+    it('actualiza viewablePassword cuando user es STUDENT con tutorId', async () => {
+      mockJwt.decode.mockReturnValue({ sub: 'st1', purpose: 'reset' });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'st1',
+        role: 'STUDENT',
+        tutorId: 'tut1',
+        passwordHash: 'oldhash',
+      });
+      mockPrisma.user.update.mockResolvedValue({ id: 'st1' });
+
+      await service.resetPassword('any-token', 'newSecret');
+
+      expect(mockCrypto.encrypt).toHaveBeenCalledWith('newSecret');
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'st1' },
+        data: {
+          passwordHash: 'newhash',
+          viewablePassword: 'enc(newSecret)',
+        },
+      });
+    });
+
+    it('NO toca viewablePassword cuando user es TUTOR', async () => {
+      mockJwt.decode.mockReturnValue({ sub: 'tut1', purpose: 'reset' });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'tut1',
+        role: 'TUTOR',
+        tutorId: null,
+        passwordHash: 'oldhash',
+      });
+      mockPrisma.user.update.mockResolvedValue({ id: 'tut1' });
+
+      await service.resetPassword('any-token', 'newSecret');
+
+      expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+      const updateArg = mockPrisma.user.update.mock.calls[0][0];
+      expect(updateArg.data).not.toHaveProperty('viewablePassword');
+    });
+
+    it('NO toca viewablePassword cuando user es STUDENT sin tutorId', async () => {
+      mockJwt.decode.mockReturnValue({ sub: 's2', purpose: 'reset' });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 's2',
+        role: 'STUDENT',
+        tutorId: null,
+        passwordHash: 'oldhash',
+      });
+      mockPrisma.user.update.mockResolvedValue({ id: 's2' });
+
+      await service.resetPassword('any-token', 'newSecret');
+
+      expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+      const updateArg = mockPrisma.user.update.mock.calls[0][0];
+      expect(updateArg.data).not.toHaveProperty('viewablePassword');
+    });
+
+    it('NO toca viewablePassword cuando user es TEACHER', async () => {
+      mockJwt.decode.mockReturnValue({ sub: 'tch1', purpose: 'reset' });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'tch1',
+        role: 'TEACHER',
+        tutorId: null,
+        passwordHash: 'oldhash',
+      });
+      mockPrisma.user.update.mockResolvedValue({ id: 'tch1' });
+
+      await service.resetPassword('any-token', 'newSecret');
+
+      expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+      const updateArg = mockPrisma.user.update.mock.calls[0][0];
+      expect(updateArg.data).not.toHaveProperty('viewablePassword');
     });
   });
 });

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { CryptoService } from '../crypto/crypto.service';
 
 // Mockear bcrypt para evitar el coste de rondas reales en los tests
 jest.mock('bcrypt');
@@ -68,6 +69,13 @@ describe('AuthService', () => {
         {
           provide: NotificationsService,
           useValue: { sendPasswordReset: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: CryptoService,
+          useValue: {
+            encrypt: jest.fn((plain: string) => `enc(${plain})`),
+            decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
+          },
         },
       ],
     }).compile();

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { CryptoService } from '../crypto/crypto.service';
 import { RegisterDto } from './dto/register.dto';
 import { RegisterTutorDto } from './dto/register-tutor.dto';
 import { LoginDto } from './dto/login.dto';
@@ -43,6 +44,7 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly config: ConfigService,
     private readonly notifications: NotificationsService,
+    private readonly crypto: CryptoService,
   ) {}
 
   async register(dto: RegisterDto): Promise<AuthResponse> {
@@ -126,6 +128,9 @@ export class AuthService {
     const studentPasswordHashes = await Promise.all(
       studentPasswords.map((pw) => bcrypt.hash(pw, 10)),
     );
+    // Cifrado reversible (AES-256-GCM) para que el tutor pueda consultar la
+    // contraseña del alumno en el panel — el hash bcrypt es irreversible.
+    const studentViewable = studentPasswords.map((pw) => this.crypto.encrypt(pw));
 
     // 5. Crear tutor y alumnos en transacción
     const { tutor, students } = await this.prisma.$transaction(async (tx) => {
@@ -146,6 +151,7 @@ export class AuthService {
             data: {
               email: studentEmails[index],
               passwordHash: studentPasswordHashes[index],
+              viewablePassword: studentViewable[index],
               name: studentDto.name,
               role: 'STUDENT',
               tutorId: createdTutor.id,

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -360,7 +360,13 @@ export class AuthService {
     }
 
     const passwordHash = await bcrypt.hash(newPassword, 10);
-    await this.prisma.user.update({ where: { id: user.id }, data: { passwordHash } });
+
+    const data: { passwordHash: string; viewablePassword?: string } = { passwordHash };
+    if (user.role === 'STUDENT' && user.tutorId) {
+      data.viewablePassword = this.crypto.encrypt(newPassword);
+    }
+
+    await this.prisma.user.update({ where: { id: user.id }, data });
 
     return { message: 'Contraseña actualizada correctamente' };
   }

--- a/apps/api/src/crypto/crypto.module.ts
+++ b/apps/api/src/crypto/crypto.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { CryptoService } from './crypto.service';
+
+@Global()
+@Module({
+  providers: [CryptoService],
+  exports: [CryptoService],
+})
+export class CryptoModule {}

--- a/apps/api/src/crypto/crypto.service.spec.ts
+++ b/apps/api/src/crypto/crypto.service.spec.ts
@@ -1,0 +1,57 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { CryptoService } from './crypto.service';
+
+const VALID_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+async function buildService(keyValue: string | undefined): Promise<CryptoService> {
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      CryptoService,
+      {
+        provide: ConfigService,
+        useValue: { get: jest.fn().mockReturnValue(keyValue) },
+      },
+    ],
+  }).compile();
+  return moduleRef.get(CryptoService);
+}
+
+describe('CryptoService', () => {
+  it('encrypt + decrypt preserva el plaintext', async () => {
+    const service = await buildService(VALID_KEY);
+    const plain = 'aB3xY7Q9';
+    const encrypted = service.encrypt(plain);
+    expect(service.decrypt(encrypted)).toBe(plain);
+  });
+
+  it('produce ciphertext distinto en cada llamada con el mismo input (IV aleatorio)', async () => {
+    const service = await buildService(VALID_KEY);
+    const a = service.encrypt('same');
+    const b = service.encrypt('same');
+    expect(a).not.toBe(b);
+    expect(service.decrypt(a)).toBe('same');
+    expect(service.decrypt(b)).toBe('same');
+  });
+
+  it('detecta manipulación del ciphertext mediante el auth tag', async () => {
+    const service = await buildService(VALID_KEY);
+    const encrypted = service.encrypt('secret');
+    const tampered = encrypted.slice(0, -1) + (encrypted.endsWith('0') ? '1' : '0');
+    expect(() => service.decrypt(tampered)).toThrow();
+  });
+
+  it('falla al construirse si la clave tiene longitud incorrecta', async () => {
+    await expect(buildService('tooshort')).rejects.toThrow('STUDENT_PASSWORD_ENC_KEY');
+  });
+
+  it('falla al construirse si la clave no está definida', async () => {
+    await expect(buildService(undefined)).rejects.toThrow('STUDENT_PASSWORD_ENC_KEY');
+  });
+
+  it('rechaza payload con formato inválido al descifrar', async () => {
+    const service = await buildService(VALID_KEY);
+    expect(() => service.decrypt('no-colons')).toThrow();
+    expect(() => service.decrypt('only:two')).toThrow();
+  });
+});

--- a/apps/api/src/crypto/crypto.service.ts
+++ b/apps/api/src/crypto/crypto.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const ENV_VAR = 'STUDENT_PASSWORD_ENC_KEY';
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const KEY_HEX_LENGTH = 64; // 32 bytes
+
+@Injectable()
+export class CryptoService {
+  private readonly key: Buffer;
+
+  constructor(config: ConfigService) {
+    const raw = config.get<string>(ENV_VAR);
+    if (!raw || raw.length !== KEY_HEX_LENGTH || !/^[0-9a-fA-F]+$/.test(raw)) {
+      throw new Error(
+        `${ENV_VAR} debe ser una cadena hex de ${KEY_HEX_LENGTH} caracteres (32 bytes). Genérala con \`openssl rand -hex 32\`.`,
+      );
+    }
+    this.key = Buffer.from(raw, 'hex');
+  }
+
+  /**
+   * Cifra un texto plano con AES-256-GCM. Devuelve "iv:authTag:ciphertext" en hex.
+   * Cada llamada produce un IV nuevo, por lo que la salida no es determinista.
+   */
+  encrypt(plain: string): string {
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(ALGORITHM, this.key, iv);
+    const encrypted = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return `${iv.toString('hex')}:${tag.toString('hex')}:${encrypted.toString('hex')}`;
+  }
+
+  /**
+   * Descifra un payload "iv:authTag:ciphertext". Lanza si el auth tag no
+   * cuadra (datos manipulados o clave incorrecta) o si el formato es inválido.
+   */
+  decrypt(payload: string): string {
+    const parts = payload.split(':');
+    if (parts.length !== 3) {
+      throw new Error('Formato de payload inválido');
+    }
+    const [ivHex, tagHex, dataHex] = parts;
+    const iv = Buffer.from(ivHex, 'hex');
+    const tag = Buffer.from(tagHex, 'hex');
+    const data = Buffer.from(dataHex, 'hex');
+    const decipher = createDecipheriv(ALGORITHM, this.key, iv);
+    decipher.setAuthTag(tag);
+    const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+    return decrypted.toString('utf8');
+  }
+}

--- a/apps/api/src/tutors/tutors.controller.ts
+++ b/apps/api/src/tutors/tutors.controller.ts
@@ -24,6 +24,12 @@ export class TutorsController {
     return this.tutorsService.getMyStudents(user.id);
   }
 
+  @Get('my-students/credentials')
+  @Roles(Role.TUTOR, Role.ADMIN)
+  getMyStudentsCredentials(@CurrentUser() user: User) {
+    return this.tutorsService.getStudentsCredentials(user.id);
+  }
+
   @Get('my-students/:studentId/courses')
   @Roles(Role.TUTOR, Role.ADMIN)
   getStudentCourses(@Param('studentId') studentId: string, @CurrentUser() user: User) {

--- a/apps/api/src/tutors/tutors.service.spec.ts
+++ b/apps/api/src/tutors/tutors.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ForbiddenException } from '@nestjs/common';
 import { TutorsService } from './tutors.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { CryptoService } from '../crypto/crypto.service';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -26,6 +27,11 @@ const mockStudent = {
 // ---------------------------------------------------------------------------
 // Mock de PrismaService
 // ---------------------------------------------------------------------------
+
+const mockCrypto = {
+  encrypt: jest.fn(),
+  decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
+};
 
 const mockPrisma = {
   user: {
@@ -76,11 +82,13 @@ describe('TutorsService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockCrypto.decrypt.mockImplementation((cipher: string) => cipher.replace(/^enc\(|\)$/g, ''));
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TutorsService,
         { provide: PrismaService, useValue: mockPrisma },
+        { provide: CryptoService, useValue: mockCrypto },
       ],
     }).compile();
 
@@ -94,7 +102,15 @@ describe('TutorsService', () => {
   describe('getMyStudents', () => {
     it('devuelve la lista de alumnos del tutor', async () => {
       const students = [
-        { id: STUDENT_ID, name: 'Alumno', email: 'a@b.com', avatarUrl: null, totalPoints: 50, currentStreak: 3, schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' } },
+        {
+          id: STUDENT_ID,
+          name: 'Alumno',
+          email: 'a@b.com',
+          avatarUrl: null,
+          totalPoints: 50,
+          currentStreak: 3,
+          schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' },
+        },
       ];
       mockPrisma.user.findMany.mockResolvedValue(students);
 
@@ -139,8 +155,15 @@ describe('TutorsService', () => {
     it('devuelve los cursos en los que está matriculado el alumno', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ tutorId: TUTOR_ID });
 
-      const course = { id: 'c1', title: 'Curso 1', schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' } };
-      mockPrisma.enrollment.findMany.mockResolvedValue([{ course }, { course: { id: 'c2', title: 'Curso 2', schoolYear: null } }]);
+      const course = {
+        id: 'c1',
+        title: 'Curso 1',
+        schoolYear: { id: 'sy1', name: '1eso', label: '1º ESO' },
+      };
+      mockPrisma.enrollment.findMany.mockResolvedValue([
+        { course },
+        { course: { id: 'c2', title: 'Curso 2', schoolYear: null } },
+      ]);
 
       const result = await service.getStudentCourses(TUTOR_ID, STUDENT_ID);
 
@@ -182,7 +205,11 @@ describe('TutorsService', () => {
       expect(result).toMatchObject({
         student: expect.objectContaining({ id: STUDENT_ID, name: 'Alumno' }),
         period: { from: null, to: null },
-        lessons: expect.objectContaining({ completedInPeriod: 0, completedAllTime: 0, activeDays: 0 }),
+        lessons: expect.objectContaining({
+          completedInPeriod: 0,
+          completedAllTime: 0,
+          activeDays: 0,
+        }),
         quizzes: expect.objectContaining({ attempts: 0, avgScore: null, bestScore: null }),
         exams: expect.objectContaining({ attempts: 0, avgScore: null, bestScore: null, passed: 0 }),
         certificates: { total: 0, byType: {} },
@@ -409,6 +436,69 @@ describe('TutorsService', () => {
 
       const dates = result.activity.map((a) => a.date);
       expect(dates).toEqual([...dates].sort());
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getStudentsCredentials
+  // -------------------------------------------------------------------------
+
+  describe('getStudentsCredentials', () => {
+    it('devuelve credenciales descifradas solo de alumnos del tutor', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([
+        { id: 's1', name: 'Pepe', email: 'pepe@x.com', viewablePassword: 'enc(aB3xY7Q9)' },
+        { id: 's2', name: 'Ana', email: 'ana@x.com', viewablePassword: 'enc(M9pQrS2t)' },
+      ]);
+
+      const result = await service.getStudentsCredentials(TUTOR_ID);
+
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { tutorId: TUTOR_ID },
+          select: expect.objectContaining({
+            id: true,
+            name: true,
+            email: true,
+            viewablePassword: true,
+          }),
+        }),
+      );
+      expect(result).toEqual([
+        { id: 's1', name: 'Pepe', email: 'pepe@x.com', password: 'aB3xY7Q9' },
+        { id: 's2', name: 'Ana', email: 'ana@x.com', password: 'M9pQrS2t' },
+      ]);
+    });
+
+    it('devuelve password=null cuando viewablePassword es null (alumno preexistente)', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([
+        { id: 's3', name: 'Old', email: 'old@x.com', viewablePassword: null },
+      ]);
+
+      const result = await service.getStudentsCredentials(TUTOR_ID);
+
+      expect(mockCrypto.decrypt).not.toHaveBeenCalled();
+      expect(result).toEqual([{ id: 's3', name: 'Old', email: 'old@x.com', password: null }]);
+    });
+
+    it('devuelve password=null si descifrar falla', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([
+        { id: 's4', name: 'Corrupt', email: 'c@x.com', viewablePassword: 'broken' },
+      ]);
+      mockCrypto.decrypt.mockImplementationOnce(() => {
+        throw new Error('bad tag');
+      });
+
+      const result = await service.getStudentsCredentials(TUTOR_ID);
+
+      expect(result).toEqual([{ id: 's4', name: 'Corrupt', email: 'c@x.com', password: null }]);
+    });
+
+    it('devuelve [] cuando el tutor no tiene alumnos', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([]);
+
+      const result = await service.getStudentsCredentials(TUTOR_ID);
+
+      expect(result).toEqual([]);
     });
   });
 });

--- a/apps/api/src/tutors/tutors.service.ts
+++ b/apps/api/src/tutors/tutors.service.ts
@@ -1,9 +1,15 @@
-import { Injectable, ForbiddenException, BadRequestException } from '@nestjs/common';
+import { Injectable, Logger, ForbiddenException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { CryptoService } from '../crypto/crypto.service';
 
 @Injectable()
 export class TutorsService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(TutorsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
 
   /**
    * Verifica que el alumno pertenece al tutor y devuelve sus campos básicos.
@@ -36,6 +42,36 @@ export class TutorsService {
         },
       },
       orderBy: { name: 'asc' },
+    });
+  }
+
+  /**
+   * Devuelve credenciales (email + contraseña descifrada) de cada alumno del tutor.
+   * Si `viewablePassword` es null o el descifrado falla, devuelve `password: null`.
+   */
+  async getStudentsCredentials(tutorId: string) {
+    const students = await this.prisma.user.findMany({
+      where: { tutorId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        viewablePassword: true,
+      },
+      orderBy: { name: 'asc' },
+    });
+
+    return students.map((s) => {
+      if (!s.viewablePassword) {
+        return { id: s.id, name: s.name, email: s.email, password: null };
+      }
+      try {
+        const password = this.crypto.decrypt(s.viewablePassword);
+        return { id: s.id, name: s.name, email: s.email, password };
+      } catch {
+        this.logger.warn(`No se pudo descifrar viewablePassword del alumno ${s.id}`);
+        return { id: s.id, name: s.name, email: s.email, password: null };
+      }
     });
   }
 

--- a/apps/web/src/api/tutors.api.ts
+++ b/apps/web/src/api/tutors.api.ts
@@ -87,8 +87,18 @@ export interface AvailableCourse {
   enrolled: boolean;
 }
 
+export interface StudentCredential {
+  id: string;
+  name: string;
+  email: string;
+  password: string | null;
+}
+
 export const tutorsApi = {
   getMyStudents: () => api.get<StudentSummary[]>('/tutors/my-students').then((r) => r.data),
+
+  getStudentsCredentials: () =>
+    api.get<StudentCredential[]>('/tutors/my-students/credentials').then((r) => r.data),
 
   getStudentCourses: (studentId: string) =>
     api.get<EnrolledCourse[]>(`/tutors/my-students/${studentId}/courses`).then((r) => r.data),

--- a/apps/web/src/components/tutor/StudentCredentialsTable.tsx
+++ b/apps/web/src/components/tutor/StudentCredentialsTable.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { tutorsApi, type StudentCredential } from '../../api/tutors.api';
+import { authApi } from '../../api/auth.api';
+
+const ORANGE = '#ea580c';
+
+export function StudentCredentialsTable() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['tutor', 'students', 'credentials'],
+    queryFn: () => tutorsApi.getStudentsCredentials(),
+    staleTime: 0,
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: (email: string) => authApi.forgotPassword(email),
+  });
+
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  if (isLoading) return <div style={{ padding: 16 }}>Cargando credenciales…</div>;
+  if (isError)
+    return <div style={{ padding: 16, color: '#b91c1c' }}>Error al cargar credenciales.</div>;
+  if (!data || data.length === 0) return null;
+
+  const onCopy = async (item: StudentCredential) => {
+    if (!item.password) return;
+    await navigator.clipboard.writeText(item.password);
+    setCopiedId(item.id);
+    setTimeout(() => setCopiedId((id) => (id === item.id ? null : id)), 1500);
+  };
+
+  return (
+    <section
+      style={{
+        background: '#fff',
+        borderRadius: 12,
+        padding: 20,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+      }}
+    >
+      <h2
+        style={{
+          fontSize: '1.1rem',
+          fontWeight: 700,
+          margin: 0,
+          marginBottom: 4,
+          color: '#0d1b2a',
+        }}
+      >
+        Credenciales de mis alumnos
+      </h2>
+      <p style={{ fontSize: '0.85rem', color: '#64748b', margin: 0, marginBottom: 16 }}>
+        Estas credenciales son privadas. No las compartas en sitios públicos.
+      </p>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+        <thead>
+          <tr style={{ textAlign: 'left', borderBottom: '1px solid #e2e8f0' }}>
+            <th style={{ padding: '8px 4px', fontWeight: 600 }}>Nombre</th>
+            <th style={{ padding: '8px 4px', fontWeight: 600 }}>Email</th>
+            <th style={{ padding: '8px 4px', fontWeight: 600 }}>Contraseña</th>
+            <th style={{ padding: '8px 4px', fontWeight: 600, width: 140 }}>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item) => (
+            <tr key={item.id} style={{ borderBottom: '1px solid #f1f5f9' }}>
+              <td style={{ padding: '8px 4px' }}>{item.name}</td>
+              <td style={{ padding: '8px 4px', fontFamily: 'monospace' }}>{item.email}</td>
+              <td style={{ padding: '8px 4px', fontFamily: 'monospace' }}>
+                {item.password ? (
+                  <>
+                    {item.password}
+                    <button
+                      type="button"
+                      onClick={() => onCopy(item)}
+                      title="Copiar al portapapeles"
+                      style={{
+                        marginLeft: 8,
+                        background: 'transparent',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: ORANGE,
+                      }}
+                    >
+                      {copiedId === item.id ? '✓ copiada' : '📋'}
+                    </button>
+                  </>
+                ) : (
+                  <span style={{ color: '#94a3b8' }}>—</span>
+                )}
+              </td>
+              <td style={{ padding: '8px 4px' }}>
+                {!item.password && (
+                  <button
+                    type="button"
+                    onClick={() => resetMutation.mutate(item.email)}
+                    disabled={resetMutation.isPending}
+                    style={{
+                      padding: '6px 10px',
+                      borderRadius: 6,
+                      border: `1px solid ${ORANGE}`,
+                      background: 'transparent',
+                      color: ORANGE,
+                      cursor: resetMutation.isPending ? 'wait' : 'pointer',
+                      fontSize: '0.8rem',
+                    }}
+                  >
+                    Restablecer
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {resetMutation.isSuccess && (
+        <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#16a34a' }}>
+          Email de restablecimiento enviado. Revisa la bandeja del alumno.
+        </p>
+      )}
+      {resetMutation.isError && (
+        <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#b91c1c' }}>
+          Error al solicitar el restablecimiento. Inténtalo de nuevo.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/pages/TutorStudentsPage.tsx
+++ b/apps/web/src/pages/TutorStudentsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { StudentCredentialsTable } from '../components/tutor/StudentCredentialsTable';
 import {
   tutorsApi,
   type StudentSummary,
@@ -878,9 +879,14 @@ export default function TutorStudentsPage() {
 
       {/* ── Panel de detalle ── */}
       {!selected ? (
-        <div style={S.empty}>
-          <span style={{ fontSize: '3rem' }}>👈</span>
-          <p style={S.emptyText}>Selecciona un alumno para ver sus métricas</p>
+        <div style={{ ...S.empty, display: 'block', padding: '2rem' }}>
+          <StudentCredentialsTable />
+          <div style={{ textAlign: 'center', marginTop: '2rem', color: '#94a3b8' }}>
+            <span style={{ fontSize: '2rem' }}>👈</span>
+            <p style={{ ...S.emptyText, marginTop: '0.5rem' }}>
+              Selecciona un alumno para ver sus métricas
+            </p>
+          </div>
         </div>
       ) : (
         <div style={S.detail}>

--- a/docs/superpowers/plans/2026-05-07-tutor-student-credentials.md
+++ b/docs/superpowers/plans/2026-05-07-tutor-student-credentials.md
@@ -1,0 +1,1142 @@
+# Tutor Student Credentials Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir que el tutor vea, en cualquier momento desde su dashboard, las credenciales (email + contraseña en plano) de cada uno de sus alumnos.
+
+**Architecture:** Añadir un campo `viewablePassword` al modelo `User`, cifrado con AES-256-GCM (clave en env). Sincronizarlo en los tres flujos que mutan la contraseña de un alumno (`registerTutor`, `resetPassword`, `admin.updateUser`). Exponer un endpoint `GET /tutors/my-students/credentials` que descifra y devuelve las credenciales solo para los alumnos del tutor solicitante.
+
+**Tech Stack:** NestJS, Prisma, PostgreSQL, Node `crypto` (AES-256-GCM nativo), React + React Query, Vite.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-tutor-student-credentials-design.md`
+
+---
+
+## File Structure
+
+**Crear:**
+
+- `apps/api/src/crypto/crypto.module.ts` — módulo Nest exportable
+- `apps/api/src/crypto/crypto.service.ts` — `encrypt` / `decrypt` con AES-256-GCM
+- `apps/api/src/crypto/crypto.service.spec.ts` — round-trip, manipulación, validación de clave
+- `apps/api/prisma/migrations/<timestamp>_add_user_viewable_password/migration.sql` — Prisma genera
+- `apps/web/src/components/tutor/StudentCredentialsTable.tsx` — tabla con copiar al portapapeles + botón restablecer
+
+**Modificar:**
+
+- `apps/api/prisma/schema.prisma` — añade `viewablePassword String?` al `User`
+- `apps/api/src/auth/auth.module.ts` — importar `CryptoModule`
+- `apps/api/src/auth/auth.service.ts` — `registerTutor`, `resetPassword`
+- `apps/api/src/auth/auth-register-tutor.service.spec.ts` — verifica encriptación
+- `apps/api/src/auth/auth.service.spec.ts` — verifica resetPassword sync
+- `apps/api/src/admin/admin.module.ts` — importar `CryptoModule`
+- `apps/api/src/admin/admin.service.ts` — `updateUser`
+- `apps/api/src/admin/admin.service.spec.ts` — verifica sync condicionada al rol
+- `apps/api/src/tutors/tutors.module.ts` — importar `CryptoModule`
+- `apps/api/src/tutors/tutors.controller.ts` — nuevo route handler
+- `apps/api/src/tutors/tutors.service.ts` — nuevo método `getStudentsCredentials`
+- `apps/api/src/tutors/tutors.service.spec.ts` — verifica filtro y descifrado
+- `apps/api/.env.example` — `STUDENT_PASSWORD_ENC_KEY`
+- `apps/web/src/api/tutors.api.ts` — añade `getStudentsCredentials`
+- `apps/web/src/pages/TutorStudentsPage.tsx` — integra `StudentCredentialsTable`
+- `CLAUDE.md` — sección 9 documenta nueva env var
+
+---
+
+## Task 1: CryptoService
+
+**Files:**
+
+- Create: `apps/api/src/crypto/crypto.service.ts`
+- Create: `apps/api/src/crypto/crypto.service.spec.ts`
+- Create: `apps/api/src/crypto/crypto.module.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Crear `apps/api/src/crypto/crypto.service.spec.ts`:
+
+```ts
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { CryptoService } from './crypto.service';
+
+const VALID_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+async function buildService(keyValue: string | undefined): Promise<CryptoService> {
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      CryptoService,
+      {
+        provide: ConfigService,
+        useValue: { get: jest.fn().mockReturnValue(keyValue) },
+      },
+    ],
+  }).compile();
+  return moduleRef.get(CryptoService);
+}
+
+describe('CryptoService', () => {
+  it('encrypt + decrypt preserva el plaintext', async () => {
+    const service = await buildService(VALID_KEY);
+    const plain = 'aB3xY7Q9';
+    const encrypted = service.encrypt(plain);
+    expect(service.decrypt(encrypted)).toBe(plain);
+  });
+
+  it('produce ciphertext distinto en cada llamada con el mismo input (IV aleatorio)', async () => {
+    const service = await buildService(VALID_KEY);
+    const a = service.encrypt('same');
+    const b = service.encrypt('same');
+    expect(a).not.toBe(b);
+    expect(service.decrypt(a)).toBe('same');
+    expect(service.decrypt(b)).toBe('same');
+  });
+
+  it('detecta manipulación del ciphertext mediante el auth tag', async () => {
+    const service = await buildService(VALID_KEY);
+    const encrypted = service.encrypt('secret');
+    const tampered = encrypted.slice(0, -1) + (encrypted.endsWith('0') ? '1' : '0');
+    expect(() => service.decrypt(tampered)).toThrow();
+  });
+
+  it('falla al construirse si la clave tiene longitud incorrecta', async () => {
+    await expect(buildService('tooshort')).rejects.toThrow('STUDENT_PASSWORD_ENC_KEY');
+  });
+
+  it('falla al construirse si la clave no está definida', async () => {
+    await expect(buildService(undefined)).rejects.toThrow('STUDENT_PASSWORD_ENC_KEY');
+  });
+
+  it('rechaza payload con formato inválido al descifrar', async () => {
+    const service = await buildService(VALID_KEY);
+    expect(() => service.decrypt('no-colons')).toThrow();
+    expect(() => service.decrypt('only:two')).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `pnpm --filter @vkbacademy/api test crypto.service.spec`
+Expected: FAIL — `CryptoService` no existe.
+
+- [ ] **Step 3: Implement CryptoService and CryptoModule**
+
+Crear `apps/api/src/crypto/crypto.service.ts`:
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const ENV_VAR = 'STUDENT_PASSWORD_ENC_KEY';
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const KEY_HEX_LENGTH = 64; // 32 bytes
+
+@Injectable()
+export class CryptoService {
+  private readonly key: Buffer;
+
+  constructor(config: ConfigService) {
+    const raw = config.get<string>(ENV_VAR);
+    if (!raw || raw.length !== KEY_HEX_LENGTH || !/^[0-9a-fA-F]+$/.test(raw)) {
+      throw new Error(
+        `${ENV_VAR} debe ser una cadena hex de ${KEY_HEX_LENGTH} caracteres (32 bytes). Genérala con \`openssl rand -hex 32\`.`,
+      );
+    }
+    this.key = Buffer.from(raw, 'hex');
+  }
+
+  /**
+   * Cifra un texto plano con AES-256-GCM. Devuelve "iv:authTag:ciphertext" en hex.
+   * Cada llamada produce un IV nuevo, por lo que la salida no es determinista.
+   */
+  encrypt(plain: string): string {
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(ALGORITHM, this.key, iv);
+    const encrypted = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return `${iv.toString('hex')}:${tag.toString('hex')}:${encrypted.toString('hex')}`;
+  }
+
+  /**
+   * Descifra un payload "iv:authTag:ciphertext". Lanza si el auth tag no
+   * cuadra (datos manipulados o clave incorrecta) o si el formato es inválido.
+   */
+  decrypt(payload: string): string {
+    const parts = payload.split(':');
+    if (parts.length !== 3) {
+      throw new Error('Formato de payload inválido');
+    }
+    const [ivHex, tagHex, dataHex] = parts;
+    const iv = Buffer.from(ivHex, 'hex');
+    const tag = Buffer.from(tagHex, 'hex');
+    const data = Buffer.from(dataHex, 'hex');
+    const decipher = createDecipheriv(ALGORITHM, this.key, iv);
+    decipher.setAuthTag(tag);
+    const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+    return decrypted.toString('utf8');
+  }
+}
+```
+
+Crear `apps/api/src/crypto/crypto.module.ts`:
+
+```ts
+import { Global, Module } from '@nestjs/common';
+import { CryptoService } from './crypto.service';
+
+@Global()
+@Module({
+  providers: [CryptoService],
+  exports: [CryptoService],
+})
+export class CryptoModule {}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `pnpm --filter @vkbacademy/api test crypto.service.spec`
+Expected: PASS — los 6 tests verdes.
+
+- [ ] **Step 5: Register CryptoModule globally in AppModule**
+
+Modificar `apps/api/src/app.module.ts`. Añadir junto a los otros imports:
+
+```ts
+import { CryptoModule } from './crypto/crypto.module';
+```
+
+Y añadirlo al array `imports`. Búscalo entre los otros (orden alfabético si se sigue, si no al final). Como `CryptoModule` está marcado `@Global()`, basta con importarlo una vez aquí.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/crypto/ apps/api/src/app.module.ts
+git commit -m "feat(crypto): add CryptoService for AES-256-GCM symmetric encryption"
+```
+
+---
+
+## Task 2: Prisma schema migration — add `viewablePassword`
+
+**Files:**
+
+- Modify: `apps/api/prisma/schema.prisma:75`
+- Create: `apps/api/prisma/migrations/<timestamp>_add_user_viewable_password/migration.sql` (Prisma genera)
+
+- [ ] **Step 1: Add field to schema**
+
+En `apps/api/prisma/schema.prisma`, dentro del `model User { ... }`, justo después de la línea `passwordHash String`, añadir:
+
+```prisma
+  viewablePassword String?  // AES-256-GCM (iv:tag:ciphertext). Solo poblado para STUDENT con tutorId.
+```
+
+- [ ] **Step 2: Generar migración**
+
+Ejecutar (necesita Postgres en local levantado vía `docker compose up -d`):
+
+```bash
+pnpm --filter @vkbacademy/api prisma migrate dev --name add_user_viewable_password
+```
+
+Esto:
+
+- Genera `apps/api/prisma/migrations/<timestamp>_add_user_viewable_password/migration.sql`
+- Aplica la migración a la BD local
+- Regenera el cliente Prisma (`@prisma/client`) con el campo nuevo
+
+- [ ] **Step 3: Verificar que el cliente compila**
+
+Run: `pnpm --filter @vkbacademy/api exec tsc --noEmit`
+Expected: PASS, sin errores. (Pueden persistir errores preexistentes ajenos a esta feature; el cambio no debe introducir nuevos errores.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "feat(db): add User.viewablePassword for tutor-visible student passwords"
+```
+
+---
+
+## Task 3: `auth.service.registerTutor` cifra `viewablePassword`
+
+**Files:**
+
+- Modify: `apps/api/src/auth/auth.service.ts:104-191`
+- Modify: `apps/api/src/auth/auth-register-tutor.service.spec.ts`
+- Modify: `apps/api/src/auth/auth.module.ts`
+
+- [ ] **Step 1: Inspeccionar el spec existente**
+
+Run: `head -80 apps/api/src/auth/auth-register-tutor.service.spec.ts`
+
+Familiarízate con cómo mockea `PrismaService` y `NotificationsService`. Busca el bloque que configura la transacción y los `tx.user.create` para tutor + alumnos.
+
+- [ ] **Step 2: Ampliar el mock para inyectar CryptoService**
+
+En `auth-register-tutor.service.spec.ts`, en la sección de mocks/providers añadir:
+
+```ts
+import { CryptoService } from '../crypto/crypto.service';
+
+const mockCrypto = {
+  encrypt: jest.fn((plain: string) => `enc(${plain})`),
+  decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
+};
+```
+
+Y en el `Test.createTestingModule({ providers: [...] })` añadir:
+
+```ts
+{ provide: CryptoService, useValue: mockCrypto },
+```
+
+- [ ] **Step 3: Write failing test**
+
+Añadir al final del `describe('registerTutor')`:
+
+```ts
+it('guarda viewablePassword cifrado para cada alumno creado', async () => {
+  // Reaprovecha el setup del happy path existente: mocks de academy, prisma.$transaction,
+  // notifications, etc. Si el spec usa un helper, llámalo. Lo importante son las
+  // assertions sobre tx.user.create de cada alumno.
+
+  // Configurar:
+  // - prisma.academy.findUnique → academy activa
+  // - prisma.user.findUnique (chequeo email tutor) → null
+  // - prisma.$transaction ejecuta la callback con un tx mockeado
+  // - tx.user.create (tutor) y (alumnos) devuelven entidades con id
+
+  // Llamar:
+  await service.registerTutor({
+    email: 'tutor@x.com',
+    password: 'tutorPass',
+    name: 'Tutor',
+    academySlug: 'vallekas-basket',
+    students: [{ name: 'Alumno Uno' }, { name: 'Alumno Dos' }],
+  });
+
+  // Assert: encrypt fue llamado dos veces (una por alumno) con la password generada
+  expect(mockCrypto.encrypt).toHaveBeenCalledTimes(2);
+
+  // Assert: cada tx.user.create de un alumno (role STUDENT) recibió viewablePassword = `enc(${plain})`
+  const studentCreateCalls = txMock.user.create.mock.calls.filter(
+    ([arg]: [{ data: { role: string } }]) => arg.data.role === 'STUDENT',
+  );
+  expect(studentCreateCalls).toHaveLength(2);
+  for (const [arg] of studentCreateCalls) {
+    expect(arg.data.viewablePassword).toBeDefined();
+    expect(arg.data.viewablePassword).toMatch(/^enc\(.+\)$/);
+  }
+});
+```
+
+> Nota: el nombre exacto del mock `txMock` depende de cómo esté escrito el spec actual. Si usa otra variable, ajústalo. Si el spec no usa `tx.user.create` separable, configura `prisma.$transaction.mockImplementation(async (cb) => cb(tx))` con un `tx` local antes de llamar al servicio.
+
+- [ ] **Step 4: Run test, expect FAIL**
+
+Run: `pnpm --filter @vkbacademy/api test auth-register-tutor.service.spec`
+Expected: FAIL — `viewablePassword` no se está pasando al `tx.user.create`.
+
+- [ ] **Step 5: Implementar**
+
+Modificar `apps/api/src/auth/auth.service.ts`:
+
+1. Importar al inicio:
+
+   ```ts
+   import { CryptoService } from '../crypto/crypto.service';
+   ```
+
+2. Inyectar en el constructor (añadir como dependencia más):
+
+   ```ts
+   constructor(
+     // ...dependencias existentes
+     private readonly crypto: CryptoService,
+   ) {}
+   ```
+
+3. En `registerTutor`, justo después de generar las contraseñas (`studentPasswords`) y antes de la transacción, cifrarlas:
+
+   ```ts
+   const studentViewable = studentPasswords.map((pw) => this.crypto.encrypt(pw));
+   ```
+
+4. Dentro de `tx.user.create` para cada alumno, añadir el campo:
+   ```ts
+   data: {
+     email: studentEmails[index],
+     passwordHash: studentPasswordHashes[index],
+     viewablePassword: studentViewable[index],  // ← nuevo
+     name: studentDto.name,
+     role: 'STUDENT',
+     tutorId: createdTutor.id,
+     // ...resto sin cambios
+   }
+   ```
+
+Modificar `apps/api/src/auth/auth.module.ts`. Si `CryptoModule` ya está como `@Global()` en `AppModule` no hay que tocar `auth.module.ts`. Verifícalo: si `CryptoService` se resuelve en runtime sin importar nada en `auth.module.ts`, perfecto. Si Nest pide que se importe explícitamente, añadir:
+
+```ts
+import { CryptoModule } from '../crypto/crypto.module';
+// ...
+@Module({ imports: [..., CryptoModule], ... })
+```
+
+- [ ] **Step 6: Run test, expect PASS**
+
+Run: `pnpm --filter @vkbacademy/api test auth-register-tutor.service.spec`
+Expected: PASS.
+
+Run también la suite completa de auth para no regresar:
+`pnpm --filter @vkbacademy/api test auth`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/auth/
+git commit -m "feat(auth): encrypt and store viewablePassword on tutor-driven student creation"
+```
+
+---
+
+## Task 4: `auth.service.resetPassword` sincroniza `viewablePassword`
+
+**Files:**
+
+- Modify: `apps/api/src/auth/auth.service.ts:332-360`
+- Modify: `apps/api/src/auth/auth.service.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+En `apps/api/src/auth/auth.service.spec.ts`, en el describe de `resetPassword` (créalo si no existe), añadir:
+
+```ts
+describe('resetPassword', () => {
+  it('actualiza viewablePassword cuando el usuario es STUDENT con tutor', async () => {
+    const student = {
+      id: 'st1',
+      email: 's@x.com',
+      role: 'STUDENT',
+      tutorId: 'tut1',
+      passwordHash: 'oldhash',
+    };
+    mockPrisma.user.findUnique.mockResolvedValue(student);
+    // El secret incluye el passwordHash actual; firmar token de reset:
+    const token = jwt.sign(
+      { sub: student.id, email: student.email },
+      mockConfig.get('JWT_SECRET') + student.passwordHash,
+      { expiresIn: '1h' },
+    );
+    mockCrypto.encrypt.mockReturnValue('enc(newSecret)');
+
+    await service.resetPassword(token, 'newSecret');
+
+    expect(mockCrypto.encrypt).toHaveBeenCalledWith('newSecret');
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: student.id },
+        data: expect.objectContaining({
+          passwordHash: expect.any(String),
+          viewablePassword: 'enc(newSecret)',
+        }),
+      }),
+    );
+  });
+
+  it('NO toca viewablePassword cuando el usuario es TUTOR', async () => {
+    const tutor = {
+      id: 'tut1',
+      email: 't@x.com',
+      role: 'TUTOR',
+      tutorId: null,
+      passwordHash: 'oldhash',
+    };
+    mockPrisma.user.findUnique.mockResolvedValue(tutor);
+    const token = jwt.sign(
+      { sub: tutor.id, email: tutor.email },
+      mockConfig.get('JWT_SECRET') + tutor.passwordHash,
+      { expiresIn: '1h' },
+    );
+
+    await service.resetPassword(token, 'newSecret');
+
+    expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+    const updateArg = mockPrisma.user.update.mock.calls[0][0];
+    expect(updateArg.data).not.toHaveProperty('viewablePassword');
+  });
+
+  it('NO toca viewablePassword cuando el usuario es STUDENT sin tutor', async () => {
+    const orphan = {
+      id: 's2',
+      email: 'o@x.com',
+      role: 'STUDENT',
+      tutorId: null,
+      passwordHash: 'oldhash',
+    };
+    mockPrisma.user.findUnique.mockResolvedValue(orphan);
+    const token = jwt.sign(
+      { sub: orphan.id, email: orphan.email },
+      mockConfig.get('JWT_SECRET') + orphan.passwordHash,
+      { expiresIn: '1h' },
+    );
+
+    await service.resetPassword(token, 'newSecret');
+
+    expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+    const updateArg = mockPrisma.user.update.mock.calls[0][0];
+    expect(updateArg.data).not.toHaveProperty('viewablePassword');
+  });
+});
+```
+
+> Nota: el spec usa `jwt.sign` con el secret real para que `verify` en el servicio acepte el token. Asegúrate de que `mockConfig.get('JWT_SECRET')` devuelve un string fijo (p. ej. `'test-secret'`). Si `auth.service.spec.ts` ya tiene un mock de Config, reusa ese valor.
+
+> Si el spec actual no inyecta `CryptoService`, añade el provider mock como en Task 3:
+>
+> ```ts
+> const mockCrypto = { encrypt: jest.fn(), decrypt: jest.fn() };
+> // ...providers: [{ provide: CryptoService, useValue: mockCrypto }]
+> ```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `pnpm --filter @vkbacademy/api test auth.service.spec`
+Expected: FAIL — el primer test falla porque `viewablePassword` no se incluye en el update.
+
+- [ ] **Step 3: Implementar**
+
+En `apps/api/src/auth/auth.service.ts`, dentro de `resetPassword`, sustituir la sección final (`const passwordHash = await bcrypt.hash(...); await this.prisma.user.update(...)`) por:
+
+```ts
+const passwordHash = await bcrypt.hash(newPassword, 10);
+
+const data: { passwordHash: string; viewablePassword?: string } = { passwordHash };
+if (user.role === 'STUDENT' && user.tutorId) {
+  data.viewablePassword = this.crypto.encrypt(newPassword);
+}
+
+await this.prisma.user.update({ where: { id: user.id }, data });
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `pnpm --filter @vkbacademy/api test auth.service.spec`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/auth/
+git commit -m "feat(auth): sync viewablePassword on resetPassword for student-with-tutor"
+```
+
+---
+
+## Task 5: `admin.service.updateUser` sincroniza `viewablePassword`
+
+**Files:**
+
+- Modify: `apps/api/src/admin/admin.service.ts:116-135`
+- Modify: `apps/api/src/admin/admin.service.spec.ts`
+- Modify: `apps/api/src/admin/admin.module.ts` (si `CryptoModule` no se resuelve global)
+
+- [ ] **Step 1: Write failing tests**
+
+En `apps/api/src/admin/admin.service.spec.ts`, añadir mock `CryptoService` (como en Task 3) y en el describe de `updateUser` añadir:
+
+```ts
+describe('updateUser viewablePassword sync', () => {
+  it('actualiza viewablePassword cuando target es STUDENT con tutor y dto trae password', async () => {
+    const student = { id: 'st1', role: 'STUDENT', tutorId: 'tut1', passwordHash: 'old' };
+    mockPrisma.user.findUnique.mockResolvedValue(student);
+    mockPrisma.user.update.mockResolvedValue({ ...student, passwordHash: 'new' });
+    mockCrypto.encrypt.mockReturnValue('enc(secret)');
+
+    await service.updateUser('st1', { password: 'secret' });
+
+    expect(mockCrypto.encrypt).toHaveBeenCalledWith('secret');
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'st1' },
+        data: expect.objectContaining({
+          passwordHash: expect.any(String),
+          viewablePassword: 'enc(secret)',
+        }),
+      }),
+    );
+  });
+
+  it('NO toca viewablePassword cuando target NO es STUDENT', async () => {
+    const teacher = { id: 'tch1', role: 'TEACHER', tutorId: null, passwordHash: 'old' };
+    mockPrisma.user.findUnique.mockResolvedValue(teacher);
+    mockPrisma.user.update.mockResolvedValue(teacher);
+
+    await service.updateUser('tch1', { password: 'secret' });
+
+    expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+    const updateArg = mockPrisma.user.update.mock.calls[0][0];
+    expect(updateArg.data).not.toHaveProperty('viewablePassword');
+  });
+
+  it('NO toca viewablePassword cuando dto NO trae password (cambio de email/nombre)', async () => {
+    const student = { id: 'st1', role: 'STUDENT', tutorId: 'tut1', passwordHash: 'old' };
+    mockPrisma.user.findUnique.mockResolvedValue(student);
+    mockPrisma.user.update.mockResolvedValue(student);
+
+    await service.updateUser('st1', { name: 'Otro Nombre' });
+
+    expect(mockCrypto.encrypt).not.toHaveBeenCalled();
+    const updateArg = mockPrisma.user.update.mock.calls[0][0];
+    expect(updateArg.data).not.toHaveProperty('viewablePassword');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `pnpm --filter @vkbacademy/api test admin.service.spec`
+Expected: FAIL — primer test fallará porque `updateUser` no setea `viewablePassword`.
+
+- [ ] **Step 3: Implementar**
+
+En `apps/api/src/admin/admin.service.ts`, modificar `updateUser` para inyectar `CryptoService` (constructor) y actualizar el bloque de password:
+
+```ts
+import { CryptoService } from '../crypto/crypto.service';
+
+// constructor:
+constructor(
+  // ...existentes
+  private readonly crypto: CryptoService,
+) {}
+
+// dentro de updateUser, sustituir:
+//   if (dto.password) data.passwordHash = await bcrypt.hash(dto.password, 10);
+// por:
+if (dto.password) {
+  data.passwordHash = await bcrypt.hash(dto.password, 10);
+  // Cargar el usuario para conocer rol y tutorId (si no está ya en scope)
+  const target = await this.prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true, tutorId: true },
+  });
+  if (target?.role === 'STUDENT' && target.tutorId) {
+    data.viewablePassword = this.crypto.encrypt(dto.password);
+  }
+}
+```
+
+> Si `updateUser` ya hace un `findUnique` previo del usuario, reutilízalo en vez de hacer otra query.
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `pnpm --filter @vkbacademy/api test admin.service.spec`
+Expected: PASS — incluyendo los 21 tests previos.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/admin/
+git commit -m "feat(admin): sync viewablePassword on updateUser for student-with-tutor"
+```
+
+---
+
+## Task 6: Endpoint `GET /tutors/my-students/credentials`
+
+**Files:**
+
+- Modify: `apps/api/src/tutors/tutors.service.ts`
+- Modify: `apps/api/src/tutors/tutors.service.spec.ts`
+- Modify: `apps/api/src/tutors/tutors.controller.ts`
+- Modify: `apps/api/src/tutors/tutors.module.ts` (si `CryptoModule` no es global)
+
+- [ ] **Step 1: Write failing tests**
+
+En `apps/api/src/tutors/tutors.service.spec.ts`:
+
+1. Añadir el mock de `CryptoService`:
+
+```ts
+import { CryptoService } from '../crypto/crypto.service';
+
+const mockCrypto = {
+  encrypt: jest.fn(),
+  decrypt: jest.fn((cipher: string) => cipher.replace(/^enc\(|\)$/g, '')),
+};
+```
+
+Y registrarlo en el `providers` del `Test.createTestingModule`:
+
+```ts
+{ provide: CryptoService, useValue: mockCrypto },
+```
+
+Limpiar `mockCrypto.decrypt` en `beforeEach` (`jest.clearAllMocks()` ya está, así que basta con resetear el `mockImplementation` si lo cambiamos en algún test).
+
+2. Añadir el describe nuevo:
+
+```ts
+describe('getStudentsCredentials', () => {
+  it('devuelve credenciales descifradas solo de alumnos del tutor', async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      { id: 's1', name: 'Pepe', email: 'pepe@x.com', viewablePassword: 'enc(aB3xY7Q9)' },
+      { id: 's2', name: 'Ana', email: 'ana@x.com', viewablePassword: 'enc(M9pQrS2t)' },
+    ]);
+
+    const result = await service.getStudentsCredentials(TUTOR_ID);
+
+    expect(mockPrisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tutorId: TUTOR_ID },
+        select: expect.objectContaining({
+          id: true,
+          name: true,
+          email: true,
+          viewablePassword: true,
+        }),
+      }),
+    );
+    expect(result).toEqual([
+      { id: 's1', name: 'Pepe', email: 'pepe@x.com', password: 'aB3xY7Q9' },
+      { id: 's2', name: 'Ana', email: 'ana@x.com', password: 'M9pQrS2t' },
+    ]);
+  });
+
+  it('devuelve password=null cuando viewablePassword es null (alumno preexistente)', async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      { id: 's3', name: 'Old', email: 'old@x.com', viewablePassword: null },
+    ]);
+
+    const result = await service.getStudentsCredentials(TUTOR_ID);
+
+    expect(mockCrypto.decrypt).not.toHaveBeenCalled();
+    expect(result).toEqual([{ id: 's3', name: 'Old', email: 'old@x.com', password: null }]);
+  });
+
+  it('devuelve password=null y loguea warning si descifrar falla', async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      { id: 's4', name: 'Corrupt', email: 'c@x.com', viewablePassword: 'broken' },
+    ]);
+    mockCrypto.decrypt.mockImplementationOnce(() => {
+      throw new Error('bad tag');
+    });
+
+    const result = await service.getStudentsCredentials(TUTOR_ID);
+
+    expect(result).toEqual([{ id: 's4', name: 'Corrupt', email: 'c@x.com', password: null }]);
+  });
+
+  it('devuelve [] cuando el tutor no tiene alumnos', async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+
+    const result = await service.getStudentsCredentials(TUTOR_ID);
+
+    expect(result).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `pnpm --filter @vkbacademy/api test tutors.service.spec`
+Expected: FAIL — `service.getStudentsCredentials` no existe.
+
+- [ ] **Step 3: Implementar el servicio**
+
+En `apps/api/src/tutors/tutors.service.ts`:
+
+1. Importar e inyectar `CryptoService` en el constructor:
+
+```ts
+import { CryptoService } from '../crypto/crypto.service';
+
+constructor(
+  private readonly prisma: PrismaService,
+  private readonly crypto: CryptoService,
+) {}
+```
+
+2. Añadir el método (al final de la clase):
+
+```ts
+async getStudentsCredentials(tutorId: string) {
+  const students = await this.prisma.user.findMany({
+    where: { tutorId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      viewablePassword: true,
+    },
+    orderBy: { name: 'asc' },
+  });
+
+  return students.map((s) => {
+    if (!s.viewablePassword) {
+      return { id: s.id, name: s.name, email: s.email, password: null };
+    }
+    try {
+      const password = this.crypto.decrypt(s.viewablePassword);
+      return { id: s.id, name: s.name, email: s.email, password };
+    } catch (err) {
+      // No loguear el ciphertext ni el plaintext; solo el id afectado.
+      this.logger.warn(`No se pudo descifrar viewablePassword del alumno ${s.id}`);
+      return { id: s.id, name: s.name, email: s.email, password: null };
+    }
+  });
+}
+```
+
+> Si `TutorsService` no tiene `private readonly logger = new Logger(TutorsService.name);`, añádelo en la clase.
+
+- [ ] **Step 4: Run service tests, expect PASS**
+
+Run: `pnpm --filter @vkbacademy/api test tutors.service.spec`
+Expected: PASS.
+
+- [ ] **Step 5: Añadir el route handler**
+
+En `apps/api/src/tutors/tutors.controller.ts`, añadir como nuevo método (mismo patrón que `getMyStudents`):
+
+```ts
+@Get('my-students/credentials')
+@Roles(Role.TUTOR, Role.ADMIN)
+getMyStudentsCredentials(@CurrentUser() user: User) {
+  return this.tutorsService.getStudentsCredentials(user.id);
+}
+```
+
+> Importante: este `@Get` debe quedar **antes** de `@Get('my-students/:studentId/...')` en el archivo, porque NestJS hace matching ordenado y `:studentId` capturaría `credentials`. Confírmalo: en el orden del archivo, ponlo justo después del `getMyStudents()` y antes de cualquier ruta con `:studentId`.
+
+- [ ] **Step 6: Verificar end-to-end con el smoke del API**
+
+Run: `pnpm --filter @vkbacademy/api test`
+Expected: PASS — toda la suite verde.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/tutors/
+git commit -m "feat(tutors): GET /tutors/my-students/credentials returns decrypted student credentials"
+```
+
+---
+
+## Task 7: Cliente API web
+
+**Files:**
+
+- Modify: `apps/web/src/api/tutors.api.ts`
+
+- [ ] **Step 1: Añadir tipo y método**
+
+Al final de `apps/web/src/api/tutors.api.ts`, antes del cierre del objeto `tutorsApi`:
+
+1. Añadir tipo (junto a las otras interfaces):
+
+```ts
+export interface StudentCredential {
+  id: string;
+  name: string;
+  email: string;
+  password: string | null;
+}
+```
+
+2. Añadir método dentro del objeto exportado:
+
+```ts
+getStudentsCredentials: () =>
+  api
+    .get<StudentCredential[]>('/tutors/my-students/credentials')
+    .then((r) => r.data),
+```
+
+- [ ] **Step 2: Verificar tsc**
+
+Run: `pnpm --filter @vkbacademy/web exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/api/tutors.api.ts
+git commit -m "feat(web): add tutorsApi.getStudentsCredentials"
+```
+
+---
+
+## Task 8: Componente `StudentCredentialsTable` en TutorStudentsPage
+
+**Files:**
+
+- Create: `apps/web/src/components/tutor/StudentCredentialsTable.tsx`
+- Modify: `apps/web/src/pages/TutorStudentsPage.tsx`
+- Modify: `apps/web/src/api/auth.api.ts` (si no existe ya `forgotPassword`)
+
+- [ ] **Step 1: Confirmar disponibilidad del cliente forgotPassword**
+
+Run: `grep -n "forgotPassword\|forgot-password" apps/web/src/api/auth.api.ts`
+Expected: ya existe (lo usa la página de recuperación). Si no existe, añadir:
+
+```ts
+forgotPassword: (email: string) =>
+  api.post('/auth/forgot-password', { email }).then((r) => r.data),
+```
+
+- [ ] **Step 2: Crear el componente**
+
+Crear `apps/web/src/components/tutor/StudentCredentialsTable.tsx`:
+
+```tsx
+import React, { useState } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { tutorsApi, type StudentCredential } from '../../api/tutors.api';
+import { authApi } from '../../api/auth.api';
+
+const ORANGE = '#ea580c';
+
+export function StudentCredentialsTable() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['tutor', 'students', 'credentials'],
+    queryFn: () => tutorsApi.getStudentsCredentials(),
+    staleTime: 0,
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: (email: string) => authApi.forgotPassword(email),
+  });
+
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  if (isLoading) return <div style={{ padding: 16 }}>Cargando credenciales…</div>;
+  if (isError)
+    return <div style={{ padding: 16, color: '#b91c1c' }}>Error al cargar credenciales.</div>;
+  if (!data || data.length === 0) return null;
+
+  const onCopy = async (item: StudentCredential) => {
+    if (!item.password) return;
+    await navigator.clipboard.writeText(item.password);
+    setCopiedId(item.id);
+    setTimeout(() => setCopiedId((id) => (id === item.id ? null : id)), 1500);
+  };
+
+  return (
+    <section
+      style={{
+        background: '#fff',
+        borderRadius: 12,
+        padding: 20,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+      }}
+    >
+      <h2
+        style={{
+          fontSize: '1.1rem',
+          fontWeight: 700,
+          margin: 0,
+          marginBottom: 4,
+          color: '#0d1b2a',
+        }}
+      >
+        Credenciales de mis alumnos
+      </h2>
+      <p style={{ fontSize: '0.85rem', color: '#64748b', margin: 0, marginBottom: 16 }}>
+        Estas credenciales son privadas. No las compartas en sitios públicos.
+      </p>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+        <thead>
+          <tr style={{ textAlign: 'left', borderBottom: '1px solid #e2e8f0' }}>
+            <th style={{ padding: '8px 4px', fontWeight: 600 }}>Nombre</th>
+            <th style={{ padding: '8px 4px', fontWeight: 600 }}>Email</th>
+            <th style={{ padding: '8px 4px', fontWeight: 600 }}>Contraseña</th>
+            <th style={{ padding: '8px 4px', fontWeight: 600, width: 140 }}>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item) => (
+            <tr key={item.id} style={{ borderBottom: '1px solid #f1f5f9' }}>
+              <td style={{ padding: '8px 4px' }}>{item.name}</td>
+              <td style={{ padding: '8px 4px', fontFamily: 'monospace' }}>{item.email}</td>
+              <td style={{ padding: '8px 4px', fontFamily: 'monospace' }}>
+                {item.password ? (
+                  <>
+                    {item.password}
+                    <button
+                      type="button"
+                      onClick={() => onCopy(item)}
+                      title="Copiar al portapapeles"
+                      style={{
+                        marginLeft: 8,
+                        background: 'transparent',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: ORANGE,
+                      }}
+                    >
+                      {copiedId === item.id ? '✓ copiada' : '📋'}
+                    </button>
+                  </>
+                ) : (
+                  <span style={{ color: '#94a3b8' }}>—</span>
+                )}
+              </td>
+              <td style={{ padding: '8px 4px' }}>
+                {!item.password && (
+                  <button
+                    type="button"
+                    onClick={() => resetMutation.mutate(item.email)}
+                    disabled={resetMutation.isPending}
+                    style={{
+                      padding: '6px 10px',
+                      borderRadius: 6,
+                      border: `1px solid ${ORANGE}`,
+                      background: 'transparent',
+                      color: ORANGE,
+                      cursor: resetMutation.isPending ? 'wait' : 'pointer',
+                      fontSize: '0.8rem',
+                    }}
+                  >
+                    Restablecer
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {resetMutation.isSuccess && (
+        <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#16a34a' }}>
+          Email de restablecimiento enviado. Revisa la bandeja del alumno.
+        </p>
+      )}
+      {resetMutation.isError && (
+        <p style={{ marginTop: 12, fontSize: '0.85rem', color: '#b91c1c' }}>
+          Error al solicitar el restablecimiento. Inténtalo de nuevo.
+        </p>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Integrar en TutorStudentsPage**
+
+Modificar `apps/web/src/pages/TutorStudentsPage.tsx`:
+
+1. Importar el componente:
+
+   ```tsx
+   import { StudentCredentialsTable } from '../components/tutor/StudentCredentialsTable';
+   ```
+
+2. Renderizar `<StudentCredentialsTable />` en algún punto visible del layout principal de la página. Si la página tiene una sección de "panel principal" tras seleccionar alumno, ponlo arriba; si no, ubícalo en la parte superior del área de contenido (no en el sidebar).
+
+- [ ] **Step 4: Verificar tsc**
+
+Run: `pnpm --filter @vkbacademy/web exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Smoke manual**
+
+Levanta el dev server (`pnpm dev`), entra como tutor, verifica:
+
+- La tabla carga con los alumnos del tutor.
+- Click en 📋 copia la contraseña al portapapeles (verifica con Cmd+V en cualquier campo).
+- Si hay un alumno sin `viewablePassword`, aparece "Restablecer" y al pulsar dispara la llamada (verifica en Network tab que se llama a `/auth/forgot-password`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/tutor/ apps/web/src/pages/TutorStudentsPage.tsx
+git commit -m "feat(web): show student credentials table on TutorStudentsPage"
+```
+
+---
+
+## Task 9: Documentación y env
+
+**Files:**
+
+- Modify: `apps/api/.env.example`
+- Modify: `CLAUDE.md` (sección 9)
+
+- [ ] **Step 1: Añadir variable a .env.example**
+
+Añadir al final de `apps/api/.env.example`:
+
+```env
+# Clave de cifrado para contraseñas visibles de alumnos por su tutor.
+# Generar con: openssl rand -hex 32
+STUDENT_PASSWORD_ENC_KEY=
+```
+
+- [ ] **Step 2: Documentar en CLAUDE.md**
+
+En `CLAUDE.md` sección 9 ("Variables de entorno"), añadir tras `RESEND_API_KEY / EMAIL_FROM` o donde haga sentido:
+
+```env
+STUDENT_PASSWORD_ENC_KEY                 # 32 bytes hex; cifra contraseñas visibles para tutor
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/.env.example CLAUDE.md
+git commit -m "docs: document STUDENT_PASSWORD_ENC_KEY env var"
+```
+
+---
+
+## Task 10: Verificación final integrada
+
+- [ ] **Step 1: Backend tests completos**
+
+Run: `pnpm --filter @vkbacademy/api test`
+Expected: PASS (todas las suites). El número de tests debe haber aumentado vs. la línea base por los añadidos en Tasks 1, 3, 4, 5, 6.
+
+- [ ] **Step 2: Web typecheck**
+
+Run: `pnpm --filter @vkbacademy/web exec tsc --noEmit`
+Expected: PASS sin nuevos errores.
+
+- [ ] **Step 3: Verificar que la env var falta hace fallar el arranque**
+
+Levantar el API sin `STUDENT_PASSWORD_ENC_KEY` definida. Esperado: el `CryptoService` lanza al construirse, Nest no arranca, mensaje claro.
+
+Restaurar la env var. Levantar de nuevo: arranca normal.
+
+- [ ] **Step 4: Smoke manual end-to-end**
+
+1. Crear un tutor nuevo desde `/register-tutor` con 2 alumnos.
+2. Loguearse como ese tutor.
+3. Ir a la página de alumnos. Verificar que la tabla muestra las 2 contraseñas en plano.
+4. Cambiar la contraseña de uno de los alumnos vía panel admin (con cuenta admin) → loguearse de nuevo como tutor → la tabla refleja la nueva contraseña.
+5. Intentar `forgot-password` para un alumno → seguir el link → cambiar contraseña → verificar que la tabla del tutor muestra la nueva.
+
+- [ ] **Step 5: Push**
+
+```bash
+git push origin main
+```
+
+> El pipeline `deploy-pipeline.yml` corre tests, despliega a PRE y se queda en gate antes de PROD. Migración a Neon PRE corre en `migrate-pre`. Verificar en GitHub Actions.
+
+---
+
+## Notas de implementación
+
+- **Orden estricto:** Task 1 (CryptoService) y Task 2 (schema) son requisitos para 3-6. No se pueden paralelizar.
+- **Tasks 3-5** podrían paralelizarse si trabajara más de un agente, pero comparten `auth.service.ts` (Tasks 3 y 4) por lo que conviene ejecutarlas en serie para evitar conflictos de merge.
+- **Task 7-8** (frontend) dependen del Task 6 (endpoint).
+- **No introducir nuevos errores `tsc`** en el repo: hay errores preexistentes en otras partes (helmet types) ajenos a esta feature; no tocarlos.
+- **Nunca loguear** el plaintext de la contraseña ni el ciphertext en error paths.
+- **No escribir** la env var en commits, README, ni Cypress fixtures.

--- a/docs/superpowers/specs/2026-05-07-tutor-student-credentials-design.md
+++ b/docs/superpowers/specs/2026-05-07-tutor-student-credentials-design.md
@@ -1,0 +1,264 @@
+# Tutor sees student credentials in dashboard
+
+> Diseño aprobado el 2026-05-07. Topic: que el tutor pueda ver las credenciales (email + contraseña en plano) de cada uno de sus alumnos en una tabla persistente dentro de su dashboard.
+
+---
+
+## 1. Contexto
+
+Hoy, cuando un tutor se registra vía `POST /auth/register-tutor` (`auth.service.ts:104`):
+
+1. Aporta sus datos + nombres de los alumnos.
+2. El sistema autogenera email único (slug del nombre) y contraseña aleatoria de 8 caracteres por alumno.
+3. Las contraseñas se hashean con bcrypt y se almacenan en `User.passwordHash`.
+4. `sendTutorWelcomeWithStudents` envía un único email al tutor con todas las credenciales (las del tutor y las de cada alumno).
+5. Tras eso, el plano se pierde: solo queda el hash bcrypt en BD.
+
+Si el tutor pierde ese email, no puede recuperar las credenciales de sus alumnos: tiene que pedir un reset por email para cada uno.
+
+---
+
+## 2. Objetivo
+
+El tutor debe ver, **en cualquier momento**, una tabla en su dashboard con una fila por alumno mostrando:
+
+- Nombre
+- Email (autogenerado)
+- Contraseña en plano
+
+Las credenciales deben permanecer disponibles aunque el tutor cierre sesión, refresque, o vuelva semanas después.
+
+---
+
+## 3. Decisión de seguridad asumida
+
+Almacenar contraseñas de alumnos en una forma **recuperable** (cifrado reversible, no hash).
+
+- Justificación: los alumnos son menores; los tutores (padres) son responsables de gestionar el acceso de sus hijos a la app y necesitan poder consultarlas en cualquier momento.
+- Riesgo aceptado: una filtración de la BD + de la clave de cifrado expone todas las contraseñas de alumnos en plano. Mitigación: clave en variable de entorno separada, nunca commiteada.
+- Alcance acotado: **solo** alumnos (`role = STUDENT`) con `tutorId != null`. Tutores, profesores y admins nunca tienen contraseña recuperable.
+
+---
+
+## 4. Modelo de datos
+
+### Cambio en Prisma
+
+```prisma
+model User {
+  // ...campos existentes
+  viewablePassword String?  // AES-256-GCM, solo poblado para STUDENT con tutorId
+}
+```
+
+- Tipo: `String?` (nullable). `null` para todos los usuarios que no son alumnos con tutor.
+- Formato del valor: `iv:authTag:ciphertext` en hex (todo concatenado con `:`).
+- Migración Prisma: `pnpm --filter @vkbacademy/api prisma migrate dev --name add_user_viewable_password`.
+
+### Estado para alumnos preexistentes
+
+Los alumnos creados antes de esta feature tendrán `viewablePassword = null`. Estrategia de UI: la tabla muestra "—" en la columna contraseña con un botón "Restablecer" que dispara el flujo `forgotPassword` para ese alumno (envía email al tutor con un link de reset).
+
+---
+
+## 5. Cifrado: `CryptoService`
+
+Nuevo módulo `apps/api/src/crypto/`:
+
+```
+crypto/
+├── crypto.module.ts
+├── crypto.service.ts
+└── crypto.service.spec.ts
+```
+
+### API
+
+```ts
+class CryptoService {
+  encrypt(plain: string): string; // devuelve "iv:authTag:ciphertext" hex
+  decrypt(payload: string): string; // throws si auth tag inválido
+}
+```
+
+### Detalles
+
+- Algoritmo: AES-256-GCM (autenticado, detecta manipulación).
+- Clave: `STUDENT_PASSWORD_ENC_KEY` en env, 32 bytes (64 hex chars).
+  - Validar al arrancar: si falta o longitud incorrecta, fallar con mensaje claro.
+- IV: 12 bytes random por cada operación de `encrypt`.
+- Auth tag: 16 bytes, almacenado junto al ciphertext.
+
+### Variable de entorno nueva
+
+Añadir a `apps/api/.env.example`:
+
+```env
+STUDENT_PASSWORD_ENC_KEY="<openssl rand -hex 32>"
+```
+
+Documentar en `CLAUDE.md` sección 9.
+
+---
+
+## 6. Puntos de actualización en backend
+
+Tres flujos hoy mutan la contraseña de un usuario. Todos deben sincronizar `viewablePassword` cuando el target es un alumno con tutor.
+
+### 6.1 `auth.service.ts:registerTutor` — creación inicial
+
+Línea ~143 (`createdStudents`): tras `bcrypt.hash`, cifrar con `CryptoService.encrypt(plainPassword)` y guardar en `viewablePassword`.
+
+### 6.2 `auth.service.ts:resetPassword` — flujo "olvidé mi contraseña"
+
+Si el usuario afectado tiene `role === 'STUDENT'` y `tutorId != null`, actualizar `viewablePassword` además de `passwordHash`. En cualquier otro caso, dejar `viewablePassword` intacto.
+
+### 6.3 `admin.service.ts:updateUser` — admin cambia password
+
+Misma regla que en 6.2. Si `dto.password` viene definido y el usuario target es alumno con tutor, sincronizar.
+
+### 6.4 No hay flujo "el alumno cambia su propia contraseña"
+
+Confirmado: hoy no existe endpoint público para que un alumno cambie su contraseña sin pasar por el flujo de reset. No hay nada que hacer aquí.
+
+---
+
+## 7. API nueva
+
+### Endpoint
+
+```
+GET /tutors/my-students/credentials
+```
+
+- Auth: JWT requerido. Roles permitidos: `TUTOR`, `ADMIN`, `SUPER_ADMIN`.
+- Filtrado:
+  - `TUTOR`: solo devuelve alumnos donde `tutorId === currentUser.id`.
+  - `ADMIN`: solo alumnos cuyo `tutorId` esté en su academia.
+  - `SUPER_ADMIN`: todos los alumnos con tutor.
+- Response:
+  ```ts
+  {
+    students: Array<{
+      id: string;
+      name: string;
+      email: string;
+      password: string | null; // null si viewablePassword es null (alumno preexistente)
+    }>;
+  }
+  ```
+
+### Implementación
+
+- Controlador: `tutors.controller.ts` añade método `getMyStudentsCredentials()`.
+- Servicio: `tutors.service.ts` añade método `getStudentsCredentials(tutor: User)`.
+  - Carga alumnos con `viewablePassword` incluido en la query.
+  - Para cada alumno con `viewablePassword != null`, descifra con `CryptoService.decrypt`.
+  - Si la descifra falla (clave rotada, datos corruptos), devuelve `password: null` y loguea warning.
+
+---
+
+## 8. Frontend
+
+### Página/sección
+
+Nueva sección en el dashboard del tutor: **"Credenciales de mis alumnos"**. Ubicación: añadir a `apps/web/src/pages/tutor/` (mirar layout actual del tutor para ver si hay un dashboard existente o si va como ruta separada).
+
+### Componente
+
+`StudentCredentialsTable` con tabla:
+
+| Nombre | Email    | Contraseña          | Acciones      |
+| ------ | -------- | ------------------- | ------------- |
+| Pepe   | pepe@... | `aB3xY7Q9` 📋       | —             |
+| Ana    | ana@...  | — _(no disponible)_ | [Restablecer] |
+
+- Click en 📋 copia al portapapeles.
+- Botón "Restablecer" dispara `POST /auth/forgot-password` con el email del alumno y muestra confirmación.
+- Aviso visible: "Estas credenciales son privadas. No las compartas en sitios públicos."
+
+### Data fetching
+
+- React Query hook `useStudentCredentials()` → llama a `GET /tutors/my-students/credentials`.
+- Cache stale time: 0 (siempre fresh, son sensibles).
+- No persistir en localStorage.
+
+---
+
+## 9. Tests
+
+### Backend
+
+- `crypto.service.spec.ts`:
+  - `encrypt + decrypt` round-trip preserva el plaintext.
+  - Detecta manipulación: alterar 1 byte del ciphertext lanza error de auth.
+  - Falla si la clave en env tiene longitud incorrecta.
+  - Distintos `iv` para llamadas sucesivas con el mismo plaintext (no determinista).
+
+- `auth.service.spec.ts` actualizado:
+  - `registerTutor` ahora guarda `viewablePassword` cifrada para cada alumno.
+  - `resetPassword` actualiza `viewablePassword` cuando target es STUDENT con tutor.
+  - `resetPassword` NO toca `viewablePassword` cuando target es TUTOR/TEACHER/ADMIN.
+
+- `admin.service.spec.ts` actualizado:
+  - `updateUser` con `password` actualiza `viewablePassword` si target es STUDENT con tutor.
+  - `updateUser` con `password` NO toca `viewablePassword` para otros roles.
+
+- `tutors.service.spec.ts`:
+  - `getStudentsCredentials` devuelve solo alumnos del tutor.
+  - Descifra correctamente.
+  - Si `viewablePassword` es null, devuelve `password: null`.
+  - Si descifra falla, loguea warning y devuelve `password: null`.
+
+### Frontend
+
+- Smoke type-check con `pnpm --filter @vkbacademy/web exec tsc --noEmit`.
+
+---
+
+## 10. Lista de archivos a tocar
+
+**Nuevos:**
+
+- `apps/api/src/crypto/crypto.module.ts`
+- `apps/api/src/crypto/crypto.service.ts`
+- `apps/api/src/crypto/crypto.service.spec.ts`
+- `apps/api/prisma/migrations/<timestamp>_add_user_viewable_password/migration.sql`
+- `apps/web/src/components/tutor/StudentCredentialsTable.tsx`
+
+**Modificados:**
+
+- `apps/api/prisma/schema.prisma` (añade `viewablePassword`)
+- `apps/api/src/auth/auth.service.ts` (3 puntos: registerTutor, resetPassword)
+- `apps/api/src/auth/auth.service.spec.ts`
+- `apps/api/src/admin/admin.service.ts` (updateUser)
+- `apps/api/src/admin/admin.service.spec.ts`
+- `apps/api/src/tutors/tutors.controller.ts`
+- `apps/api/src/tutors/tutors.service.ts`
+- `apps/api/src/tutors/tutors.service.spec.ts`
+- `apps/api/src/app.module.ts` (registrar CryptoModule)
+- `apps/api/.env.example`
+- `apps/web/src/api/tutors.api.ts`
+- `apps/web/src/pages/tutor/...` (añadir sección o ruta)
+- `CLAUDE.md` sección 9 (documentar nueva env var)
+
+---
+
+## 11. Riesgos y mitigaciones
+
+| Riesgo                                               | Mitigación                                                                  |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| Filtración BD + clave → exposición masa de passwords | Clave separada del backup BD, no commiteada, rotable.                       |
+| Pérdida/rotación de la clave                         | Documentar en runbook. Alumnos sin descifrar verán "—" + botón restablecer. |
+| Devolver passwords por error a otro tutor            | Test específico verifica filtrado por `tutorId`.                            |
+| Logs accidentales con plaintext                      | Nunca loguear el plaintext descifrado, ni en error paths.                   |
+| Cambio de password olvida sincronizar                | Cobertura de tests obligatoria en los 3 flujos.                             |
+
+---
+
+## 12. Fuera de alcance (no en esta feature)
+
+- Endpoint para que el tutor regenere manualmente la contraseña de un alumno (futuro).
+- Auditoría de quién consulta credenciales (futuro).
+- Rotación automática de la clave de cifrado (futuro).
+- Migración masiva de alumnos preexistentes (descartado: usamos botón "Restablecer" individual).


### PR DESCRIPTION
## Summary

- Permite al tutor ver email + contraseña de cada uno de sus alumnos desde el dashboard, en cualquier momento
- Añade `User.viewablePassword` cifrado con AES-256-GCM (clave en env `STUDENT_PASSWORD_ENC_KEY`)
- Sincroniza el campo en los 3 flujos que mutan la contraseña de un alumno: `registerTutor`, `resetPassword`, `admin.updateUser`
- Nuevo endpoint `GET /tutors/my-students/credentials` (TUTOR/ADMIN) que descifra y devuelve credenciales solo de los alumnos del tutor solicitante

## Implementación (TDD, 9 commits)

- `feat(crypto)` — CryptoService AES-256-GCM con IV aleatorio + auth tag
- `feat(db)` — migración Prisma `viewablePassword String?`
- `feat(auth)` x2 — cifra en `registerTutor` y sincroniza en `resetPassword` (solo STUDENT con tutorId)
- `feat(admin)` — sincroniza en `admin.updateUser` (solo STUDENT con tutorId, condicionado a dto.password)
- `feat(tutors)` — nuevo endpoint + service `getStudentsCredentials` (descifra; password=null si falla)
- `feat(web)` — `tutorsApi.getStudentsCredentials` + `<StudentCredentialsTable />` en `TutorStudentsPage`
- `docs` — `.env.example` y `CLAUDE.md` documentan `STUDENT_PASSWORD_ENC_KEY`

## Test plan

- [x] `pnpm --filter @vkbacademy/api test` — 459/459 verde (suite completa)
- [x] `pnpm --filter @vkbacademy/web exec tsc --noEmit` — limpio
- [ ] Generar `STUDENT_PASSWORD_ENC_KEY` (`openssl rand -hex 32`) en Render PRE y PROD antes de mergear
- [ ] Smoke E2E manual: registrar tutor con 2 alumnos → loguearse como tutor → verificar tabla muestra credenciales en plano
- [ ] Probar reset password de un alumno → la tabla refleja la nueva contraseña
- [ ] Probar admin.updateUser cambiando password → la tabla refleja el cambio
- [ ] Verificar que un alumno preexistente (sin viewablePassword) muestra "Restablecer" y dispara `forgot-password`

## Notas de seguridad

- El plaintext nunca se loguea (ni en error paths del descifrado)
- `viewablePassword` solo se pobla para STUDENT con `tutorId` (TUTOR/TEACHER/ADMIN nunca tienen el campo)
- El endpoint filtra por `tutorId` del usuario autenticado: cada tutor solo ve sus alumnos
- Si arranca el API sin `STUDENT_PASSWORD_ENC_KEY` válida (32 bytes hex), `CryptoService` falla en build → Nest no levanta

🤖 Generated with [Claude Code](https://claude.com/claude-code)