### PR TITLE
fix+feat(web): UI fixes, retos, asignaturas y registro mejorado

### DIFF
--- a/apps/api/src/certificates/certificates.service.ts
+++ b/apps/api/src/certificates/certificates.service.ts
@@ -38,6 +38,7 @@ export class CertificatesService {
       recipientName: c.user.name,
       scopeTitle: c.course?.title ?? c.module?.title ?? '',
       scopeId: c.courseId ?? c.moduleId ?? '',
+      courseId: c.courseId ?? c.module?.course.id ?? undefined,
       courseTitle: c.module ? c.module.course.title : undefined,
     };
   }
@@ -73,10 +74,7 @@ export class CertificatesService {
 
   // ─── Hook: completar lección → emitir MODULE_COMPLETION / COURSE_COMPLETION
 
-  async checkAndIssueLessonCertificates(
-    userId: string,
-    lessonId: string,
-  ): Promise<void> {
+  async checkAndIssueLessonCertificates(userId: string, lessonId: string): Promise<void> {
     const lesson = await this.prisma.lesson.findUnique({
       where: { id: lessonId },
       select: {
@@ -104,9 +102,7 @@ export class CertificatesService {
     const moduleId = lesson.module.id;
     const courseId = lesson.module.courseId;
     const moduleLessonIds = lesson.module.lessons.map((l) => l.id);
-    const allLessonIds = lesson.module.course.modules.flatMap((m) =>
-      m.lessons.map((l) => l.id),
-    );
+    const allLessonIds = lesson.module.course.modules.flatMap((m) => m.lessons.map((l) => l.id));
 
     // Comprobar si el módulo está completo
     if (moduleLessonIds.length > 0) {
@@ -118,12 +114,7 @@ export class CertificatesService {
         },
       });
       if (completedInModule === moduleLessonIds.length) {
-        await this.issueCertificate(
-          userId,
-          moduleId,
-          'module',
-          CertificateType.MODULE_COMPLETION,
-        );
+        await this.issueCertificate(userId, moduleId, 'module', CertificateType.MODULE_COMPLETION);
       }
     }
 
@@ -137,23 +128,14 @@ export class CertificatesService {
         },
       });
       if (completedInCourse === allLessonIds.length) {
-        await this.issueCertificate(
-          userId,
-          courseId,
-          'course',
-          CertificateType.COURSE_COMPLETION,
-        );
+        await this.issueCertificate(userId, courseId, 'course', CertificateType.COURSE_COMPLETION);
       }
     }
   }
 
   // ─── Hook: entregar examen → emitir MODULE_EXAM / COURSE_EXAM ─────────────
 
-  async issueExamCertificate(
-    userId: string,
-    attemptId: string,
-    score: number,
-  ): Promise<void> {
+  async issueExamCertificate(userId: string, attemptId: string, score: number): Promise<void> {
     if (score < 50) return;
 
     const attempt = await this.prisma.examAttempt.findUnique({
@@ -300,6 +282,7 @@ export class CertificatesService {
         issuedAt: cert.issuedAt.toISOString(),
         scopeTitle,
         scopeId: cert.courseId ?? cert.moduleId ?? '',
+        courseId: cert.courseId ?? cert.module?.course.id ?? undefined,
         courseTitle,
       },
     };

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -92,7 +92,36 @@ export default function AppLayout() {
         <button className="app-hamburger" onClick={() => setMenuOpen(true)} aria-label="Abrir menú">
           ☰
         </button>
-        <span className="app-topbar-brand">🏀 {brandName}</span>
+        <span className="app-topbar-brand">
+          {brandLogo ? (
+            <img
+              src={brandLogo}
+              alt={brandName}
+              style={{ height: 28, width: 'auto', objectFit: 'contain', display: 'block' }}
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).style.display = 'none';
+              }}
+            />
+          ) : (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 28,
+                height: 28,
+                borderRadius: 8,
+                background: `linear-gradient(135deg, ${c}, ${c}cc)`,
+                color: contrastText(c),
+                fontWeight: 800,
+                fontSize: '0.9rem',
+              }}
+            >
+              {brandName.charAt(0)}
+            </span>
+          )}
+          <span style={{ fontWeight: 700 }}>{brandName}</span>
+        </span>
         <button
           className="app-topbar-logout"
           onClick={() => logout()}

