### PR TITLE
feat(student): asignaturas, retos, accesos rápidos y curso obligatorio en registro

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -260,6 +260,35 @@ async function main() {
     data: { userId: student.id, courseId: courseMath.id },
   });
 
+  // ── Asignaturas por defecto disponibles para auto-matriculación ─────────
+  // schoolYearId: null → visibles para alumnos de cualquier nivel
+  await Promise.all([
+    prisma.course.create({
+      data: {
+        title: 'Matemáticas',
+        description: 'Asignatura de Matemáticas. Matricúlate para acceder al contenido.',
+        published: true,
+        subject: 'Matemáticas',
+      },
+    }),
+    prisma.course.create({
+      data: {
+        title: 'Física y Química',
+        description: 'Asignatura de Física y Química. Matricúlate para acceder al contenido.',
+        published: true,
+        subject: 'Física y Química',
+      },
+    }),
+    prisma.course.create({
+      data: {
+        title: 'Inglés',
+        description: 'Asignatura de Inglés. Matricúlate para acceder al contenido.',
+        published: true,
+        subject: 'Inglés',
+      },
+    }),
+  ]);
+
   // Crear retos de ejemplo — 15 distintos cubriendo los 9 ChallengeType
   const challengesData: Array<{
     title: string;

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -260,130 +260,161 @@ async function main() {
     data: { userId: student.id, courseId: courseMath.id },
   });
 
