### PR TITLE
feat(challenges): retos de ejercicios, teoría y exámenes

### DIFF
--- a/apps/api/prisma/migrations/20260508075300_reto_types_exercise_theory_exam/migration.sql
+++ b/apps/api/prisma/migrations/20260508075300_reto_types_exercise_theory_exam/migration.sql
@@ -1,0 +1,27 @@
+-- Reemplaza ChallengeType: quita retos ligados a lecciones/módulos/cursos/clases,
+-- añade retos de Ejercicios, Teoría y Exámenes.
+
+-- 1. Borrar progreso de usuarios y retos existentes (incompatibles con nuevo enum)
+DELETE FROM "UserChallenge";
+DELETE FROM "Challenge";
+
+-- 2. Recrear el enum (Postgres no permite quitar valores in-place)
+ALTER TYPE "ChallengeType" RENAME TO "ChallengeType_old";
+
+CREATE TYPE "ChallengeType" AS ENUM (
+  'EXERCISE_COMPLETED',
+  'EXERCISE_SCORE',
+  'THEORY_COMPLETED',
+  'EXAM_COMPLETED',
+  'EXAM_SCORE',
+  'STREAK_WEEKLY',
+  'TOTAL_HOURS_EXERCISE',
+  'TOTAL_HOURS_THEORY',
+  'TOTAL_HOURS_EXAM'
+);
+
+ALTER TABLE "Challenge"
+  ALTER COLUMN "type" TYPE "ChallengeType"
+  USING "type"::text::"ChallengeType";
+
+DROP TYPE "ChallengeType_old";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -381,13 +381,15 @@ model Redemption {
 // ─────────────────────────────────────────────────────────
 
 enum ChallengeType {
-  LESSON_COMPLETED // completa N lecciones en total
-  MODULE_COMPLETED // completa N módulos enteros
-  COURSE_COMPLETED // completa N cursos completos
-  QUIZ_SCORE // consigue ≥ N% en cualquier quiz
-  BOOKING_ATTENDED // asiste a N clases confirmadas (endAt < now)
+  EXERCISE_COMPLETED // completa N ejercicios (lessons EXERCISE/MATCH/SORT/FILL_BLANK/QUIZ)
+  EXERCISE_SCORE // consigue ≥ N% en cualquier ejercicio (QuizAttempt.score)
+  THEORY_COMPLETED // genera/lee N módulos de teoría (TheoryModule)
+  EXAM_COMPLETED // entrega N exámenes (ExamAttempt.submittedAt)
+  EXAM_SCORE // consigue ≥ N% en cualquier examen
   STREAK_WEEKLY // racha activa de N semanas consecutivas
-  TOTAL_HOURS // acumula N horas (bookings + lecciones VIDEO × 20min)
+  TOTAL_HOURS_EXERCISE // acumula N horas en ejercicios (5 min × completados)
+  TOTAL_HOURS_THEORY // acumula N horas en teoría (10 min × TheoryLesson)
+  TOTAL_HOURS_EXAM // acumula N horas en exámenes (submittedAt − startedAt)
 }
 
 model Challenge {

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -260,35 +260,35 @@ async function main() {
     data: { userId: student.id, courseId: courseMath.id },
   });
 
-  // Crear retos de ejemplo (uno por cada ChallengeType)
+  // Crear retos de ejemplo (Ejercicios, Teoría, Exámenes + racha)
   await Promise.all([
     prisma.challenge.create({
       data: {
-        title: 'Primer paso',
-        description: 'Completa tu primera lección del curso.',
-        type: ChallengeType.LESSON_COMPLETED,
+        title: 'Primer ejercicio',
+        description: 'Completa tu primer ejercicio.',
+        type: ChallengeType.EXERCISE_COMPLETED,
         target: 1,
         points: 10,
-        badgeIcon: '📖',
+        badgeIcon: '🎯',
         badgeColor: '#10b981',
       },
     }),
     prisma.challenge.create({
       data: {
-        title: 'Módulo superado',
-        description: 'Completa todos los temas de un módulo entero.',
-        type: ChallengeType.MODULE_COMPLETED,
-        target: 1,
-        points: 50,
-        badgeIcon: '🎓',
-        badgeColor: '#3b82f6',
+        title: 'Entrenado',
+        description: 'Completa 25 ejercicios.',
+        type: ChallengeType.EXERCISE_COMPLETED,
+        target: 25,
+        points: 80,
+        badgeIcon: '💪',
+        badgeColor: '#22c55e',
       },
     }),
     prisma.challenge.create({
       data: {
-        title: 'Maestro del quiz',
-        description: 'Consigue al menos 80 puntos en cualquier quiz.',
-        type: ChallengeType.QUIZ_SCORE,
+        title: 'Ojo clínico',
+        description: 'Consigue al menos 80 puntos en cualquier ejercicio.',
+        type: ChallengeType.EXERCISE_SCORE,
         target: 80,
         points: 30,
         badgeIcon: '🧠',
@@ -297,13 +297,79 @@ async function main() {
     }),
     prisma.challenge.create({
       data: {
-        title: 'Alumno dedicado',
-        description: 'Asiste a 3 clases particulares confirmadas.',
-        type: ChallengeType.BOOKING_ATTENDED,
+        title: 'Curioso',
+        description: 'Genera tu primer módulo de teoría.',
+        type: ChallengeType.THEORY_COMPLETED,
+        target: 1,
+        points: 15,
+        badgeIcon: '📚',
+        badgeColor: '#0ea5e9',
+      },
+    }),
+    prisma.challenge.create({
+      data: {
+        title: 'Estudioso',
+        description: 'Genera 10 módulos de teoría.',
+        type: ChallengeType.THEORY_COMPLETED,
+        target: 10,
+        points: 70,
+        badgeIcon: '🎓',
+        badgeColor: '#3b82f6',
+      },
+    }),
+    prisma.challenge.create({
+      data: {
+        title: 'Primer examen',
+        description: 'Entrega tu primer examen.',
+        type: ChallengeType.EXAM_COMPLETED,
+        target: 1,
+        points: 25,
+        badgeIcon: '📝',
+        badgeColor: '#f97316',
+      },
+    }),
+    prisma.challenge.create({
+      data: {
+        title: 'Maestro del examen',
+        description: 'Consigue al menos 90 puntos en cualquier examen.',
+        type: ChallengeType.EXAM_SCORE,
+        target: 90,
+        points: 100,
+        badgeIcon: '🏆',
+        badgeColor: '#eab308',
+      },
+    }),
+    prisma.challenge.create({
+      data: {
+        title: 'Maratón de ejercicios',
+        description: 'Acumula 5 horas haciendo ejercicios.',
+        type: ChallengeType.TOTAL_HOURS_EXERCISE,
+        target: 5,
+        points: 60,
+        badgeIcon: '⏱️',
+        badgeColor: '#6366f1',
+      },
+    }),
+    prisma.challenge.create({
+      data: {
+        title: 'Maratón de teoría',
+        description: 'Acumula 5 horas estudiando teoría.',
+        type: ChallengeType.TOTAL_HOURS_THEORY,
+        target: 5,
+        points: 60,
+        badgeIcon: '📖',
+        badgeColor: '#14b8a6',
+      },
+    }),
+    prisma.challenge.create({
+      data: {
+        title: 'Maratón de exámenes',
+        description: 'Acumula 3 horas resolviendo exámenes.',
+        type: ChallengeType.TOTAL_HOURS_EXAM,
         target: 3,
-        points: 75,
-        badgeIcon: '📅',
-        badgeColor: '#f59e0b',
+        points: 90,
+        badgeIcon: '⌛',
+        badgeColor: '#ec4899',
       },
     }),
     prisma.challenge.create({
@@ -315,17 +381,6 @@ async function main() {
         points: 100,
         badgeIcon: '🔥',
         badgeColor: '#ef4444',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Maratonista',
-        description: 'Acumula 5 horas de formación entre lecciones y clases.',
-        type: ChallengeType.TOTAL_HOURS,
-        target: 5,
-        points: 60,
-        badgeIcon: '⏱️',
-        badgeColor: '#6366f1',
       },
     }),
   ]);

--- a/apps/api/src/bookings/bookings.module.ts
+++ b/apps/api/src/bookings/bookings.module.ts
@@ -3,10 +3,9 @@ import { BookingsController } from './bookings.controller';
 import { BookingsService } from './bookings.service';
 import { DailyModule } from '../daily/daily.module';
 import { NotificationsModule } from '../notifications/notifications.module';
-import { ChallengesModule } from '../challenges/challenges.module';
 
 @Module({
-  imports: [DailyModule, NotificationsModule, ChallengesModule],
+  imports: [DailyModule, NotificationsModule],
   controllers: [BookingsController],
   providers: [BookingsService],
 })

--- a/apps/api/src/bookings/bookings.service.spec.ts
+++ b/apps/api/src/bookings/bookings.service.spec.ts
@@ -1,11 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { Role, BookingMode, BookingStatus, ChallengeType } from '@prisma/client';
+import { Role, BookingMode, BookingStatus } from '@prisma/client';
 import { BookingsService } from './bookings.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { DailyService } from '../daily/daily.service';
 import { NotificationsService } from '../notifications/notifications.service';
-import { ChallengesService } from '../challenges/challenges.service';
 
 describe('BookingsService', () => {
   let service: BookingsService;
@@ -41,10 +40,6 @@ describe('BookingsService', () => {
     sendBookingCancelled: jest.fn().mockResolvedValue(undefined),
   };
 
-  const mockChallenges = {
-    checkAndAward: jest.fn().mockResolvedValue(undefined),
-  };
-
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -52,7 +47,6 @@ describe('BookingsService', () => {
         { provide: PrismaService, useValue: mockPrisma },
         { provide: DailyService, useValue: mockDaily },
         { provide: NotificationsService, useValue: mockNotifications },
-        { provide: ChallengesService, useValue: mockChallenges },
       ],
     }).compile();
 
@@ -61,7 +55,6 @@ describe('BookingsService', () => {
     mockNotifications.sendBookingCreated.mockResolvedValue(undefined);
     mockNotifications.sendBookingConfirmed.mockResolvedValue(undefined);
     mockNotifications.sendBookingCancelled.mockResolvedValue(undefined);
-    mockChallenges.checkAndAward.mockResolvedValue(undefined);
   });
 
   // ─── getMyBookings ────────────────────────────────────────────────────────────
@@ -166,17 +159,17 @@ describe('BookingsService', () => {
     it('TUTOR: lanza ForbiddenException si el alumno no le pertenece', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ tutorId: 'otherTutor' });
 
-      await expect(
-        service.create(validDto, 'tutor1', Role.TUTOR),
-      ).rejects.toThrow(ForbiddenException);
+      await expect(service.create(validDto, 'tutor1', Role.TUTOR)).rejects.toThrow(
+        ForbiddenException,
+      );
     });
 
     it('lanza NotFoundException si el profesor no existe', async () => {
       mockPrisma.teacherProfile.findUnique.mockResolvedValue(null);
 
-      await expect(
-        service.create(validDto, 'admin1', Role.ADMIN),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.create(validDto, 'admin1', Role.ADMIN)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('lanza NotFoundException si el courseId indicado no existe', async () => {
@@ -188,9 +181,7 @@ describe('BookingsService', () => {
 
       const dto = { ...validDto, courseId: 'nonexistent-course' };
 
-      await expect(
-        service.create(dto, 'admin1', Role.ADMIN),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.create(dto, 'admin1', Role.ADMIN)).rejects.toThrow(NotFoundException);
     });
 
     it('lanza BadRequestException si startAt >= endAt', async () => {
@@ -205,9 +196,7 @@ describe('BookingsService', () => {
         endAt: '2026-01-20T10:00:00Z',
       };
 
-      await expect(
-        service.create(dto, 'admin1', Role.ADMIN),
-      ).rejects.toThrow(BadRequestException);
+      await expect(service.create(dto, 'admin1', Role.ADMIN)).rejects.toThrow(BadRequestException);
     });
 
     it('lanza BadRequestException si startAt es en el pasado', async () => {
@@ -222,9 +211,7 @@ describe('BookingsService', () => {
         endAt: '2026-01-10T11:00:00Z',
       };
 
-      await expect(
-        service.create(dto, 'admin1', Role.ADMIN),
-      ).rejects.toThrow(BadRequestException);
+      await expect(service.create(dto, 'admin1', Role.ADMIN)).rejects.toThrow(BadRequestException);
     });
 
     it('lanza BadRequestException si hay conflicto de horario con otra reserva', async () => {
@@ -234,9 +221,9 @@ describe('BookingsService', () => {
       });
       mockPrisma.booking.findFirst.mockResolvedValue({ id: 'existing-booking' });
 
-      await expect(
-        service.create(validDto, 'admin1', Role.ADMIN),
-      ).rejects.toThrow(BadRequestException);
+      await expect(service.create(validDto, 'admin1', Role.ADMIN)).rejects.toThrow(
+        BadRequestException,
+      );
     });
 
     it('crea la reserva correctamente en el happy path', async () => {
@@ -248,7 +235,7 @@ describe('BookingsService', () => {
       const createdBooking = { id: 'new-booking', studentId: 'student1', teacherId: 'tp1' };
       mockPrisma.booking.create.mockResolvedValue(createdBooking);
       mockPrisma.user.findUnique
-        .mockResolvedValueOnce({ name: 'Admin User' })  // creador
+        .mockResolvedValueOnce({ name: 'Admin User' }) // creador
         .mockResolvedValueOnce({ name: 'Alumno Test' }); // alumno
 
       const result = await service.create(validDto, 'admin1', Role.ADMIN);
@@ -274,7 +261,7 @@ describe('BookingsService', () => {
       mockPrisma.booking.create.mockResolvedValue({ id: 'new-booking' });
       // Para Role.ADMIN no hay verificación de tutorId, solo las dos llamadas finales
       mockPrisma.user.findUnique
-        .mockResolvedValueOnce({ name: 'Admin User' })  // creador
+        .mockResolvedValueOnce({ name: 'Admin User' }) // creador
         .mockResolvedValueOnce({ name: 'Alumno Test' }); // alumno
 
       await service.create(validDto, 'admin1', Role.ADMIN, 'academy1');
@@ -377,33 +364,6 @@ describe('BookingsService', () => {
             meetingUrl: 'https://daily.co/room/b1',
           }),
         }),
-      );
-    });
-
-    it('llama a challenges.checkAndAward con BOOKING_ATTENDED y TOTAL_HOURS tras confirmar', async () => {
-      mockPrisma.booking.findUnique.mockResolvedValue({
-        id: 'b1',
-        teacherId: 'tp1',
-        mode: BookingMode.IN_PERSON,
-        meetingUrl: null,
-        studentId: 'student1',
-        courseId: null,
-        startAt: new Date('2026-01-20T10:00:00Z'),
-        endAt: new Date('2026-01-20T11:00:00Z'),
-      });
-      mockPrisma.teacherProfile.findUnique.mockResolvedValue({
-        id: 'tp1',
-        user: { name: 'Profesor Test' },
-      });
-      mockPrisma.booking.update.mockResolvedValue({ id: 'b1', status: BookingStatus.CONFIRMED });
-      mockPrisma.user.findUnique.mockResolvedValue(null);
-
-      await service.confirm('b1', 'teacher1');
-
-      expect(mockChallenges.checkAndAward).toHaveBeenCalledWith(
-        'student1',
-        ChallengeType.BOOKING_ATTENDED,
-        ChallengeType.TOTAL_HOURS,
       );
     });
   });

--- a/apps/api/src/bookings/bookings.service.ts
+++ b/apps/api/src/bookings/bookings.service.ts
@@ -5,11 +5,10 @@ import {
   ForbiddenException,
   BadRequestException,
 } from '@nestjs/common';
-import { Role, BookingStatus, BookingMode, ChallengeType } from '@prisma/client';
+import { Role, BookingStatus, BookingMode } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { DailyService } from '../daily/daily.service';
 import { NotificationsService } from '../notifications/notifications.service';
-import { ChallengesService } from '../challenges/challenges.service';
 import { CreateBookingDto } from './dto/create-booking.dto';
 
 @Injectable()
@@ -20,7 +19,6 @@ export class BookingsService {
     private readonly prisma: PrismaService,
     private readonly daily: DailyService,
     private readonly notifications: NotificationsService,
-    private readonly challenges: ChallengesService,
   ) {}
 
   async getMyBookings(userId: string, role: Role, academyId?: string | null) {
@@ -75,7 +73,12 @@ export class BookingsService {
     });
   }
 
-  async create(dto: CreateBookingDto, creatorId: string, creatorRole: Role, academyId?: string | null) {
+  async create(
+    dto: CreateBookingDto,
+    creatorId: string,
+    creatorRole: Role,
+    academyId?: string | null,
+  ) {
     // Si es TUTOR, verificar que el studentId pertenece a sus alumnos
     if (creatorRole === Role.TUTOR) {
       const student = await this.prisma.user.findUnique({
@@ -105,7 +108,8 @@ export class BookingsService {
     const startAt = new Date(dto.startAt);
     const endAt = new Date(dto.endAt);
 
-    if (startAt >= endAt) throw new BadRequestException('La fecha de inicio debe ser anterior a la de fin');
+    if (startAt >= endAt)
+      throw new BadRequestException('La fecha de inicio debe ser anterior a la de fin');
     if (startAt < new Date()) throw new BadRequestException('No se puede reservar en el pasado');
 
     // Verificar conflicto
@@ -189,7 +193,10 @@ export class BookingsService {
         })
       : null;
     const course = booking.courseId
-      ? await this.prisma.course.findUnique({ where: { id: booking.courseId }, select: { title: true } })
+      ? await this.prisma.course.findUnique({
+          where: { id: booking.courseId },
+          select: { title: true },
+        })
       : null;
 
     if (student) {
@@ -206,15 +213,10 @@ export class BookingsService {
           meetingUrl,
           courseName: course?.title,
         })
-        .catch((err) => this.logger.error('Error enviando notificación de reserva confirmada', err));
+        .catch((err) =>
+          this.logger.error('Error enviando notificación de reserva confirmada', err),
+        );
     }
-
-    // Disparar evaluación de retos en segundo plano para el alumno
-    void this.challenges.checkAndAward(
-      booking.studentId,
-      ChallengeType.BOOKING_ATTENDED,
-      ChallengeType.TOTAL_HOURS,
-    );
 
     return confirmed;
   }
@@ -272,8 +274,10 @@ export class BookingsService {
 
     // Notificar solo a las partes que no cancelaron
     const notifyEmails: Array<{ email: string; name: string }> = [];
-    if (!isTeacher && teacher) notifyEmails.push({ email: teacher.user.email, name: teacher.user.name });
-    if (!isTutor && !isStudent && tutor) notifyEmails.push({ email: tutor.email, name: tutor.name });
+    if (!isTeacher && teacher)
+      notifyEmails.push({ email: teacher.user.email, name: teacher.user.name });
+    if (!isTutor && !isStudent && tutor)
+      notifyEmails.push({ email: tutor.email, name: tutor.name });
     if (!isStudent && student) notifyEmails.push({ email: student.email, name: student.name });
 
     if (notifyEmails.length > 0 && student && teacher) {

--- a/apps/api/src/challenges/challenges.service.spec.ts
+++ b/apps/api/src/challenges/challenges.service.spec.ts
@@ -21,10 +21,10 @@ describe('ChallengesService', () => {
       findMany: jest.Mock;
     };
     userProgress: { count: jest.Mock };
-    module: { findMany: jest.Mock };
-    course: { findMany: jest.Mock };
     quizAttempt: { aggregate: jest.Mock };
-    booking: { count: jest.Mock; findMany: jest.Mock };
+    theoryModule: { count: jest.Mock };
+    theoryLesson: { count: jest.Mock };
+    examAttempt: { count: jest.Mock; aggregate: jest.Mock; findMany: jest.Mock };
     redemption: { create: jest.Mock };
     $transaction: jest.Mock;
   };
@@ -39,19 +39,16 @@ describe('ChallengesService', () => {
         findMany: jest.fn(),
       },
       userProgress: { count: jest.fn() },
-      module: { findMany: jest.fn() },
-      course: { findMany: jest.fn() },
       quizAttempt: { aggregate: jest.fn() },
-      booking: { count: jest.fn(), findMany: jest.fn() },
+      theoryModule: { count: jest.fn() },
+      theoryLesson: { count: jest.fn() },
+      examAttempt: { count: jest.fn(), aggregate: jest.fn(), findMany: jest.fn() },
       redemption: { create: jest.fn() },
       $transaction: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ChallengesService,
-        { provide: PrismaService, useValue: mockPrisma },
-      ],
+      providers: [ChallengesService, { provide: PrismaService, useValue: mockPrisma }],
     }).compile();
 
     service = module.get<ChallengesService>(ChallengesService);
@@ -168,24 +165,22 @@ describe('ChallengesService', () => {
     it('lanza error si el usuario no existe', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
 
-      await expect(
-        service.redeemItem('user1', 'Camiseta', 500),
-      ).rejects.toThrow('Usuario no encontrado');
+      await expect(service.redeemItem('user1', 'Camiseta', 500)).rejects.toThrow(
+        'Usuario no encontrado',
+      );
     });
 
     it('lanza error si el usuario no tiene puntos suficientes', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ totalPoints: 50 });
 
-      await expect(
-        service.redeemItem('user1', 'Camiseta', 500),
-      ).rejects.toThrow(/insuficientes/);
+      await expect(service.redeemItem('user1', 'Camiseta', 500)).rejects.toThrow(/insuficientes/);
     });
 
     it('ejecuta la transacción atómica y devuelve el resultado del canje', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ totalPoints: 1000 });
       mockPrisma.$transaction.mockResolvedValue([
         { totalPoints: 800 }, // resultado de user.update
-        {},                    // resultado de redemption.create
+        {}, // resultado de redemption.create
       ]);
 
       const result = await service.redeemItem('user1', 'Balón firmado', 200);
@@ -198,8 +193,8 @@ describe('ChallengesService', () => {
 
     it('la transacción incluye user.update (decrement) y redemption.create', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ totalPoints: 500 });
-      mockPrisma.$transaction.mockImplementation(
-        (operations: unknown[]) => Promise.resolve(operations.map(() => ({}))),
+      mockPrisma.$transaction.mockImplementation((operations: unknown[]) =>
+        Promise.resolve(operations.map(() => ({}))),
       );
 
       await service.redeemItem('user1', 'Gorra', 350);
@@ -212,9 +207,7 @@ describe('ChallengesService', () => {
     it('el error de puntos incluye el mensaje con los puntos actuales y necesarios', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ totalPoints: 100 });
 
-      await expect(
-        service.redeemItem('user1', 'Botella', 200),
-      ).rejects.toThrow(/100/);
+      await expect(service.redeemItem('user1', 'Botella', 200)).rejects.toThrow(/100/);
     });
   });
 
@@ -241,7 +234,7 @@ describe('ChallengesService', () => {
       mockPrisma.challenge.findMany.mockRejectedValue(new Error('DB error'));
 
       await expect(
-        service.checkAndAward('user1', ChallengeType.LESSON_COMPLETED),
+        service.checkAndAward('user1', ChallengeType.EXERCISE_COMPLETED),
       ).resolves.toBeUndefined();
     });
 
@@ -250,14 +243,14 @@ describe('ChallengesService', () => {
 
       await service.checkAndAward(
         'user1',
-        ChallengeType.LESSON_COMPLETED,
-        ChallengeType.MODULE_COMPLETED,
+        ChallengeType.EXERCISE_COMPLETED,
+        ChallengeType.EXAM_COMPLETED,
       );
 
       expect(mockPrisma.challenge.findMany).toHaveBeenCalledWith({
         where: {
           isActive: true,
-          type: { in: [ChallengeType.LESSON_COMPLETED, ChallengeType.MODULE_COMPLETED] },
+          type: { in: [ChallengeType.EXERCISE_COMPLETED, ChallengeType.EXAM_COMPLETED] },
         },
       });
     });
@@ -265,7 +258,7 @@ describe('ChallengesService', () => {
     it('crea un nuevo UserChallenge cuando el usuario completa el reto por primera vez', async () => {
       const challenge = {
         id: 'ch1',
-        type: ChallengeType.LESSON_COMPLETED,
+        type: ChallengeType.EXERCISE_COMPLETED,
         target: 5,
         points: 100,
       };
@@ -275,7 +268,7 @@ describe('ChallengesService', () => {
       mockPrisma.userChallenge.upsert.mockResolvedValue({});
       mockPrisma.user.update.mockResolvedValue({});
 
-      await service.checkAndAward('user1', ChallengeType.LESSON_COMPLETED);
+      await service.checkAndAward('user1', ChallengeType.EXERCISE_COMPLETED);
 
       expect(mockPrisma.userChallenge.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -295,7 +288,7 @@ describe('ChallengesService', () => {
     it('actualiza el progreso sin completar si no llega al target', async () => {
       const challenge = {
         id: 'ch1',
-        type: ChallengeType.LESSON_COMPLETED,
+        type: ChallengeType.EXERCISE_COMPLETED,
         target: 10,
         points: 200,
       };
@@ -304,7 +297,7 @@ describe('ChallengesService', () => {
       mockPrisma.userChallenge.findUnique.mockResolvedValue(null);
       mockPrisma.userChallenge.upsert.mockResolvedValue({});
 
-      await service.checkAndAward('user1', ChallengeType.LESSON_COMPLETED);
+      await service.checkAndAward('user1', ChallengeType.EXERCISE_COMPLETED);
 
       expect(mockPrisma.userChallenge.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -318,7 +311,7 @@ describe('ChallengesService', () => {
     it('omite el reto si ya estaba completado — no duplica los puntos', async () => {
       const challenge = {
         id: 'ch1',
-        type: ChallengeType.LESSON_COMPLETED,
+        type: ChallengeType.EXERCISE_COMPLETED,
         target: 5,
         points: 100,
       };
@@ -326,7 +319,7 @@ describe('ChallengesService', () => {
       mockPrisma.userProgress.count.mockResolvedValue(10); // supera target
       mockPrisma.userChallenge.findUnique.mockResolvedValue({ completed: true }); // ya completado
 
-      await service.checkAndAward('user1', ChallengeType.LESSON_COMPLETED);
+      await service.checkAndAward('user1', ChallengeType.EXERCISE_COMPLETED);
 
       // Al estar ya completado, no debe upsertarse ni incrementar puntos
       expect(mockPrisma.userChallenge.upsert).not.toHaveBeenCalled();
@@ -336,7 +329,7 @@ describe('ChallengesService', () => {
     it('no incrementa puntos si el reto existía pero no estaba completado y aún no llega al target', async () => {
       const challenge = {
         id: 'ch1',
-        type: ChallengeType.LESSON_COMPLETED,
+        type: ChallengeType.EXERCISE_COMPLETED,
         target: 20,
         points: 500,
       };
@@ -348,7 +341,7 @@ describe('ChallengesService', () => {
       });
       mockPrisma.userChallenge.upsert.mockResolvedValue({});
 
-      await service.checkAndAward('user1', ChallengeType.LESSON_COMPLETED);
+      await service.checkAndAward('user1', ChallengeType.EXERCISE_COMPLETED);
 
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
@@ -356,7 +349,7 @@ describe('ChallengesService', () => {
     it('no hace nada si no hay retos activos para los tipos de evento', async () => {
       mockPrisma.challenge.findMany.mockResolvedValue([]); // sin retos
 
-      await service.checkAndAward('user1', ChallengeType.QUIZ_SCORE);
+      await service.checkAndAward('user1', ChallengeType.EXERCISE_SCORE);
 
       expect(mockPrisma.userChallenge.upsert).not.toHaveBeenCalled();
     });
@@ -438,8 +431,8 @@ describe('ChallengesService', () => {
     it('combina retos activos con el progreso actual del usuario', async () => {
       const challenge = {
         id: 'ch1',
-        title: 'Completar 10 lecciones',
-        type: ChallengeType.LESSON_COMPLETED,
+        title: 'Completar 10 ejercicios',
+        type: ChallengeType.EXERCISE_COMPLETED,
         target: 10,
         points: 100,
         isActive: true,
@@ -468,7 +461,7 @@ describe('ChallengesService', () => {
       const challenge = {
         id: 'ch2',
         title: 'Quiz Perfecto',
-        type: ChallengeType.QUIZ_SCORE,
+        type: ChallengeType.EXERCISE_SCORE,
         target: 100,
         points: 50,
         isActive: true,

--- a/apps/api/src/challenges/challenges.service.ts
+++ b/apps/api/src/challenges/challenges.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ChallengeType, BookingStatus, LessonType } from '@prisma/client';
+import { ChallengeType, LessonType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 /** Devuelve la semana ISO como "2026-W07" */
@@ -67,50 +67,29 @@ export class ChallengesService {
     });
   }
 
+  /** Tipos de Lesson considerados "ejercicio" para los retos */
+  private static readonly EXERCISE_LESSON_TYPES: LessonType[] = [
+    LessonType.EXERCISE,
+    LessonType.MATCH,
+    LessonType.SORT,
+    LessonType.FILL_BLANK,
+    LessonType.QUIZ,
+  ];
+
   /** Calcula el progreso actual del usuario para un tipo de reto */
   private async calculateProgress(userId: string, type: ChallengeType): Promise<number> {
     switch (type) {
-      case ChallengeType.LESSON_COMPLETED:
-        return this.prisma.userProgress.count({ where: { userId, completed: true } });
-
-      case ChallengeType.MODULE_COMPLETED: {
-        // Módulos donde TODAS las lecciones tienen UserProgress.completed=true para el usuario
-        const modules = await this.prisma.module.findMany({
-          include: {
-            lessons: {
-              include: {
-                progress: { where: { userId, completed: true } },
-              },
-            },
+      case ChallengeType.EXERCISE_COMPLETED:
+        return this.prisma.userProgress.count({
+          where: {
+            userId,
+            completed: true,
+            lesson: { type: { in: ChallengesService.EXERCISE_LESSON_TYPES } },
           },
         });
-        return modules.filter(
-          (m) => m.lessons.length > 0 && m.lessons.every((l) => l.progress.length > 0),
-        ).length;
-      }
 
-      case ChallengeType.COURSE_COMPLETED: {
-        // Cursos donde TODAS las lecciones de todos los módulos están completadas
-        const courses = await this.prisma.course.findMany({
-          include: {
-            modules: {
-              include: {
-                lessons: {
-                  include: {
-                    progress: { where: { userId, completed: true } },
-                  },
-                },
-              },
-            },
-          },
-        });
-        return courses.filter((c) => {
-          const allLessons = c.modules.flatMap((m) => m.lessons);
-          return allLessons.length > 0 && allLessons.every((l) => l.progress.length > 0);
-        }).length;
-      }
-
-      case ChallengeType.QUIZ_SCORE: {
+      case ChallengeType.EXERCISE_SCORE: {
+        // QuizAttempt es la única fuente de score para ejercicios
         const agg = await this.prisma.quizAttempt.aggregate({
           where: { userId },
           _max: { score: true },
@@ -118,10 +97,21 @@ export class ChallengesService {
         return Math.round(agg._max.score ?? 0);
       }
 
-      case ChallengeType.BOOKING_ATTENDED:
-        return this.prisma.booking.count({
-          where: { studentId: userId, status: BookingStatus.CONFIRMED, endAt: { lte: new Date() } },
+      case ChallengeType.THEORY_COMPLETED:
+        return this.prisma.theoryModule.count({ where: { userId } });
+
+      case ChallengeType.EXAM_COMPLETED:
+        return this.prisma.examAttempt.count({
+          where: { userId, submittedAt: { not: null } },
         });
+
+      case ChallengeType.EXAM_SCORE: {
+        const agg = await this.prisma.examAttempt.aggregate({
+          where: { userId, submittedAt: { not: null } },
+          _max: { score: true },
+        });
+        return Math.round(agg._max.score ?? 0);
+      }
 
       case ChallengeType.STREAK_WEEKLY: {
         const u = await this.prisma.user.findUnique({
@@ -131,24 +121,36 @@ export class ChallengesService {
         return u?.currentStreak ?? 0;
       }
 
-      case ChallengeType.TOTAL_HOURS: {
-        // Horas de bookings confirmados pasados
-        const bookings = await this.prisma.booking.findMany({
-          where: { studentId: userId, status: BookingStatus.CONFIRMED, endAt: { lte: new Date() } },
-          select: { startAt: true, endAt: true },
+      case ChallengeType.TOTAL_HOURS_EXERCISE: {
+        // Heurística: 5 min por ejercicio completado
+        const exercises = await this.prisma.userProgress.count({
+          where: {
+            userId,
+            completed: true,
+            lesson: { type: { in: ChallengesService.EXERCISE_LESSON_TYPES } },
+          },
         });
-        const bookingHours = bookings.reduce(
-          (acc, b) => acc + (b.endAt.getTime() - b.startAt.getTime()) / 3_600_000,
-          0,
-        );
+        return Math.floor(exercises * (5 / 60));
+      }
 
-        // Horas de lecciones VIDEO completadas (20 min cada una)
-        const videoLessons = await this.prisma.userProgress.count({
-          where: { userId, completed: true, lesson: { type: LessonType.VIDEO } },
+      case ChallengeType.TOTAL_HOURS_THEORY: {
+        // Heurística: 10 min por TheoryLesson en módulos del usuario
+        const theoryLessons = await this.prisma.theoryLesson.count({
+          where: { module: { userId } },
         });
-        const videoHours = videoLessons * (20 / 60);
+        return Math.floor(theoryLessons * (10 / 60));
+      }
 
-        return Math.floor(bookingHours + videoHours);
+      case ChallengeType.TOTAL_HOURS_EXAM: {
+        const exams = await this.prisma.examAttempt.findMany({
+          where: { userId, submittedAt: { not: null } },
+          select: { startedAt: true, submittedAt: true },
+        });
+        const hours = exams.reduce((acc, e) => {
+          if (!e.submittedAt) return acc;
+          return acc + (e.submittedAt.getTime() - e.startedAt.getTime()) / 3_600_000;
+        }, 0);
+        return Math.floor(hours);
       }
 
       default:
@@ -256,7 +258,9 @@ export class ChallengesService {
     if (!user) throw new Error('Usuario no encontrado');
 
     if (user.totalPoints < cost) {
-      throw new Error(`Puntos insuficientes. Tienes ${user.totalPoints} pts y necesitas ${cost} pts.`);
+      throw new Error(
+        `Puntos insuficientes. Tienes ${user.totalPoints} pts y necesitas ${cost} pts.`,
+      );
     }
 
     const [updated] = await this.prisma.$transaction([

--- a/apps/api/src/exams/exams.module.ts
+++ b/apps/api/src/exams/exams.module.ts
@@ -4,9 +4,10 @@ import { ExamsController } from './exams.controller';
 import { ExamsService } from './exams.service';
 import { AiExamsService } from './ai-exams.service';
 import { CertificatesModule } from '../certificates/certificates.module';
+import { ChallengesModule } from '../challenges/challenges.module';
 
 @Module({
-  imports: [PrismaModule, CertificatesModule],
+  imports: [PrismaModule, CertificatesModule, ChallengesModule],
   controllers: [ExamsController],
   providers: [ExamsService, AiExamsService],
 })

--- a/apps/api/src/exams/exams.service.spec.ts
+++ b/apps/api/src/exams/exams.service.spec.ts
@@ -3,6 +3,7 @@ import { BadRequestException, ForbiddenException, NotFoundException } from '@nes
 import { ExamsService } from './exams.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CertificatesService } from '../certificates/certificates.service';
+import { ChallengesService } from '../challenges/challenges.service';
 
 // Helper: construye una pregunta de examen con respuestas
 function buildQuestion(id: string, correctAnswerIdx = 0) {
@@ -51,18 +52,24 @@ describe('ExamsService', () => {
     issueExamCertificate: jest.fn().mockResolvedValue(undefined),
   };
 
+  const mockChallenges = {
+    checkAndAward: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ExamsService,
         { provide: PrismaService, useValue: mockPrisma },
         { provide: CertificatesService, useValue: mockCertificates },
+        { provide: ChallengesService, useValue: mockChallenges },
       ],
     }).compile();
 
     service = module.get<ExamsService>(ExamsService);
     jest.clearAllMocks();
     mockCertificates.issueExamCertificate.mockResolvedValue(undefined);
+    mockChallenges.checkAndAward.mockResolvedValue(undefined);
   });
 
   // ─── getBankInfo ─────────────────────────────────────────────────────────────

--- a/apps/api/src/exams/exams.service.ts
+++ b/apps/api/src/exams/exams.service.ts
@@ -4,8 +4,10 @@ import {
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
+import { ChallengeType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CertificatesService } from '../certificates/certificates.service';
+import { ChallengesService } from '../challenges/challenges.service';
 import { StartExamDto } from './dto/start-exam.dto';
 import { SubmitExamDto } from './dto/submit-exam.dto';
 
@@ -32,6 +34,7 @@ export class ExamsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly certificates: CertificatesService,
+    private readonly challenges: ChallengesService,
   ) {}
 
   // ─── Info del banco de preguntas ──────────────────────────────────────────
@@ -240,6 +243,14 @@ export class ExamsService {
 
     // Emitir certificado de examen en segundo plano si el score supera el mínimo
     void this.certificates.issueExamCertificate(userId, attemptId, score);
+
+    // Disparar evaluación de retos en segundo plano (sin bloquear la respuesta)
+    void this.challenges.checkAndAward(
+      userId,
+      ChallengeType.EXAM_COMPLETED,
+      ChallengeType.EXAM_SCORE,
+      ChallengeType.TOTAL_HOURS_EXAM,
+    );
 
     return {
       attemptId,

--- a/apps/api/src/progress/progress.service.spec.ts
+++ b/apps/api/src/progress/progress.service.spec.ts
@@ -102,7 +102,7 @@ describe('ProgressService', () => {
               text: '¿Cuántos pasos se pueden dar sin botar?',
               order: 0,
               answers: [
-                { id: 'a1', text: 'Uno' },  // sin isCorrect (select explícito)
+                { id: 'a1', text: 'Uno' }, // sin isCorrect (select explícito)
                 { id: 'a2', text: 'Dos' },
               ],
             },
@@ -133,8 +133,7 @@ describe('ProgressService', () => {
       await service.findLesson('lesson1', 'user1');
 
       const prismaCall = mockPrisma.lesson.findUnique.mock.calls[0][0];
-      const answersSelect =
-        prismaCall?.include?.quiz?.include?.questions?.include?.answers?.select;
+      const answersSelect = prismaCall?.include?.quiz?.include?.questions?.include?.answers?.select;
 
       // El select debe existir y no incluir isCorrect
       expect(answersSelect).toBeDefined();
@@ -201,17 +200,15 @@ describe('ProgressService', () => {
       expect(result).toEqual(fakeProgress);
     });
 
-    it('dispara checkAndAward con los 4 tipos de evento de una lección', async () => {
+    it('dispara checkAndAward con los tipos de evento de un ejercicio', async () => {
       mockPrisma.userProgress.upsert.mockResolvedValue({});
 
       await service.completeLesson('lesson1', 'user1');
 
       expect(mockChallenges.checkAndAward).toHaveBeenCalledWith(
         'user1',
-        ChallengeType.LESSON_COMPLETED,
-        ChallengeType.MODULE_COMPLETED,
-        ChallengeType.COURSE_COMPLETED,
-        ChallengeType.TOTAL_HOURS,
+        ChallengeType.EXERCISE_COMPLETED,
+        ChallengeType.TOTAL_HOURS_EXERCISE,
       );
     });
 
@@ -229,7 +226,9 @@ describe('ProgressService', () => {
     it('no espera a checkAndIssueLessonCertificates — patrón void (non-blocking)', async () => {
       let resolveCertificates!: () => void;
       mockCertificates.checkAndIssueLessonCertificates.mockReturnValue(
-        new Promise<void>((resolve) => { resolveCertificates = resolve; }),
+        new Promise<void>((resolve) => {
+          resolveCertificates = resolve;
+        }),
       );
       mockPrisma.userProgress.upsert.mockResolvedValue({ completed: true });
 
@@ -243,7 +242,9 @@ describe('ProgressService', () => {
       // checkAndAward devuelve una promesa que resuelve más tarde
       let resolveCheckAndAward!: () => void;
       mockChallenges.checkAndAward.mockReturnValue(
-        new Promise<void>((resolve) => { resolveCheckAndAward = resolve; }),
+        new Promise<void>((resolve) => {
+          resolveCheckAndAward = resolve;
+        }),
       );
       mockPrisma.userProgress.upsert.mockResolvedValue({ completed: true });
 

--- a/apps/api/src/progress/progress.service.ts
+++ b/apps/api/src/progress/progress.service.ts
@@ -90,10 +90,8 @@ export class ProgressService {
     // Disparar evaluación de retos en segundo plano (sin bloquear la respuesta)
     void this.challenges.checkAndAward(
       userId,
-      ChallengeType.LESSON_COMPLETED,
-      ChallengeType.MODULE_COMPLETED,
-      ChallengeType.COURSE_COMPLETED,
-      ChallengeType.TOTAL_HOURS,
+      ChallengeType.EXERCISE_COMPLETED,
+      ChallengeType.TOTAL_HOURS_EXERCISE,
     );
 
     // Verificar y emitir certificados de completado en segundo plano

--- a/apps/api/src/quizzes/quizzes.service.spec.ts
+++ b/apps/api/src/quizzes/quizzes.service.spec.ts
@@ -125,9 +125,9 @@ describe('QuizzesService', () => {
     it('lanza NotFoundException si el quiz no existe', async () => {
       mockPrisma.quiz.findUnique.mockResolvedValue(null);
 
-      await expect(
-        service.submit('nonexistent', { answers: [] }, 'user1'),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.submit('nonexistent', { answers: [] }, 'user1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('calcula score 100% cuando todas las respuestas son correctas', async () => {
@@ -178,12 +178,16 @@ describe('QuizzesService', () => {
       mockPrisma.quiz.findUnique.mockResolvedValue(quiz);
       mockPrisma.quizAttempt.create.mockResolvedValue({});
 
-      const result = await service.submit('quiz1', {
-        answers: [
-          { questionId: 'q1', answerId: 'q1-correct' }, // correcta
-          { questionId: 'q2', answerId: 'q2-wrong' },   // incorrecta
-        ],
-      }, 'user1');
+      const result = await service.submit(
+        'quiz1',
+        {
+          answers: [
+            { questionId: 'q1', answerId: 'q1-correct' }, // correcta
+            { questionId: 'q2', answerId: 'q2-wrong' }, // incorrecta
+          ],
+        },
+        'user1',
+      );
 
       expect(result.corrections[0].isCorrect).toBe(true);
       expect(result.corrections[0].correctAnswerId).toBe('q1-correct');
@@ -196,9 +200,13 @@ describe('QuizzesService', () => {
       mockPrisma.quiz.findUnique.mockResolvedValue(quiz);
       mockPrisma.quizAttempt.create.mockResolvedValue({});
 
-      await service.submit('quiz1', {
-        answers: [{ questionId: 'q1', answerId: 'q1-correct' }],
-      }, 'user1');
+      await service.submit(
+        'quiz1',
+        {
+          answers: [{ questionId: 'q1', answerId: 'q1-correct' }],
+        },
+        'user1',
+      );
 
       expect(mockPrisma.quizAttempt.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -211,18 +219,22 @@ describe('QuizzesService', () => {
       );
     });
 
-    it('dispara checkAndAward con QUIZ_SCORE sin bloquear la respuesta', async () => {
+    it('dispara checkAndAward con EXERCISE_SCORE sin bloquear la respuesta', async () => {
       const quiz = buildQuiz(1);
       mockPrisma.quiz.findUnique.mockResolvedValue(quiz);
       mockPrisma.quizAttempt.create.mockResolvedValue({});
 
-      await service.submit('quiz1', {
-        answers: [{ questionId: 'q1', answerId: 'q1-correct' }],
-      }, 'user1');
+      await service.submit(
+        'quiz1',
+        {
+          answers: [{ questionId: 'q1', answerId: 'q1-correct' }],
+        },
+        'user1',
+      );
 
       expect(mockChallenges.checkAndAward).toHaveBeenCalledWith(
         'user1',
-        ChallengeType.QUIZ_SCORE,
+        ChallengeType.EXERCISE_SCORE,
       );
     });
 
@@ -232,13 +244,17 @@ describe('QuizzesService', () => {
       mockPrisma.quizAttempt.create.mockResolvedValue({});
 
       // 1 de 3 correctas = 33.333...%
-      const result = await service.submit('quiz1', {
-        answers: [
-          { questionId: 'q1', answerId: 'q1-correct' },  // correcta
-          { questionId: 'q2', answerId: 'q2-wrong' },    // incorrecta
-          { questionId: 'q3', answerId: 'q3-wrong' },    // incorrecta
-        ],
-      }, 'user1');
+      const result = await service.submit(
+        'quiz1',
+        {
+          answers: [
+            { questionId: 'q1', answerId: 'q1-correct' }, // correcta
+            { questionId: 'q2', answerId: 'q2-wrong' }, // incorrecta
+            { questionId: 'q3', answerId: 'q3-wrong' }, // incorrecta
+          ],
+        },
+        'user1',
+      );
 
       // Math.round(1/3 * 100 * 10) / 10 = Math.round(333.33) / 10 = 333 / 10 = 33.3
       expect(result.score).toBe(33.3);
@@ -291,9 +307,9 @@ describe('QuizzesService', () => {
     it('lanza NotFoundException si el intento no pertenece al usuario o quiz', async () => {
       mockPrisma.quizAttempt.findFirst.mockResolvedValue(null);
 
-      await expect(
-        service.getAttemptDetail('quiz1', 'attempt1', 'user1'),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.getAttemptDetail('quiz1', 'attempt1', 'user1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('lanza NotFoundException si el quiz no existe al reconstruir correcciones', async () => {
@@ -305,16 +321,16 @@ describe('QuizzesService', () => {
       });
       mockPrisma.quiz.findUnique.mockResolvedValue(null);
 
-      await expect(
-        service.getAttemptDetail('quiz1', 'att1', 'user1'),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.getAttemptDetail('quiz1', 'att1', 'user1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('devuelve correcciones con textos de pregunta y respuestas', async () => {
       const quiz = buildQuiz(2);
       const storedAnswers = [
         { questionId: 'q1', answerId: 'q1-correct' }, // acierto
-        { questionId: 'q2', answerId: 'q2-wrong' },   // fallo
+        { questionId: 'q2', answerId: 'q2-wrong' }, // fallo
       ];
 
       mockPrisma.quizAttempt.findFirst.mockResolvedValue({

--- a/apps/api/src/quizzes/quizzes.service.ts
+++ b/apps/api/src/quizzes/quizzes.service.ts
@@ -81,7 +81,7 @@ export class QuizzesService {
     });
 
     // Disparar evaluación de retos en segundo plano (sin bloquear la respuesta)
-    void this.challenges.checkAndAward(userId, ChallengeType.QUIZ_SCORE);
+    void this.challenges.checkAndAward(userId, ChallengeType.EXERCISE_SCORE);
 
     return {
       score,

--- a/apps/api/src/theory/theory.module.ts
+++ b/apps/api/src/theory/theory.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AiModule } from '../ai/ai.module';
 import { YoutubeModule } from '../youtube/youtube.module';
+import { ChallengesModule } from '../challenges/challenges.module';
 import { TheoryController } from './theory.controller';
 import { TheoryService } from './theory.service';
 
 @Module({
-  imports: [PrismaModule, AiModule, YoutubeModule],
+  imports: [PrismaModule, AiModule, YoutubeModule, ChallengesModule],
   controllers: [TheoryController],
   providers: [TheoryService],
 })

--- a/apps/api/src/theory/theory.service.spec.ts
+++ b/apps/api/src/theory/theory.service.spec.ts
@@ -15,6 +15,7 @@ describe('TheoryService', () => {
   };
   let ai: { generate: jest.Mock };
   let youtube: { findCandidates: jest.Mock };
+  let challenges: { checkAndAward: jest.Mock };
   let service: TheoryService;
 
   const baseCourse = {
@@ -63,7 +64,13 @@ describe('TheoryService', () => {
     };
     ai = { generate: jest.fn() };
     youtube = { findCandidates: jest.fn() };
-    service = new TheoryService(prisma as never, ai as never, youtube as never);
+    challenges = { checkAndAward: jest.fn().mockResolvedValue(undefined) };
+    service = new TheoryService(
+      prisma as never,
+      ai as never,
+      youtube as never,
+      challenges as never,
+    );
   });
 
   describe('generate', () => {

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -5,10 +5,17 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { Prisma, TheoryLessonKind, type TheoryModule, type TheoryLesson } from '@prisma/client';
+import {
+  ChallengeType,
+  Prisma,
+  TheoryLessonKind,
+  type TheoryModule,
+  type TheoryLesson,
+} from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AiProviderService } from '../ai/ai-provider.service';
 import { YoutubeService } from '../youtube/youtube.service';
+import { ChallengesService } from '../challenges/challenges.service';
 import { GenerateTheoryDto } from './dto/generate-theory.dto';
 
 interface GeneratedTheoryLesson {
@@ -46,6 +53,7 @@ export class TheoryService {
     private readonly prisma: PrismaService,
     private readonly ai: AiProviderService,
     private readonly youtube: YoutubeService,
+    private readonly challenges: ChallengesService,
   ) {}
 
   async generate(userId: string, dto: GenerateTheoryDto): Promise<TheoryModuleWithLessons> {
@@ -93,7 +101,7 @@ export class TheoryService {
       }),
     );
 
-    return this.prisma.theoryModule.create({
+    const created = await this.prisma.theoryModule.create({
       data: {
         userId,
         courseId: dto.courseId,
@@ -119,6 +127,15 @@ export class TheoryService {
       },
       include: { lessons: { orderBy: { order: 'asc' } } },
     });
+
+    // Disparar evaluación de retos en segundo plano (sin bloquear la respuesta)
+    void this.challenges.checkAndAward(
+      userId,
+      ChallengeType.THEORY_COMPLETED,
+      ChallengeType.TOTAL_HOURS_THEORY,
+    );
+
+    return created;
   }
 
   listMine(userId: string, courseId?: string): Promise<TheoryModule[]> {

--- a/apps/web/src/api/admin.api.ts
+++ b/apps/web/src/api/admin.api.ts
@@ -322,13 +322,15 @@ export interface AdminRedemption {
 // ─── Challenges (Admin) ───────────────────────────────────────────────────────
 
 export type AdminChallengeType =
-  | 'LESSON_COMPLETED'
-  | 'MODULE_COMPLETED'
-  | 'COURSE_COMPLETED'
-  | 'QUIZ_SCORE'
-  | 'BOOKING_ATTENDED'
+  | 'EXERCISE_COMPLETED'
+  | 'EXERCISE_SCORE'
+  | 'THEORY_COMPLETED'
+  | 'EXAM_COMPLETED'
+  | 'EXAM_SCORE'
   | 'STREAK_WEEKLY'
-  | 'TOTAL_HOURS';
+  | 'TOTAL_HOURS_EXERCISE'
+  | 'TOTAL_HOURS_THEORY'
+  | 'TOTAL_HOURS_EXAM';
 
 export interface AdminChallenge {
   id: string;

--- a/apps/web/src/api/challenges.api.ts
+++ b/apps/web/src/api/challenges.api.ts
@@ -1,13 +1,15 @@
 import api from '../lib/axios';
 
 export type ChallengeType =
-  | 'LESSON_COMPLETED'
-  | 'MODULE_COMPLETED'
-  | 'COURSE_COMPLETED'
-  | 'QUIZ_SCORE'
-  | 'BOOKING_ATTENDED'
+  | 'EXERCISE_COMPLETED'
+  | 'EXERCISE_SCORE'
+  | 'THEORY_COMPLETED'
+  | 'EXAM_COMPLETED'
+  | 'EXAM_SCORE'
   | 'STREAK_WEEKLY'
-  | 'TOTAL_HOURS';
+  | 'TOTAL_HOURS_EXERCISE'
+  | 'TOTAL_HOURS_THEORY'
+  | 'TOTAL_HOURS_EXAM';
 
 export interface ChallengeWithProgress {
   id: string;
@@ -56,11 +58,9 @@ export interface RedeemResult {
 }
 
 export const challengesApi = {
-  getMyProgress: () =>
-    api.get<ChallengesProgressResponse>('/challenges').then((r) => r.data),
+  getMyProgress: () => api.get<ChallengesProgressResponse>('/challenges').then((r) => r.data),
 
-  getSummary: () =>
-    api.get<ChallengeSummary>('/challenges/summary').then((r) => r.data),
+  getSummary: () => api.get<ChallengeSummary>('/challenges/summary').then((r) => r.data),
 
   redeemItem: (itemName: string, cost: number) =>
     api.post<RedeemResult>('/challenges/redeem', { itemName, cost }).then((r) => r.data),

--- a/apps/web/src/pages/admin/AdminChallengesPage.tsx
+++ b/apps/web/src/pages/admin/AdminChallengesPage.tsx
@@ -6,18 +6,24 @@ import {
   useDeleteChallenge,
   useToggleChallenge,
 } from '../../hooks/useChallenges';
-import type { AdminChallenge, AdminChallengeType, CreateChallengePayload } from '../../api/admin.api';
+import type {
+  AdminChallenge,
+  AdminChallengeType,
+  CreateChallengePayload,
+} from '../../api/admin.api';
 import AcademyFilter from '../../components/AcademyFilter';
 import { useAcademyFilterStore } from '../../store/academy-filter.store';
 
 const CHALLENGE_TYPE_LABELS: Record<AdminChallengeType, string> = {
-  LESSON_COMPLETED: 'Lecciones completadas',
-  MODULE_COMPLETED: 'Módulos completados',
-  COURSE_COMPLETED: 'Cursos completados',
-  QUIZ_SCORE: 'Puntuación en quiz (%)',
-  BOOKING_ATTENDED: 'Clases asistidas',
+  EXERCISE_COMPLETED: 'Ejercicios completados',
+  EXERCISE_SCORE: 'Puntuación en ejercicio (%)',
+  THEORY_COMPLETED: 'Módulos de teoría',
+  EXAM_COMPLETED: 'Exámenes entregados',
+  EXAM_SCORE: 'Puntuación en examen (%)',
   STREAK_WEEKLY: 'Racha semanal',
-  TOTAL_HOURS: 'Horas totales',
+  TOTAL_HOURS_EXERCISE: 'Horas en ejercicios',
+  TOTAL_HOURS_THEORY: 'Horas en teoría',
+  TOTAL_HOURS_EXAM: 'Horas en exámenes',
 };
 
 const CHALLENGE_TYPES = Object.keys(CHALLENGE_TYPE_LABELS) as AdminChallengeType[];
@@ -25,7 +31,7 @@ const CHALLENGE_TYPES = Object.keys(CHALLENGE_TYPE_LABELS) as AdminChallengeType
 const EMPTY_FORM: CreateChallengePayload = {
   title: '',
   description: '',
-  type: 'LESSON_COMPLETED',
+  type: 'EXERCISE_COMPLETED',
   target: 1,
   points: 10,
   badgeIcon: '🏅',
@@ -71,11 +77,25 @@ function ChallengeForm({ initial, onSubmit, onCancel, isPending, title }: Challe
   return (
     <div style={overlayStyle}>
       <div style={modalStyle}>
-        <h2 style={{ fontSize: '1.2rem', fontWeight: 700, marginBottom: '1.5rem', color: 'var(--color-text)' }}>
+        <h2
+          style={{
+            fontSize: '1.2rem',
+            fontWeight: 700,
+            marginBottom: '1.5rem',
+            color: 'var(--color-text)',
+          }}
+        >
           {title}
         </h2>
 
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '1rem', marginBottom: '0.5rem' }}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr auto',
+            gap: '1rem',
+            marginBottom: '0.5rem',
+          }}
+        >
           <div className="field">
             <label>Título</label>
             <input
@@ -108,10 +128,7 @@ function ChallengeForm({ initial, onSubmit, onCancel, isPending, title }: Challe
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
           <div className="field">
             <label>Tipo de reto</label>
-            <select
-              value={form.type}
-              onChange={(e) => set('type', e.target.value)}
-            >
+            <select value={form.type} onChange={(e) => set('type', e.target.value)}>
               {CHALLENGE_TYPES.map((t) => (
                 <option key={t} value={t}>
                   {CHALLENGE_TYPE_LABELS[t]}
@@ -149,7 +166,15 @@ function ChallengeForm({ initial, onSubmit, onCancel, isPending, title }: Challe
                 type="color"
                 value={form.badgeColor}
                 onChange={(e) => set('badgeColor', e.target.value)}
-                style={{ width: 40, height: 36, border: 'none', borderRadius: 6, cursor: 'pointer', padding: 0, flexShrink: 0 }}
+                style={{
+                  width: 40,
+                  height: 36,
+                  border: 'none',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                  padding: 0,
+                  flexShrink: 0,
+                }}
               />
               <input
                 style={{ flex: 1 }}
@@ -161,7 +186,9 @@ function ChallengeForm({ initial, onSubmit, onCancel, isPending, title }: Challe
           </div>
         </div>
 
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem', marginTop: '1rem' }}>
+        <div
+          style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem', marginTop: '1rem' }}
+        >
           <button className="btn btn-ghost" onClick={onCancel} disabled={isPending}>
             Cancelar
           </button>
@@ -231,7 +258,15 @@ export default function AdminChallengesPage() {
 
       {/* Hero */}
       <div className="page-hero animate-in">
-        <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: '1rem',
+          }}
+        >
           <div>
             <h1 className="hero-title">Gestión de Retos</h1>
             <p className="hero-subtitle">
@@ -270,7 +305,11 @@ export default function AdminChallengesPage() {
               {list.map((c) => (
                 <tr
                   key={c.id}
-                  style={{ borderBottom: '1px solid var(--color-border)', cursor: 'pointer', transition: 'background 0.12s' }}
+                  style={{
+                    borderBottom: '1px solid var(--color-border)',
+                    cursor: 'pointer',
+                    transition: 'background 0.12s',
+                  }}
                   onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--color-bg)')}
                   onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                   onClick={() => setEditing(c)}
@@ -361,7 +400,15 @@ export default function AdminChallengesPage() {
                       <span style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
                         <button
                           className="btn"
-                          style={{ padding: '0.25rem 0.6rem', fontSize: '0.78rem', background: 'rgba(220,38,38,0.1)', color: 'var(--color-error)', border: '1px solid rgba(220,38,38,0.25)', borderRadius: 'var(--radius-sm)', cursor: 'pointer' }}
+                          style={{
+                            padding: '0.25rem 0.6rem',
+                            fontSize: '0.78rem',
+                            background: 'rgba(220,38,38,0.1)',
+                            color: 'var(--color-error)',
+                            border: '1px solid rgba(220,38,38,0.25)',
+                            borderRadius: 'var(--radius-sm)',
+                            cursor: 'pointer',
+                          }}
                           onClick={() => handleDelete(c.id)}
                           disabled={deleteMutation.isPending}
                         >
@@ -378,7 +425,11 @@ export default function AdminChallengesPage() {
                     ) : (
                       <button
                         className="btn btn-ghost"
-                        style={{ padding: '0.3rem 0.65rem', fontSize: '0.8rem', color: 'var(--color-error)' }}
+                        style={{
+                          padding: '0.3rem 0.65rem',
+                          fontSize: '0.8rem',
+                          color: 'var(--color-error)',
+                        }}
                         onClick={() => setConfirmDelete(c.id)}
                       >
                         Eliminar
@@ -391,7 +442,12 @@ export default function AdminChallengesPage() {
                 <tr>
                   <td
                     colSpan={8}
-                    style={{ ...tdStyle, textAlign: 'center', color: 'var(--color-text-muted)', padding: '3rem' }}
+                    style={{
+                      ...tdStyle,
+                      textAlign: 'center',
+                      color: 'var(--color-text-muted)',
+                      padding: '3rem',
+                    }}
                   >
                     No hay retos creados aún.
                   </td>


### PR DESCRIPTION
## Summary
- Reemplaza el sistema de retos para alinearlos al nuevo modelo: **ejercicios + teoría IA + exámenes** en lugar de lecciones/módulos/cursos/clases particulares.
- 9 valores nuevos del enum `ChallengeType` (incluida la racha semanal, que se mantiene). 11 retos seedeados.
- Heurística de horas: 5 min por ejercicio, 10 min por TheoryLesson, duración real (`submittedAt − startedAt`) para exámenes.

### Cambios en `ChallengeType`
**Quita:** `LESSON_COMPLETED`, `MODULE_COMPLETED`, `COURSE_COMPLETED`, `BOOKING_ATTENDED`, `QUIZ_SCORE`, `TOTAL_HOURS`
**Añade:** `EXERCISE_COMPLETED`, `EXERCISE_SCORE`, `THEORY_COMPLETED`, `EXAM_COMPLETED`, `EXAM_SCORE`, `TOTAL_HOURS_EXERCISE`, `TOTAL_HOURS_THEORY`, `TOTAL_HOURS_EXAM`
**Mantiene:** `STREAK_WEEKLY`

### Triggers (`checkAndAward`)
| Servicio | Disparos |
|----------|----------|
| `progress.completeLesson` | `EXERCISE_COMPLETED`, `TOTAL_HOURS_EXERCISE` |
| `quizzes.submit` | `EXERCISE_SCORE` |
| `theory.generate` | `THEORY_COMPLETED`, `TOTAL_HOURS_THEORY` |
| `exams.submit` | `EXAM_COMPLETED`, `EXAM_SCORE`, `TOTAL_HOURS_EXAM` |
| `bookings.confirm` | ya no dispara retos |

### Migración
La migración `20260508075300_reto_types_exercise_theory_exam` borra retos previos + `UserChallenge` huérfanos y recrea el enum (Postgres no permite quitar valores in-place).

⚠️ Al desplegar a PRE/PROD se perderá el progreso histórico de retos de los usuarios. Acordado con el equipo (los retos viejos ya no aplican al nuevo modelo).

## Test plan
- [x] `pnpm --filter @vkbacademy/api test` → 458/458 pass
- [x] `pnpm --filter @vkbacademy/web exec tsc --noEmit` → exit 0
- [x] Migración aplicada localmente y `prisma db seed` ejecutado sin errores
- [ ] Verificar en PRE: completar 1 ejercicio → ver progreso en `Primer ejercicio`
- [ ] Verificar en PRE: generar 1 módulo de teoría → ver progreso en `Curioso`
- [ ] Verificar en PRE: entregar 1 examen → ver progreso en `Primer examen`
- [ ] Admin → crear/editar retos del nuevo tipo desde el panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)