--- a/apps/web/src/pages/CertificatesPage.tsx
+++ b/apps/web/src/pages/CertificatesPage.tsx
@@ -4,7 +4,10 @@ import type { Certificate, CertificateType } from '@vkbacademy/shared';
 
 // ─── Metadatos por tipo ───────────────────────────────────────────────────────
 
-const TYPE_LABELS: Record<CertificateType, { label: string; icon: string; badgeBg: string; badgeColor: string }> = {
+const TYPE_LABELS: Record<
+  CertificateType,
+  { label: string; icon: string; badgeBg: string; badgeColor: string }
+> = {
   MODULE_COMPLETION: {
     label: 'Módulo completado',
     icon: '📜',
@@ -93,7 +96,15 @@ function CertificateCard({ cert }: { cert: Certificate }) {
 
       {/* Curso padre (si es módulo) */}
       {cert.courseTitle && (
-        <div style={{ fontSize: '0.82rem', color: '#6b7280', display: 'flex', alignItems: 'center', gap: 5 }}>
+        <div
+          style={{
+            fontSize: '0.82rem',
+            color: '#6b7280',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+          }}
+        >
           <span>📚</span>
           <span>{cert.courseTitle}</span>
         </div>
@@ -121,7 +132,15 @@ function CertificateCard({ cert }: { cert: Certificate }) {
       )}
 
       {/* Fecha de emisión */}
-      <div style={{ fontSize: '0.8rem', color: '#6b7280', display: 'flex', alignItems: 'center', gap: 5 }}>
+      <div
+        style={{
+          fontSize: '0.8rem',
+          color: '#6b7280',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 5,
+        }}
+      >
         <span>📅</span>
         <span>
           Emitido el{' '}
@@ -192,7 +211,9 @@ export default function CertificatesPage() {
       <div style={{ maxWidth: 840, margin: '0 auto' }}>
         <div className="page-hero animate-in">
           <h1 className="hero-title">Mis Certificados</h1>
-          <p style={{ color: 'rgba(252,165,165,0.9)', marginTop: 8 }}>Error al cargar los certificados.</p>
+          <p style={{ color: 'rgba(252,165,165,0.9)', marginTop: 8 }}>
+            Error al cargar los certificados.
+          </p>
         </div>
       </div>
     );
@@ -202,13 +223,15 @@ export default function CertificatesPage() {
 
   return (
     <div style={{ maxWidth: 840, margin: '0 auto' }}>
-
       {/* Hero */}
       <div className="page-hero animate-in">
         <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 12 }}>
           <span style={{ fontSize: '2.5rem' }}>📜</span>
           {total > 0 && (
-            <div className="stat-card" style={{ padding: '8px 18px', display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+            <div
+              className="stat-card"
+              style={{ padding: '8px 18px', display: 'inline-flex', gap: 6, alignItems: 'center' }}
+            >
               <span
                 style={{
                   fontSize: '1.4rem',
@@ -221,7 +244,9 @@ export default function CertificatesPage() {
               >
                 {total}
               </span>
-              <span style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', fontWeight: 500 }}>
+              <span
+                style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', fontWeight: 500 }}
+              >
                 {total === 1 ? 'certificado' : 'certificados'}
               </span>
             </div>
@@ -246,29 +271,130 @@ export default function CertificatesPage() {
           }}
         >
           <div style={{ fontSize: '4rem', marginBottom: 16 }}>📜</div>
-          <div style={{ fontWeight: 700, fontSize: '1.1rem', color: 'var(--color-text)', marginBottom: 8 }}>
+          <div
+            style={{
+              fontWeight: 700,
+              fontSize: '1.1rem',
+              color: 'var(--color-text)',
+              marginBottom: 8,
+            }}
+          >
             Aun no tienes certificados
           </div>
-          <div style={{ fontSize: '0.9rem', color: 'var(--color-text-muted)', maxWidth: 400, margin: '0 auto', lineHeight: 1.6 }}>
+          <div
+            style={{
+              fontSize: '0.9rem',
+              color: 'var(--color-text-muted)',
+              maxWidth: 400,
+              margin: '0 auto',
+              lineHeight: 1.6,
+            }}
+          >
             Completa modulos o cursos enteros y aprueba examenes para obtener tus primeros diplomas.
           </div>
         </div>
       )}
 
-      {/* Grid de certificados */}
+      {/* Certificados agrupados por curso */}
       {certs && certs.length > 0 && (
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))',
-            gap: '18px',
-          }}
-        >
-          {certs.map((cert) => (
-            <CertificateCard key={cert.id} cert={cert} />
+        <div style={{ display: 'flex', flexDirection: 'column' as const, gap: 28 }}>
+          {groupCertificatesByCourse(certs).map((group) => (
+            <CourseGroup key={group.key} title={group.title} count={group.certs.length}>
+              {group.certs.map((cert) => (
+                <CertificateCard key={cert.id} cert={cert} />
+              ))}
+            </CourseGroup>
           ))}
         </div>
       )}
     </div>
+  );
+}
+
+// ─── Agrupador por curso ──────────────────────────────────────────────────────
+
+interface CertificateGroup {
+  key: string;
+  title: string;
+  certs: Certificate[];
+}
+
+function groupCertificatesByCourse(certs: Certificate[]): CertificateGroup[] {
+  const groups = new Map<string, CertificateGroup>();
+
+  for (const cert of certs) {
+    // Para módulos, courseTitle es el padre; para curso, scopeTitle ES el curso.
+    const isCourseScope = cert.type === 'COURSE_COMPLETION' || cert.type === 'COURSE_EXAM';
+    const title = isCourseScope ? cert.scopeTitle : (cert.courseTitle ?? cert.scopeTitle);
+    const key = cert.courseId ?? title;
+
+    let group = groups.get(key);
+    if (!group) {
+      group = { key, title, certs: [] };
+      groups.set(key, group);
+    }
+    group.certs.push(cert);
+  }
+
+  return Array.from(groups.values());
+}
+
+function CourseGroup({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          marginBottom: 14,
+        }}
+      >
+        <span style={{ fontSize: '1.2rem' }}>📚</span>
+        <h2
+          style={{
+            margin: 0,
+            fontSize: '1.05rem',
+            fontWeight: 800,
+            color: 'var(--color-text)',
+          }}
+        >
+          {title}
+        </h2>
+        <span
+          style={{
+            fontSize: '0.72rem',
+            fontWeight: 700,
+            padding: '2px 10px',
+            borderRadius: 999,
+            background: 'rgba(234,88,12,0.12)',
+            color: '#ea580c',
+            border: '1px solid rgba(234,88,12,0.25)',
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase' as const,
+          }}
+        >
+          {count} {count === 1 ? 'certificado' : 'certificados'}
+        </span>
+        <div style={{ flex: 1, height: 1, background: 'var(--color-border)' }} />
+      </header>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))',
+          gap: '18px',
+        }}
+      >
+        {children}
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/pages/ExamsListPage.tsx
+++ b/apps/web/src/pages/ExamsListPage.tsx
@@ -7,7 +7,7 @@ import {
   useDeleteAiExamBank,
   useStartAiAttempt,
 } from '../hooks/useExams';
-import { useCourses, useCourse } from '../hooks/useCourses';
+import { useCourses } from '../hooks/useCourses';
 import type { AiExamBankSummary } from '../api/exams.api';
 
 // ─── Helper: color de score ───────────────────────────────────────────────────
@@ -333,7 +333,6 @@ function AiBankCard({
 function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSuccess: () => void }) {
   const { data: coursesPage } = useCourses();
   const [courseId, setCourseId] = useState('');
-  const [moduleId, setModuleId] = useState('');
   const [topic, setTopic] = useState('');
   const [numQuestions, setNumQuestions] = useState<5 | 10>(5);
   const [useTimer, setUseTimer] = useState(false);
@@ -341,11 +340,9 @@ function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSucc
   const [onlyOnce, setOnlyOnce] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const { data: courseDetail } = useCourse(courseId);
   const generate = useGenerateAiExam();
 
   const courses = coursesPage?.data ?? [];
-  const modules = courseDetail?.modules ?? [];
 
   const canSubmit = courseId && topic.trim().length >= 3 && !generate.isPending;
 
@@ -354,7 +351,6 @@ function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSucc
     try {
       await generate.mutateAsync({
         courseId,
-        moduleId: moduleId || undefined,
         topic: topic.trim(),
         numQuestions,
         timeLimit: useTimer ? Math.round(timerMins * 60) : undefined,
@@ -389,6 +385,19 @@ function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSucc
     fontSize: '0.95rem',
     outline: 'none',
     boxSizing: 'border-box' as const,
+  };
+
+  const selectStyle: React.CSSProperties = {
+    ...inputStyle,
+    appearance: 'none',
+    WebkitAppearance: 'none',
+    MozAppearance: 'none',
+    backgroundImage:
+      "url(\"data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3e%3cpath d='M1 1.5L6 6.5L11 1.5' stroke='%236b7280' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e\")",
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'right 14px center',
+    paddingRight: 38,
+    cursor: 'pointer',
   };
 
   return (
@@ -451,11 +460,8 @@ function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSucc
           <label style={labelStyle}>Curso</label>
           <select
             value={courseId}
-            onChange={(e) => {
-              setCourseId(e.target.value);
-              setModuleId('');
-            }}
-            style={inputStyle}
+            onChange={(e) => setCourseId(e.target.value)}
+            style={selectStyle}
           >
             <option value="">Selecciona un curso...</option>
             {courses.map((c) => (
@@ -465,25 +471,6 @@ function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSucc
             ))}
           </select>
         </div>
-
-        {/* Módulo (opcional) */}
-        {courseId && modules.length > 0 && (
-          <div style={{ marginBottom: 16 }}>
-            <label style={labelStyle}>Módulo (opcional)</label>
-            <select
-              value={moduleId}
-              onChange={(e) => setModuleId(e.target.value)}
-              style={inputStyle}
-            >
-              <option value="">Todo el curso</option>
-              {modules.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.title}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
 
         {/* Tema */}
         <div style={{ marginBottom: 16 }}>

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -258,6 +258,23 @@ body {
   font-family: var(--font-sans);
 }
 
+.field select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: var(--color-bg);
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3e%3cpath d='M1 1.5L6 6.5L11 1.5' stroke='%236b7280' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  padding-right: 38px;
+  cursor: pointer;
+}
+
+.field select option {
+  background: #ffffff;
+  color: var(--color-text);
+}
+
 .field input:focus,
 .field select:focus,
 .field textarea:focus {
@@ -536,13 +553,19 @@ body {
   }
 
   .app-topbar-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     color: #fff;
-    font-weight: 800;
-    font-size: 1rem;
-    background: var(--gradient-orange);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    font-weight: 700;
+    font-size: 0.95rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+  .app-topbar-brand img {
+    flex-shrink: 0;
   }
 
   .app-hamburger,

--- a/apps/web/src/utils/certificatePdf.ts
+++ b/apps/web/src/utils/certificatePdf.ts
@@ -1,11 +1,11 @@
 import jsPDF from 'jspdf';
 import type { Certificate } from '@vkbacademy/shared';
 
-// Paleta del club (mismas constantes que examPdf.ts)
-const PURPLE = { r: 99, g: 102, b: 241 } as const;  // #6366f1 — color primario
-const GOLD   = { r: 202, g: 138, b: 4   } as const;  // dorado para certificados
-const DARK   = { r: 30,  g: 27,  b: 24  } as const;
-const MUTED  = { r: 120, g: 113, b: 108 } as const;
+// Paleta del club — naranja VKB como color primario
+const ORANGE = { r: 234, g: 88, b: 12 } as const; // #ea580c — naranja primario
+const GOLD = { r: 202, g: 138, b: 4 } as const; // dorado para certificados
+const DARK = { r: 30, g: 27, b: 24 } as const;
+const MUTED = { r: 120, g: 113, b: 108 } as const;
 const PAGE_W = 210;
 const PAGE_H = 297;
 
@@ -22,8 +22,8 @@ function setColor(
 const TYPE_LABELS: Record<string, string> = {
   MODULE_COMPLETION: 'Certificado de Módulo Completado',
   COURSE_COMPLETION: 'Certificado de Curso Completado',
-  MODULE_EXAM:  'Certificado de Examen de Módulo',
-  COURSE_EXAM:  'Certificado de Examen de Curso',
+  MODULE_EXAM: 'Certificado de Examen de Módulo',
+  COURSE_EXAM: 'Certificado de Examen de Curso',
 };
 
 export function downloadCertificatePdf(cert: Certificate) {
@@ -32,8 +32,8 @@ export function downloadCertificatePdf(cert: Certificate) {
   const contentW = PAGE_W - margin * 2;
   const issuedAt = new Date(cert.issuedAt);
 
-  // ── Banda morada superior ──────────────────────────────────────────────────
-  setColor(doc, 'fill', PURPLE);
+  // ── Banda naranja superior ─────────────────────────────────────────────────
+  setColor(doc, 'fill', ORANGE);
   doc.rect(0, 0, PAGE_W, 52, 'F');
 
   // Logo / marca
@@ -49,14 +49,14 @@ export function downloadCertificatePdf(cert: Certificate) {
   const chipX = PAGE_W - margin;
   setColor(doc, 'fill', { r: 255, g: 255, b: 255 });
   doc.roundedRect(chipX - chipW, 5, chipW, 10, 2, 2, 'F');
-  setColor(doc, 'text', PURPLE);
+  setColor(doc, 'text', ORANGE);
   doc.setFont('helvetica', 'bold');
   doc.text(chipText, chipX - chipW / 2, 11.5, { align: 'center' });
 
-  // Subtítulo
+  // Subtítulo (naranja claro sobre la banda)
   doc.setFontSize(10);
   doc.setFont('helvetica', 'normal');
-  doc.setTextColor(199, 210, 254);
+  doc.setTextColor(255, 215, 180);
   doc.text(TYPE_LABELS[cert.type] ?? cert.type, margin, 24);
 
   // Título principal
@@ -112,7 +112,7 @@ export function downloadCertificatePdf(cert: Certificate) {
   if (cert.examScore !== null && cert.examScore !== undefined) {
     doc.setFontSize(28);
     doc.setFont('helvetica', 'bold');
-    setColor(doc, 'text', PURPLE);
+    setColor(doc, 'text', ORANGE);
     doc.text(`${cert.examScore.toFixed(1)}%`, PAGE_W / 2, y, { align: 'center' });
     y += 16;
   }
@@ -159,7 +159,7 @@ export function downloadCertificatePdf(cert: Certificate) {
   y += 28;
 
   // ── Código de verificación ─────────────────────────────────────────────────
-  setColor(doc, 'fill', { r: 245, g: 243, b: 255 });
+  setColor(doc, 'fill', { r: 255, g: 247, b: 237 });
   doc.roundedRect(margin, y, contentW, 22, 4, 4, 'F');
 
   doc.setFontSize(8);
@@ -169,7 +169,7 @@ export function downloadCertificatePdf(cert: Certificate) {
 
   doc.setFontSize(10);
   doc.setFont('helvetica', 'bold');
-  setColor(doc, 'text', PURPLE);
+  setColor(doc, 'text', ORANGE);
   doc.text(cert.verifyCode, margin + contentW / 2, y + 16, { align: 'center' });
 
   // ── Pie de página ──────────────────────────────────────────────────────────
@@ -182,7 +182,10 @@ export function downloadCertificatePdf(cert: Certificate) {
   doc.text('Verifica en vkbacademy.com/verify', PAGE_W - margin, PAGE_H - 4.5, { align: 'right' });
 
   // ── Guardar ────────────────────────────────────────────────────────────────
-  const slug = cert.scopeTitle.replace(/\s+/g, '-').toLowerCase().replace(/[^a-z0-9-]/g, '');
+  const slug = cert.scopeTitle
+    .replace(/\s+/g, '-')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '');
   const filename = `certificado-${slug}-${issuedAt.toISOString().slice(0, 10)}.pdf`;
   doc.save(filename);
 }

--- a/packages/shared/src/types/certificate.types.ts
+++ b/packages/shared/src/types/certificate.types.ts
@@ -10,10 +10,11 @@ export interface Certificate {
   verifyCode: string;
   examScore: number | null;
   issuedAt: string;
-  recipientName: string;   // user.name
-  scopeTitle: string;      // título del módulo o curso
-  scopeId: string;         // courseId o moduleId
-  courseTitle?: string;    // curso padre (solo si el certificado es de módulo)
+  recipientName: string; // user.name
+  scopeTitle: string; // título del módulo o curso
+  scopeId: string; // courseId o moduleId
+  courseId?: string; // id del curso (propio o padre del módulo) para agrupar
+  courseTitle?: string; // curso padre (solo si el certificado es de módulo)
 }
 
 export interface CertificateVerification {


### PR DESCRIPTION
## Summary

Iteraciones de UI, datos y nuevas vistas sobre la app web tras feedback del usuario:

### Lote 1 — UI fixes iniciales
- **Logo móvil**: el topbar mostraba `🏀 {brandName}` con `background-clip:text` y la combinación renderizaba como un punto naranja en algunos móviles. Ahora pinta `academy.logoUrl` (con fallback a la inicial en cuadrado naranja).
- **Dropdowns de Curso** en *Teoría*, *Ejercicios* y modal de creación de *Exámenes*: el `<select>` nativo se confundía con el fondo del formulario. Añadido `appearance:none`, chevron SVG inline.
- **Modal "Crear examen"**: eliminado el desplegable de **Módulo** (ya no aplica).
- **PDF de certificado**: color primario morado (`#6366f1`) → naranja VKB (`#ea580c`).
- **Pestaña "Mis Certificados"**: agrupa por curso. Añadido `courseId` al DTO de `Certificate`.

### Lote 2 — segunda iteración
- **15 retos distintos en seed** cubriendo los 9 `ChallengeType`.
- **Dropdown más visible**: shorthand `background:` con SVG chevron naranja, fondo blanco y borde `#d1d5db`. `min-height: 44px`.
- **Quita "Certificados" de STUDENT**: eliminada la entrada del nav del rol STUDENT.

### Lote 3 — accesos rápidos, asignaturas y registro
- **Dashboard STUDENT**: añadido `🎓 Exámenes → /my-exams` a Accesos rápidos.
- **Vista Asignaturas (`/subjects`)**: nueva página donde el alumno puede auto-matricularse / darse de baja. Nav link `📚 Asignaturas` entre Inicio y Ejercicios. Endpoints nuevos: `GET /courses/subjects`, `POST/DELETE /courses/:id/enroll`. Seed con 3 asignaturas por defecto (Matemáticas, Física y Química, Inglés) sin `schoolYear` para que aparezcan a todos los niveles.
- **Registro de tutor**: el `schoolYearId` del alumno pasa a ser **obligatorio**. El frontend muestra siempre el select "Curso del alumno (ej: 3º ESO)" como `required`; spec actualizado.

## Test plan

- [x] `pnpm --filter @vkbacademy/web exec tsc --noEmit` ✅
- [x] `pnpm --filter @vkbacademy/api test` → 458/458 ✅
- [x] `prisma db seed` local OK
- [ ] Verificación visual en navegador:
  - [ ] Topbar móvil con logo (no punto naranja)
  - [ ] Dropdown Curso en Teoría / Ejercicios / Exámenes bien estilado
  - [ ] Modal Crear examen sin "Módulo (opcional)"
  - [ ] PDF de certificado en naranja
  - [ ] Mis Certificados agrupa por curso
  - [ ] Sidebar STUDENT no muestra "📜 Certificados"
  - [ ] Sidebar STUDENT muestra "📚 Asignaturas" debajo de Inicio
  - [ ] /subjects lista las 3 asignaturas con toggle matricular/baja
  - [ ] Dashboard STUDENT muestra "Exámenes" en Accesos rápidos
  - [ ] /challenges lista 15 retos
  - [ ] Registro tutor obliga a seleccionar curso del alumno

## Despliegue

- Tras merge: re-ejecutar `prisma db seed` en PRE/PROD para que aparezcan los 15 retos y las 3 asignaturas por defecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)