-  // Crear retos de ejemplo (Ejercicios, Teoría, Exámenes + racha)
-  await Promise.all([
-    prisma.challenge.create({
-      data: {
-        title: 'Primer ejercicio',
-        description: 'Completa tu primer ejercicio.',
-        type: ChallengeType.EXERCISE_COMPLETED,
-        target: 1,
-        points: 10,
-        badgeIcon: '🎯',
-        badgeColor: '#10b981',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Entrenado',
-        description: 'Completa 25 ejercicios.',
-        type: ChallengeType.EXERCISE_COMPLETED,
-        target: 25,
-        points: 80,
-        badgeIcon: '💪',
-        badgeColor: '#22c55e',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Ojo clínico',
-        description: 'Consigue al menos 80 puntos en cualquier ejercicio.',
-        type: ChallengeType.EXERCISE_SCORE,
-        target: 80,
-        points: 30,
-        badgeIcon: '🧠',
-        badgeColor: '#8b5cf6',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Curioso',
-        description: 'Genera tu primer módulo de teoría.',
-        type: ChallengeType.THEORY_COMPLETED,
-        target: 1,
-        points: 15,
-        badgeIcon: '📚',
-        badgeColor: '#0ea5e9',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Estudioso',
-        description: 'Genera 10 módulos de teoría.',
-        type: ChallengeType.THEORY_COMPLETED,
-        target: 10,
-        points: 70,
-        badgeIcon: '🎓',
-        badgeColor: '#3b82f6',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Primer examen',
-        description: 'Entrega tu primer examen.',
-        type: ChallengeType.EXAM_COMPLETED,
-        target: 1,
-        points: 25,
-        badgeIcon: '📝',
-        badgeColor: '#f97316',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Maestro del examen',
-        description: 'Consigue al menos 90 puntos en cualquier examen.',
-        type: ChallengeType.EXAM_SCORE,
-        target: 90,
-        points: 100,
-        badgeIcon: '🏆',
-        badgeColor: '#eab308',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Maratón de ejercicios',
-        description: 'Acumula 5 horas haciendo ejercicios.',
-        type: ChallengeType.TOTAL_HOURS_EXERCISE,
-        target: 5,
-        points: 60,
-        badgeIcon: '⏱️',
-        badgeColor: '#6366f1',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Maratón de teoría',
-        description: 'Acumula 5 horas estudiando teoría.',
-        type: ChallengeType.TOTAL_HOURS_THEORY,
-        target: 5,
-        points: 60,
-        badgeIcon: '📖',
-        badgeColor: '#14b8a6',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Maratón de exámenes',
-        description: 'Acumula 3 horas resolviendo exámenes.',
-        type: ChallengeType.TOTAL_HOURS_EXAM,
-        target: 3,
-        points: 90,
-        badgeIcon: '⌛',
-        badgeColor: '#ec4899',
-      },
-    }),
-    prisma.challenge.create({
-      data: {
-        title: 'Racha de fuego',
-        description: 'Mantén una racha activa de 4 semanas consecutivas.',
-        type: ChallengeType.STREAK_WEEKLY,
-        target: 4,
-        points: 100,
-        badgeIcon: '🔥',
-        badgeColor: '#ef4444',
-      },
-    }),
-  ]);
+  // Crear retos de ejemplo — 15 distintos cubriendo los 9 ChallengeType
+  const challengesData: Array<{
+    title: string;
+    description: string;
+    type: ChallengeType;
+    target: number;
+    points: number;
+    badgeIcon: string;
+    badgeColor: string;
+  }> = [
+    // ── Ejercicios completados (3) ──────────────────────────────────────────
+    {
+      title: 'Primer ejercicio',
+      description: 'Completa tu primer ejercicio.',
+      type: ChallengeType.EXERCISE_COMPLETED,
+      target: 1,
+      points: 10,
+      badgeIcon: '🎯',
+      badgeColor: '#10b981',
+    },
+    {
+      title: 'En forma',
+      description: 'Completa 10 ejercicios.',
+      type: ChallengeType.EXERCISE_COMPLETED,
+      target: 10,
+      points: 40,
+      badgeIcon: '🏃',
+      badgeColor: '#16a34a',
+    },
+    {
+      title: 'Entrenado',
+      description: 'Completa 25 ejercicios.',
+      type: ChallengeType.EXERCISE_COMPLETED,
+      target: 25,
+      points: 80,
+      badgeIcon: '💪',
+      badgeColor: '#22c55e',
+    },
+    // ── Score en ejercicios (2) ──────────────────────────────────────────────
+    {
+      title: 'Ojo clínico',
+      description: 'Consigue al menos 80% en cualquier ejercicio.',
+      type: ChallengeType.EXERCISE_SCORE,
+      target: 80,
+      points: 30,
+      badgeIcon: '🧠',
+      badgeColor: '#8b5cf6',
+    },
+    {
+      title: 'Pleno',
+      description: 'Consigue 100% en cualquier ejercicio.',
+      type: ChallengeType.EXERCISE_SCORE,
+      target: 100,
+      points: 50,
+      badgeIcon: '💯',
+      badgeColor: '#a855f7',
+    },
+    // ── Teoría (2) ───────────────────────────────────────────────────────────
+    {
+      title: 'Curioso',
+      description: 'Genera tu primer módulo de teoría.',
+      type: ChallengeType.THEORY_COMPLETED,
+      target: 1,
+      points: 15,
+      badgeIcon: '📚',
+      badgeColor: '#0ea5e9',
+    },
+    {
+      title: 'Estudioso',
+      description: 'Genera 10 módulos de teoría.',
+      type: ChallengeType.THEORY_COMPLETED,
+      target: 10,
+      points: 70,
+      badgeIcon: '🎓',
+      badgeColor: '#3b82f6',
+    },
+    // ── Exámenes completados (2) ─────────────────────────────────────────────
+    {
+      title: 'Primer examen',
+      description: 'Entrega tu primer examen.',
+      type: ChallengeType.EXAM_COMPLETED,
+      target: 1,
+      points: 25,
+      badgeIcon: '📝',
+      badgeColor: '#f97316',
+    },
+    {
+      title: 'Veterano',
+      description: 'Entrega 10 exámenes.',
+      type: ChallengeType.EXAM_COMPLETED,
+      target: 10,
+      points: 90,
+      badgeIcon: '🪖',
+      badgeColor: '#dc2626',
+    },
+    // ── Score en exámenes (2) ────────────────────────────────────────────────
+    {
+      title: 'Aprobado con nota',
+      description: 'Consigue al menos 70% en cualquier examen.',
+      type: ChallengeType.EXAM_SCORE,
+      target: 70,
+      points: 40,
+      badgeIcon: '✅',
+      badgeColor: '#84cc16',
+    },
+    {
+      title: 'Maestro del examen',
+      description: 'Consigue al menos 90% en cualquier examen.',
+      type: ChallengeType.EXAM_SCORE,
+      target: 90,
+      points: 100,
+      badgeIcon: '🏆',
+      badgeColor: '#eab308',
+    },
+    // ── Horas acumuladas (3) ─────────────────────────────────────────────────
+    {
+      title: 'Maratón de ejercicios',
+      description: 'Acumula 5 horas haciendo ejercicios.',
+      type: ChallengeType.TOTAL_HOURS_EXERCISE,
+      target: 5,
+      points: 60,
+      badgeIcon: '⏱️',
+      badgeColor: '#6366f1',
+    },
+    {
+      title: 'Maratón de teoría',
+      description: 'Acumula 5 horas estudiando teoría.',
+      type: ChallengeType.TOTAL_HOURS_THEORY,
+      target: 5,
+      points: 60,
+      badgeIcon: '📖',
+      badgeColor: '#14b8a6',
+    },
+    {
+      title: 'Maratón de exámenes',
+      description: 'Acumula 3 horas resolviendo exámenes.',
+      type: ChallengeType.TOTAL_HOURS_EXAM,
+      target: 3,
+      points: 90,
+      badgeIcon: '⌛',
+      badgeColor: '#ec4899',
+    },
+    // ── Racha (1) ────────────────────────────────────────────────────────────
+    {
+      title: 'Racha de fuego',
+      description: 'Mantén una racha activa de 4 semanas consecutivas.',
+      type: ChallengeType.STREAK_WEEKLY,
+      target: 4,
+      points: 100,
+      badgeIcon: '🔥',
+      badgeColor: '#ef4444',
+    },
+  ];
+
+  await Promise.all(challengesData.map((data) => prisma.challenge.create({ data })));
 
   console.log('✅ Seed completado:');
   console.log(`   🏫 Academy:  ${vkbAcademy.name} (${vkbAcademy.slug})`);

--- a/apps/api/src/auth/auth-register-tutor.service.spec.ts
+++ b/apps/api/src/auth/auth-register-tutor.service.spec.ts
@@ -331,7 +331,7 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@test.es',
           password: 'password123',
           academySlug: 'academia-inexistente',
-          students: [{ name: 'Alumno' }],
+          students: [{ name: 'Alumno', schoolYearId: 'sy1' }],
         }),
       ).rejects.toThrow(NotFoundException);
     });
@@ -345,7 +345,7 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@test.es',
           password: 'password123',
           academySlug: 'vallekas-basket',
-          students: [{ name: 'Alumno' }],
+          students: [{ name: 'Alumno', schoolYearId: 'sy1' }],
         }),
       ).rejects.toThrow(BadRequestException);
     });
@@ -360,7 +360,7 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@vkbacademy.es',
           password: 'password123',
           academySlug: 'vallekas-basket',
-          students: [{ name: 'Alumno' }],
+          students: [{ name: 'Alumno', schoolYearId: 'sy1' }],
         }),
       ).rejects.toThrow(ConflictException);
     });
@@ -374,7 +374,7 @@ describe('AuthService.registerTutor', () => {
           email: 'tutor@test.es',
           password: 'password123',
           academySlug: 'inexistente',
-          students: [{ name: 'Alumno' }],
+          students: [{ name: 'Alumno', schoolYearId: 'sy1' }],
         });
       } catch {
         // esperado
@@ -402,7 +402,7 @@ describe('AuthService.registerTutor', () => {
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'María Pérez García' }],
+        students: [{ name: 'María Pérez García', schoolYearId: 'sy1' }],
       });
 
       const studentCreateCall = mockPrisma.user.create.mock.calls[1][0];
@@ -426,7 +426,7 @@ describe('AuthService.registerTutor', () => {
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'Juan García' }],
+        students: [{ name: 'Juan García', schoolYearId: 'sy1' }],
       });
 
       const studentCreateCall = mockPrisma.user.create.mock.calls[1][0];
@@ -444,7 +444,7 @@ describe('AuthService.registerTutor', () => {
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'Juan García' }, { name: 'Juan García' }],
+        students: [{ name: 'Juan García', schoolYearId: 'sy1' }, { name: 'Juan García', schoolYearId: 'sy1' }],
       });
 
       expect(mockPrisma.user.create.mock.calls[1][0].data.email).toBe('juan-garcia@vkbacademy.com');
@@ -504,7 +504,7 @@ describe('AuthService.registerTutor', () => {
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'Alumno Uno' }, { name: 'Alumno Dos' }],
+        students: [{ name: 'Alumno Uno', schoolYearId: 'sy1' }, { name: 'Alumno Dos', schoolYearId: 'sy1' }],
       });
 
       expect(mockCrypto.encrypt).toHaveBeenCalledTimes(2);
@@ -525,7 +525,7 @@ describe('AuthService.registerTutor', () => {
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'Alumno Uno' }, { name: 'Alumno Dos' }],
+        students: [{ name: 'Alumno Uno', schoolYearId: 'sy1' }, { name: 'Alumno Dos', schoolYearId: 'sy1' }],
       });
 
       const studentCreateCalls = mockPrisma.user.create.mock.calls.filter(
@@ -545,7 +545,7 @@ describe('AuthService.registerTutor', () => {
         email: 'tutor@test.es',
         password: 'password123',
         academySlug: 'vallekas-basket',
-        students: [{ name: 'Alumno' }],
+        students: [{ name: 'Alumno', schoolYearId: 'sy1' }],
       });
 
       const tutorCreateCall = mockPrisma.user.create.mock.calls[0][0];

--- a/apps/api/src/auth/dto/register-tutor.dto.ts
+++ b/apps/api/src/auth/dto/register-tutor.dto.ts
@@ -6,7 +6,6 @@ import {
   IsArray,
   ArrayMinSize,
   ValidateNested,
-  IsOptional,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -16,9 +15,9 @@ export class RegisterStudentDto {
   @MaxLength(100)
   name: string;
 
-  @IsOptional()
-  @IsString()
-  schoolYearId?: string;
+  @IsString({ message: 'Debes indicar el curso del alumno' })
+  @MinLength(1, { message: 'Debes indicar el curso del alumno' })
+  schoolYearId: string;
 }
 
 export class RegisterTutorDto {

--- a/apps/api/src/courses/courses.controller.ts
+++ b/apps/api/src/courses/courses.controller.ts
@@ -1,9 +1,21 @@
-import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { Role, User } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { CurrentAcademy } from '../auth/decorators/current-academy.decorator';
+import { AcademyGuard } from '../auth/guards/academy.guard';
 import { CoursesService } from './courses.service';
 import { CreateCourseDto } from './dto/create-course.dto';
 import { UpdateCourseDto } from './dto/update-course.dto';
@@ -30,6 +42,28 @@ export class CoursesController {
     });
   }
 
+  // ── Asignaturas: listado para auto-matricularse ─────────────────────────
+  // (debe ir ANTES de @Get(':id') para que Nest lo resuelva como ruta estática)
+  @Get('subjects')
+  listSubjects(@CurrentUser() user: User) {
+    return this.coursesService.listAvailableSubjects(user.id);
+  }
+
+  @Post(':id/enroll')
+  @UseGuards(AcademyGuard)
+  enrollSelf(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+    @CurrentAcademy() academyId: string | null,
+  ) {
+    return this.coursesService.enrollSelf(user.id, id, academyId);
+  }
+
+  @Delete(':id/enroll')
+  unenrollSelf(@Param('id') id: string, @CurrentUser() user: User) {
+    return this.coursesService.unenrollSelf(user.id, id);
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string, @CurrentUser() user: User) {
     return this.coursesService.findOne(id, user);
@@ -43,10 +77,7 @@ export class CoursesController {
   @Get(':id/student-progress/:studentId')
   @UseGuards(RolesGuard)
   @Roles(Role.TUTOR, Role.TEACHER, Role.ADMIN)
-  getStudentCourseProgress(
-    @Param('id') id: string,
-    @Param('studentId') studentId: string,
-  ) {
+  getStudentCourseProgress(@Param('id') id: string, @Param('studentId') studentId: string) {
     return this.coursesService.getStudentCourseProgress(id, studentId);
   }
 

--- a/apps/api/src/courses/courses.service.ts
+++ b/apps/api/src/courses/courses.service.ts
@@ -37,10 +37,7 @@ export class CoursesService {
 
       if (enrolledIds.length > 0) {
         // Ver cursos de su nivel + los enrolados explícitamente (pueden ser de otro nivel)
-        where.OR = [
-          { schoolYearId: schoolYearId ?? '__none__' },
-          { id: { in: enrolledIds } },
-        ];
+        where.OR = [{ schoolYearId: schoolYearId ?? '__none__' }, { id: { in: enrolledIds } }];
       } else if (schoolYearId) {
         where.schoolYearId = schoolYearId;
       } else {
@@ -135,9 +132,7 @@ export class CoursesService {
       totalLessons: lessonIds.length,
       completedLessons: completedLessonIds.length,
       percentageComplete:
-        lessonIds.length > 0
-          ? Math.round((completedLessonIds.length / lessonIds.length) * 100)
-          : 0,
+        lessonIds.length > 0 ? Math.round((completedLessonIds.length / lessonIds.length) * 100) : 0,
       completedLessonIds,
     };
   }
@@ -184,9 +179,7 @@ export class CoursesService {
       totalLessons: lessonIds.length,
       completedLessons: completedSet.size,
       percentageComplete:
-        lessonIds.length > 0
-          ? Math.round((completedSet.size / lessonIds.length) * 100)
-          : 0,
+        lessonIds.length > 0 ? Math.round((completedSet.size / lessonIds.length) * 100) : 0,
       modules,
     };
   }
@@ -198,5 +191,60 @@ export class CoursesService {
   async update(id: string, dto: UpdateCourseDto) {
     await this.findOne(id);
     return this.prisma.course.update({ where: { id }, data: dto });
+  }
+
+  /**
+   * Lista las asignaturas disponibles para auto-matricularse: todos los cursos
+   * publicados, marcando si el alumno ya está matriculado.
+   */
+  async listAvailableSubjects(userId: string) {
+    const [courses, enrollments] = await Promise.all([
+      this.prisma.course.findMany({
+        where: { published: true },
+        orderBy: [{ subject: 'asc' }, { title: 'asc' }],
+        include: {
+          schoolYear: { select: { id: true, label: true } },
+        },
+      }),
+      this.prisma.enrollment.findMany({
+        where: { userId },
+        select: { courseId: true },
+      }),
+    ]);
+
+    const enrolledIds = new Set(enrollments.map((e) => e.courseId));
+
+    return courses.map((c) => ({
+      id: c.id,
+      title: c.title,
+      description: c.description,
+      subject: c.subject,
+      schoolYear: c.schoolYear,
+      isEnrolled: enrolledIds.has(c.id),
+    }));
+  }
+
+  /** Auto-matriculación del alumno en un curso publicado. */
+  async enrollSelf(userId: string, courseId: string, academyId: string | null) {
+    const course = await this.prisma.course.findUnique({
+      where: { id: courseId },
+      select: { id: true, published: true },
+    });
+    if (!course) throw new NotFoundException('Curso no encontrado');
+    if (!course.published) {
+      throw new ForbiddenException('Este curso no está disponible para matriculación');
+    }
+
+    return this.prisma.enrollment.upsert({
+      where: { userId_courseId: { userId, courseId } },
+      create: { userId, courseId, academyId: academyId ?? undefined },
+      update: {},
+    });
+  }
+
+  /** Auto-baja del alumno en un curso. */
+  async unenrollSelf(userId: string, courseId: string) {
+    await this.prisma.enrollment.deleteMany({ where: { userId, courseId } });
+    return { success: true };
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import TheoryPage from './pages/TheoryPage';
 import TheoryModulePage from './pages/TheoryModulePage';
 import AdminExamBankPage from './pages/admin/AdminExamBankPage';
 import CertificatesPage from './pages/CertificatesPage';
+import SubjectsPage from './pages/SubjectsPage';
 import AdminAcademiesPage from './pages/admin/AdminAcademiesPage';
 import AcademyLandingPage from './pages/marketing/AcademyLandingPage';
 import AppLayout from './layouts/AppLayout';
@@ -105,6 +106,9 @@ export default function App() {
       >
         {/* Dashboard es la raíz privada */}
         <Route path="dashboard" element={<DashboardPage />} />
+
+        {/* Asignaturas — auto-matriculación del alumno */}
+        <Route path="subjects" element={<SubjectsPage />} />
 
         {/* Fase 2 — Cursos */}
         <Route path="courses" element={<CoursesPage />} />

--- a/apps/web/src/api/courses.api.ts
+++ b/apps/web/src/api/courses.api.ts
@@ -45,46 +45,51 @@ export interface RecentLesson {
 
 export const coursesApi = {
   list: (params?: { page?: number; limit?: number; schoolYearId?: string }) =>
-    api
-      .get<PaginatedResponse<Course>>('/courses', { params })
-      .then((r) => r.data),
+    api.get<PaginatedResponse<Course>>('/courses', { params }).then((r) => r.data),
 
-  get: (id: string) =>
-    api.get<Course>(`/courses/${id}`).then((r) => r.data),
+  get: (id: string) => api.get<Course>(`/courses/${id}`).then((r) => r.data),
 
   getProgress: (id: string) =>
     api.get<CourseProgress>(`/courses/${id}/progress`).then((r) => r.data),
 
-  getLesson: (id: string) =>
-    api.get<LessonDetail>(`/lessons/${id}`).then((r) => r.data),
+  getLesson: (id: string) => api.get<LessonDetail>(`/lessons/${id}`).then((r) => r.data),
 
   completeLesson: (id: string) =>
     api.post<UserProgress>(`/lessons/${id}/complete`).then((r) => r.data),
 
-  getQuiz: (id: string) =>
-    api.get<PublicQuiz>(`/quizzes/${id}`).then((r) => r.data),
+  getQuiz: (id: string) => api.get<PublicQuiz>(`/quizzes/${id}`).then((r) => r.data),
 
   submitQuiz: (id: string, answers: QuizAnswerSubmission[]) =>
-    api
-      .post<QuizSubmitResult>(`/quizzes/${id}/submit`, { answers })
-      .then((r) => r.data),
+    api.post<QuizSubmitResult>(`/quizzes/${id}/submit`, { answers }).then((r) => r.data),
 
   getQuizAttempts: (id: string) =>
     api.get<QuizAttempt[]>(`/quizzes/${id}/attempts`).then((r) => r.data),
 
   getAttemptDetail: (quizId: string, attemptId: string) =>
-    api
-      .get<QuizAttemptDetail>(`/quizzes/${quizId}/attempts/${attemptId}`)
-      .then((r) => r.data),
+    api.get<QuizAttemptDetail>(`/quizzes/${quizId}/attempts/${attemptId}`).then((r) => r.data),
 
-  getRecentLessons: () =>
-    api.get<RecentLesson[]>('/lessons/recent').then((r) => r.data),
+  getRecentLessons: () => api.get<RecentLesson[]>('/lessons/recent').then((r) => r.data),
 
   getStudentProgress: (courseId: string, studentId: string) =>
     api
       .get<StudentCourseProgress>(`/courses/${courseId}/student-progress/${studentId}`)
       .then((r) => r.data),
 
-  getSchoolYears: () =>
-    api.get<SchoolYear[]>('/school-years').then((r) => r.data),
+  getSchoolYears: () => api.get<SchoolYear[]>('/school-years').then((r) => r.data),
+
+  // ── Asignaturas (auto-matriculación del alumno) ────────────────────────
+  listSubjects: () => api.get<SubjectCourse[]>('/courses/subjects').then((r) => r.data),
+
+  enrollSelf: (courseId: string) => api.post(`/courses/${courseId}/enroll`).then((r) => r.data),
+
+  unenrollSelf: (courseId: string) => api.delete(`/courses/${courseId}/enroll`).then((r) => r.data),
 };
+
+export interface SubjectCourse {
+  id: string;
+  title: string;
+  description: string | null;
+  subject: string | null;
+  schoolYear: { id: string; label: string } | null;
+  isEnrolled: boolean;
+}

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -59,8 +59,7 @@ export function useCompleteLesson(courseId: string) {
 export function useSubmitQuiz(quizId: string, lessonId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (answers: QuizAnswerSubmission[]) =>
-      coursesApi.submitQuiz(quizId, answers),
+    mutationFn: (answers: QuizAnswerSubmission[]) => coursesApi.submitQuiz(quizId, answers),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['lessons', lessonId] });
       void queryClient.invalidateQueries({ queryKey: ['quizzes', quizId, 'attempts'] });
@@ -85,10 +84,44 @@ export function useRecentLessons() {
   });
 }
 
-export function useStudentCourseProgress(courseId: string | null | undefined, studentId: string | null | undefined) {
+export function useStudentCourseProgress(
+  courseId: string | null | undefined,
+  studentId: string | null | undefined,
+) {
   return useQuery({
     queryKey: ['courses', courseId, 'student-progress', studentId],
     queryFn: () => coursesApi.getStudentProgress(courseId!, studentId!),
     enabled: !!courseId && !!studentId,
+  });
+}
+
+// ── Asignaturas: auto-matriculación del alumno ───────────────────────────
+
+export function useSubjects() {
+  return useQuery({
+    queryKey: ['courses', 'subjects'],
+    queryFn: () => coursesApi.listSubjects(),
+  });
+}
+
+export function useEnrollSelf() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (courseId: string) => coursesApi.enrollSelf(courseId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['courses', 'subjects'] });
+      void queryClient.invalidateQueries({ queryKey: ['courses', 'list'] });
+    },
+  });
+}
+
+export function useUnenrollSelf() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (courseId: string) => coursesApi.unenrollSelf(courseId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['courses', 'subjects'] });
+      void queryClient.invalidateQueries({ queryKey: ['courses', 'list'] });
+    },
   });
 }

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -62,6 +62,7 @@ function buildNavLinks(role: Role | undefined): NavLink[] {
   // STUDENT por defecto
   return [
     ...base,
+    { to: '/subjects', label: '📚 Asignaturas' },
     { to: '/exercises', label: '🧮 Ejercicios' },
     { to: '/theory', label: '📖 Teoría' },
     { to: '/my-exams', label: '🎓 Exámenes' },

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -66,7 +66,6 @@ function buildNavLinks(role: Role | undefined): NavLink[] {
     { to: '/theory', label: '📖 Teoría' },
     { to: '/my-exams', label: '🎓 Exámenes' },
     { to: '/challenges', label: '🏆 Retos' },
-    { to: '/certificates', label: '📜 Certificados' },
     { to: '/profile', label: '👤 Mi perfil' },
   ];
 }

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -33,6 +33,12 @@ export default function DashboardPage() {
             desc: 'Practica con ejercicios al instante',
             to: '/exercises',
           },
+          {
+            emoji: '🎓',
+            label: 'Exámenes',
+            desc: 'Pon a prueba tus conocimientos',
+            to: '/my-exams',
+          },
         ]
       : user.role === Role.TEACHER
         ? [

--- a/apps/web/src/pages/ExamsListPage.tsx
+++ b/apps/web/src/pages/ExamsListPage.tsx
@@ -392,12 +392,13 @@ function CreateAiExamModal({ onClose, onSuccess }: { onClose: () => void; onSucc
     appearance: 'none',
     WebkitAppearance: 'none',
     MozAppearance: 'none',
-    backgroundImage:
-      "url(\"data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3e%3cpath d='M1 1.5L6 6.5L11 1.5' stroke='%236b7280' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e\")",
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'right 14px center',
-    paddingRight: 38,
+    background:
+      "url(\"data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='14' height='10' viewBox='0 0 14 10' fill='none'%3e%3cpath d='M1 1.5L7 8L13 1.5' stroke='%23ea580c' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e\") no-repeat right 14px center / 14px 10px, #ffffff",
+    border: '1.5px solid #d1d5db',
+    paddingRight: 40,
     cursor: 'pointer',
+    minHeight: 44,
+    lineHeight: 1.2,
   };
 
   return (

--- a/apps/web/src/pages/RegisterPage.tsx
+++ b/apps/web/src/pages/RegisterPage.tsx
@@ -71,7 +71,7 @@ export default function RegisterPage() {
 
   function handleStep2(e: FormEvent) {
     e.preventDefault();
-    const valid = students.every((s) => s.name.trim().length > 0);
+    const valid = students.every((s) => s.name.trim().length > 0 && s.schoolYearId.length > 0);
     if (!valid) return;
 
     mutate({
@@ -81,7 +81,7 @@ export default function RegisterPage() {
       academySlug,
       students: students.map((s) => ({
         name: s.name.trim(),
-        ...(s.schoolYearId ? { schoolYearId: s.schoolYearId } : {}),
+        schoolYearId: s.schoolYearId,
       })),
     });
   }
@@ -211,23 +211,22 @@ export default function RegisterPage() {
                   </span>
                 </div>
 
-                {schoolYears.length > 0 && (
-                  <div className="field field-dark">
-                    <label htmlFor={`student-sy-${i}`}>Nivel educativo</label>
-                    <select
-                      id={`student-sy-${i}`}
-                      value={student.schoolYearId}
-                      onChange={(e) => updateStudent(i, 'schoolYearId', e.target.value)}
-                    >
-                      <option value="">Selecciona el curso</option>
-                      {schoolYears.map((sy) => (
-                        <option key={sy.id} value={sy.id}>
-                          {sy.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                )}
+                <div className="field field-dark">
+                  <label htmlFor={`student-sy-${i}`}>Curso del alumno</label>
+                  <select
+                    id={`student-sy-${i}`}
+                    value={student.schoolYearId}
+                    onChange={(e) => updateStudent(i, 'schoolYearId', e.target.value)}
+                    required
+                  >
+                    <option value="">Selecciona el curso (ej: 3º ESO)</option>
+                    {schoolYears.map((sy) => (
+                      <option key={sy.id} value={sy.id}>
+                        {sy.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
             ))}
 

--- a/apps/web/src/pages/SubjectsPage.tsx
+++ b/apps/web/src/pages/SubjectsPage.tsx
@@ -1,0 +1,189 @@
+import { useSubjects, useEnrollSelf, useUnenrollSelf } from '../hooks/useCourses';
+import type { SubjectCourse } from '../api/courses.api';
+
+const SUBJECT_ICONS: Record<string, string> = {
+  Matemáticas: '📐',
+  'Física y Química': '⚗️',
+  Inglés: '🇬🇧',
+};
+
+function iconFor(subject: string | null): string {
+  if (!subject) return '📚';
+  return SUBJECT_ICONS[subject] ?? '📚';
+}
+
+function SubjectCard({ course }: { course: SubjectCourse }) {
+  const enroll = useEnrollSelf();
+  const unenroll = useUnenrollSelf();
+
+  const isPending =
+    (enroll.isPending && enroll.variables === course.id) ||
+    (unenroll.isPending && unenroll.variables === course.id);
+
+  function toggle() {
+    if (course.isEnrolled) unenroll.mutate(course.id);
+    else enroll.mutate(course.id);
+  }
+
+  return (
+    <div
+      className="vkb-card animate-in"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        padding: '20px 22px',
+        position: 'relative',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <span style={{ fontSize: '2.2rem', lineHeight: 1 }}>
+          {iconFor(course.subject ?? course.title)}
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontWeight: 800,
+              fontSize: '1.05rem',
+              color: 'var(--color-text)',
+              lineHeight: 1.25,
+            }}
+          >
+            {course.title}
+          </div>
+          {course.schoolYear && (
+            <div
+              style={{
+                fontSize: '0.78rem',
+                color: 'var(--color-text-muted)',
+                marginTop: 2,
+              }}
+            >
+              {course.schoolYear.label}
+            </div>
+          )}
+        </div>
+        {course.isEnrolled && (
+          <span
+            style={{
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              padding: '3px 10px',
+              borderRadius: 999,
+              background: 'rgba(22,163,74,0.10)',
+              color: '#16a34a',
+              border: '1px solid rgba(22,163,74,0.25)',
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Matriculado
+          </span>
+        )}
+      </div>
+
+      {course.description && (
+        <p
+          style={{
+            margin: 0,
+            fontSize: '0.85rem',
+            color: 'var(--color-text-muted)',
+            lineHeight: 1.5,
+          }}
+        >
+          {course.description}
+        </p>
+      )}
+
+      <button
+        type="button"
+        className={course.isEnrolled ? 'btn btn-ghost' : 'btn btn-primary'}
+        style={{ alignSelf: 'flex-start', padding: '9px 18px', fontSize: '0.85rem' }}
+        onClick={toggle}
+        disabled={isPending}
+      >
+        {isPending ? 'Guardando…' : course.isEnrolled ? 'Darme de baja' : 'Matricularme'}
+      </button>
+    </div>
+  );
+}
+
+export default function SubjectsPage() {
+  const { data: subjects, isLoading, isError } = useSubjects();
+
+  return (
+    <div style={{ maxWidth: 840, margin: '0 auto' }}>
+      <div className="page-hero animate-in">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 12 }}>
+          <span style={{ fontSize: '2.4rem' }}>📚</span>
+        </div>
+        <h1 className="hero-title">Asignaturas</h1>
+        <p className="hero-subtitle">
+          Matricúlate en las asignaturas que quieras seguir. Puedes darte de alta o de baja en
+          cualquier momento.
+        </p>
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--color-text-muted)', marginTop: 24 }}>Cargando asignaturas…</p>
+      )}
+
+      {isError && (
+        <p style={{ color: '#dc2626', marginTop: 24 }}>
+          No se pudieron cargar las asignaturas. Inténtalo de nuevo.
+        </p>
+      )}
+
+      {!isLoading && !isError && subjects && subjects.length === 0 && (
+        <div
+          style={{
+            textAlign: 'center',
+            padding: '56px 24px',
+            background: 'var(--color-surface)',
+            borderRadius: 'var(--radius-xl)',
+            border: '1.5px solid var(--color-border)',
+            marginTop: 24,
+          }}
+        >
+          <div style={{ fontSize: '4rem', marginBottom: 16 }}>📚</div>
+          <div
+            style={{
+              fontWeight: 700,
+              fontSize: '1.05rem',
+              color: 'var(--color-text)',
+              marginBottom: 8,
+            }}
+          >
+            No hay asignaturas disponibles
+          </div>
+          <div
+            style={{
+              fontSize: '0.9rem',
+              color: 'var(--color-text-muted)',
+              maxWidth: 380,
+              margin: '0 auto',
+              lineHeight: 1.6,
+            }}
+          >
+            El administrador aún no ha publicado ninguna asignatura.
+          </div>
+        </div>
+      )}
+
+      {subjects && subjects.length > 0 && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+            gap: 18,
+            marginTop: 24,
+          }}
+        >
+          {subjects.map((c) => (
+            <SubjectCard key={c.id} course={c} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -262,12 +262,20 @@ body {
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  background-color: var(--color-bg);
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3e%3cpath d='M1 1.5L6 6.5L11 1.5' stroke='%236b7280' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right 14px center;
-  padding-right: 38px;
+  background:
+    url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='14' height='10' viewBox='0 0 14 10' fill='none'%3e%3cpath d='M1 1.5L7 8L13 1.5' stroke='%23ea580c' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e")
+      no-repeat right 14px center / 14px 10px,
+    #ffffff;
+  border: 1.5px solid #d1d5db;
+  color: var(--color-text);
+  padding-right: 40px;
   cursor: pointer;
+  min-height: 44px;
+  line-height: 1.2;
+}
+
+.field select:hover {
+  border-color: #9ca3af;
 }
 
 .field select option {


### PR DESCRIPTION
## Summary

Continuación del PR #34 con los 2 lotes de cambios que no llegaron al squash-merge.

### Retos, dropdown y nav
- **15 retos distintos en seed** cubriendo los 9 `ChallengeType` (3 `EXERCISE_COMPLETED`, 2 `EXERCISE_SCORE`, 2 `THEORY_COMPLETED`, 2 `EXAM_COMPLETED`, 2 `EXAM_SCORE`, 3 `TOTAL_HOURS_*`, 1 `STREAK_WEEKLY`).
- **Dropdown Curso más visible**: shorthand `background:` con SVG chevron naranja, fondo blanco y borde `#d1d5db`. `min-height: 44px` para target táctil.
- **Quita "Certificados" de STUDENT**: eliminada la entrada del nav del rol STUDENT.

### Asignaturas, accesos rápidos y registro
- **Dashboard STUDENT**: añadido `🎓 Exámenes → /my-exams` a Accesos rápidos.
- **Vista Asignaturas (`/subjects`)**: nueva página donde el alumno auto-matricularse / darse de baja. Nav link `📚 Asignaturas` entre Inicio y Ejercicios. Nuevos endpoints: `GET /courses/subjects`, `POST/DELETE /courses/:id/enroll`. Seed con 3 asignaturas por defecto (Matemáticas, Física y Química, Inglés) sin `schoolYear` para que aparezcan a cualquier nivel.
- **Registro de tutor**: el `schoolYearId` del alumno pasa a ser **obligatorio**. El frontend muestra siempre el select "Curso del alumno (ej: 3º ESO)" como `required`; spec actualizado.

## Files

- `apps/api/prisma/seed.ts` — 15 retos + 3 asignaturas
- `apps/api/src/auth/dto/register-tutor.dto.ts` + spec — schoolYearId required
- `apps/api/src/courses/courses.service.ts` + `courses.controller.ts` — endpoints subjects/enroll
- `apps/web/src/api/courses.api.ts` + `hooks/useCourses.ts` — cliente API
- `apps/web/src/pages/SubjectsPage.tsx` (nuevo) + `App.tsx` — ruta y página
- `apps/web/src/layouts/AppLayout.tsx` — nav STUDENT (quita Certificados, añade Asignaturas)
- `apps/web/src/pages/DashboardPage.tsx` — Exámenes en accesos rápidos
- `apps/web/src/pages/RegisterPage.tsx` — curso del alumno required
- `apps/web/src/styles/global.css` — `.field select` mejorado
- `apps/web/src/pages/ExamsListPage.tsx` — `selectStyle` actualizado

## Test plan

- [x] `pnpm --filter @vkbacademy/web exec tsc --noEmit` ✅
- [x] `pnpm --filter @vkbacademy/api test` → 458/458 ✅
- [x] `prisma db seed` local OK
- [ ] Verificación visual:
  - [ ] Sidebar STUDENT muestra 📚 Asignaturas y NO 📜 Certificados
  - [ ] /subjects lista las 3 asignaturas con toggle matricular/baja
  - [ ] Dashboard STUDENT muestra "Exámenes" en Accesos rápidos
  - [ ] /challenges lista 15 retos
  - [ ] Registro de tutor obliga a seleccionar el curso del alumno
  - [ ] Dropdown Curso bien estilado en Teoría / Ejercicios / Exámenes

## Despliegue

- Tras merge: re-ejecutar `prisma db seed` en PRE/PROD para que aparezcan los 15 retos y las 3 asignaturas por defecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)