### PR TITLE
fix(api): /school-years público y tests TDD para Asignaturas

### DIFF
--- a/apps/api/src/courses/courses.service.spec.ts
+++ b/apps/api/src/courses/courses.service.spec.ts
@@ -40,6 +40,8 @@ const mockPrisma = {
   },
   enrollment: {
     findMany: jest.fn(),
+    upsert: jest.fn(),
+    deleteMany: jest.fn(),
   },
   userProgress: {
     findMany: jest.fn(),
@@ -55,10 +57,7 @@ describe('CoursesService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        CoursesService,
-        { provide: PrismaService, useValue: mockPrisma },
-      ],
+      providers: [CoursesService, { provide: PrismaService, useValue: mockPrisma }],
     }).compile();
 
     service = module.get<CoursesService>(CoursesService);
@@ -129,10 +128,7 @@ describe('CoursesService', () => {
 
       const whereArg = mockPrisma.course.findMany.mock.calls[0][0].where;
       expect(whereArg.published).toBe(true);
-      expect(whereArg.OR).toEqual([
-        { schoolYearId: 'sy1' },
-        { id: { in: ['courseX'] } },
-      ]);
+      expect(whereArg.OR).toEqual([{ schoolYearId: 'sy1' }, { id: { in: ['courseX'] } }]);
     });
 
     it('ADMIN: devuelve todos los cursos sin filtro published', async () => {
@@ -232,10 +228,7 @@ describe('CoursesService', () => {
     });
 
     it('percentageComplete = 100 si todas las lecciones están completadas', async () => {
-      mockPrisma.userProgress.findMany.mockResolvedValue([
-        { lessonId: 'l1' },
-        { lessonId: 'l2' },
-      ]);
+      mockPrisma.userProgress.findMany.mockResolvedValue([{ lessonId: 'l1' }, { lessonId: 'l2' }]);
 
       const result = await service.getCourseProgress('course1', 'u1');
 
@@ -310,6 +303,153 @@ describe('CoursesService', () => {
       );
 
       expect(mockPrisma.course.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listAvailableSubjects — la página Asignaturas debe mostrar TODOS los cursos
+  // publicados (matriculado o no), marcando isEnrolled.
+  // -------------------------------------------------------------------------
+
+  describe('listAvailableSubjects', () => {
+    const subjMath = {
+      id: 'subj-math',
+      title: 'Matemáticas',
+      description: 'Asignatura',
+      subject: 'Matemáticas',
+      published: true,
+      schoolYear: null,
+    };
+    const subjPhys = {
+      id: 'subj-phys',
+      title: 'Física y Química',
+      description: 'Asignatura',
+      subject: 'Física y Química',
+      published: true,
+      schoolYear: null,
+    };
+    const subjEng = {
+      id: 'subj-eng',
+      title: 'Inglés',
+      description: 'Asignatura',
+      subject: 'Inglés',
+      published: true,
+      schoolYear: null,
+    };
+
+    it('devuelve también los cursos en los que el alumno NO está matriculado', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([subjMath, subjPhys, subjEng]);
+      mockPrisma.enrollment.findMany.mockResolvedValue([{ courseId: subjMath.id }]);
+
+      const result = await service.listAvailableSubjects('u1');
+
+      expect(result).toHaveLength(3);
+      const ids = result.map((c) => c.id);
+      expect(ids).toEqual(expect.arrayContaining([subjMath.id, subjPhys.id, subjEng.id]));
+    });
+
+    it('marca isEnrolled=true sólo para los cursos en los que el alumno está matriculado', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([subjMath, subjPhys, subjEng]);
+      mockPrisma.enrollment.findMany.mockResolvedValue([{ courseId: subjMath.id }]);
+
+      const result = await service.listAvailableSubjects('u1');
+
+      const byId = Object.fromEntries(result.map((c) => [c.id, c]));
+      expect(byId[subjMath.id].isEnrolled).toBe(true);
+      expect(byId[subjPhys.id].isEnrolled).toBe(false);
+      expect(byId[subjEng.id].isEnrolled).toBe(false);
+    });
+
+    it('filtra cursos no publicados en la consulta a Prisma', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.enrollment.findMany.mockResolvedValue([]);
+
+      await service.listAvailableSubjects('u1');
+
+      const where = mockPrisma.course.findMany.mock.calls[0][0].where;
+      expect(where.published).toBe(true);
+    });
+
+    it('devuelve array vacío sin reventar si no hay cursos publicados', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.enrollment.findMany.mockResolvedValue([]);
+
+      const result = await service.listAvailableSubjects('u1');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // enrollSelf — auto-matriculación del alumno desde Asignaturas.
+  // -------------------------------------------------------------------------
+
+  describe('enrollSelf', () => {
+    it('matricula al alumno en un curso publicado', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', published: true });
+      mockPrisma.enrollment.upsert.mockResolvedValue({
+        id: 'enr1',
+        userId: 'u1',
+        courseId: 'c1',
+      });
+
+      const result = await service.enrollSelf('u1', 'c1', 'academy1');
+
+      expect(mockPrisma.enrollment.upsert).toHaveBeenCalledWith({
+        where: { userId_courseId: { userId: 'u1', courseId: 'c1' } },
+        create: { userId: 'u1', courseId: 'c1', academyId: 'academy1' },
+        update: {},
+      });
+      expect(result.courseId).toBe('c1');
+    });
+
+    it('lanza NotFoundException si el curso no existe', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue(null);
+
+      await expect(service.enrollSelf('u1', 'missing', null)).rejects.toThrow(NotFoundException);
+      expect(mockPrisma.enrollment.upsert).not.toHaveBeenCalled();
+    });
+
+    it('lanza ForbiddenException si el curso no está publicado', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', published: false });
+
+      await expect(service.enrollSelf('u1', 'c1', null)).rejects.toThrow(ForbiddenException);
+      expect(mockPrisma.enrollment.upsert).not.toHaveBeenCalled();
+    });
+
+    it('es idempotente: una segunda matriculación no falla (upsert)', async () => {
+      mockPrisma.course.findUnique.mockResolvedValue({ id: 'c1', published: true });
+      mockPrisma.enrollment.upsert.mockResolvedValue({ id: 'enr1', userId: 'u1', courseId: 'c1' });
+
+      await service.enrollSelf('u1', 'c1', null);
+      await service.enrollSelf('u1', 'c1', null);
+
+      expect(mockPrisma.enrollment.upsert).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // unenrollSelf — el alumno puede darse de baja desde Asignaturas.
+  // -------------------------------------------------------------------------
+
+  describe('unenrollSelf', () => {
+    it('borra la matriculación del usuario y del curso', async () => {
+      mockPrisma.enrollment.deleteMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.unenrollSelf('u1', 'c1');
+
+      expect(mockPrisma.enrollment.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'u1', courseId: 'c1' },
+      });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('no falla si el alumno no estaba matriculado (deleteMany devuelve 0)', async () => {
+      mockPrisma.enrollment.deleteMany.mockResolvedValue({ count: 0 });
+
+      const result = await service.unenrollSelf('u1', 'c1');
+
+      expect(result).toEqual({ success: true });
     });
   });
 });

--- a/apps/api/src/school-years/school-years.controller.spec.ts
+++ b/apps/api/src/school-years/school-years.controller.spec.ts
@@ -1,0 +1,26 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { SchoolYearsController } from './school-years.controller';
+
+/**
+ * El formulario público de registro (`RegisterPage`) consulta `/school-years`
+ * antes de existir un token. Por tanto, ni la clase ni el método `findAll`
+ * deben estar protegidos por `JwtAuthGuard`.
+ */
+describe('SchoolYearsController — public access contract', () => {
+  function readGuards(target: object | Function): unknown[] {
+    return (Reflect.getMetadata(GUARDS_METADATA, target) as unknown[]) ?? [];
+  }
+
+  it('no aplica JwtAuthGuard a nivel de clase', () => {
+    const classGuards = readGuards(SchoolYearsController);
+
+    expect(classGuards).not.toContain(JwtAuthGuard);
+  });
+
+  it('no aplica JwtAuthGuard a `findAll`', () => {
+    const handlerGuards = readGuards(SchoolYearsController.prototype.findAll);
+
+    expect(handlerGuards).not.toContain(JwtAuthGuard);
+  });
+});

--- a/apps/api/src/school-years/school-years.controller.ts
+++ b/apps/api/src/school-years/school-years.controller.ts
@@ -1,9 +1,12 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Controller, Get } from '@nestjs/common';
 import { SchoolYearsService } from './school-years.service';
 
+/**
+ * Endpoint público: el formulario de registro (`RegisterPage`) lo consulta sin
+ * sesión iniciada para poblar el selector "Curso del alumno". Los datos no son
+ * sensibles (sólo etiquetas tipo "1º ESO").
+ */
 @Controller('school-years')
-@UseGuards(JwtAuthGuard)
 export class SchoolYearsController {
   constructor(private readonly schoolYearsService: SchoolYearsService) {}
 

--- a/apps/api/test/e2e/13-school-years.e2e-spec.ts
+++ b/apps/api/test/e2e/13-school-years.e2e-spec.ts
@@ -24,9 +24,11 @@ describe('School Years — /school-years', () => {
       expect(res.body.length).toBeGreaterThan(0);
     });
 
-    it('devuelve 401 sin token de autenticación', async () => {
+    it('es público (no requiere token) para que el formulario de registro pueda poblarlo', async () => {
       const res = await publicGet('/school-years');
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThan(0);
     });
 
     it('cada item tiene id, name y label', async () => {


### PR DESCRIPTION
## Summary

Fix con TDD red→green de dos issues que bloqueaban el flujo de alumno tras PR #35:

- **`/school-years` ahora es público.** El formulario de `RegisterPage` consultaba el endpoint sin token (todavía no hay sesión) y el `JwtAuthGuard` a nivel de clase lo bloqueaba → el selector "Curso del alumno" salía vacío. Los datos no son sensibles (etiquetas tipo "1º ESO").
- **Cobertura de tests para Asignaturas.** `listAvailableSubjects`, `enrollSelf`, `unenrollSelf` no tenían tests unitarios; ahora 10 tests bloquean el contrato (mostrar también no-matriculados, marcar `isEnrolled`, idempotencia, rechazo de cursos no publicados o inexistentes).

## TDD aplicado

### Issue 1 — `/school-years` público
1. **RED**: nuevo `school-years.controller.spec.ts` introspecta metadata de Nest y exige que ni la clase ni `findAll` lleven `JwtAuthGuard`. Falla.
2. **GREEN**: se elimina `@UseGuards(JwtAuthGuard)` de `school-years.controller.ts`.
3. E2E (`13-school-years.e2e-spec.ts`) actualizado: petición sin token devuelve `200` con array.

### Issue 2 — Asignaturas: mostrar no-matriculados + permitir matriculación
1. **RED**: 10 tests nuevos en `courses.service.spec.ts` para `listAvailableSubjects`, `enrollSelf`, `unenrollSelf`.
2. **GREEN**: la implementación ya cumple el contrato → tests pasan al instante. Quedan como guardia anti-regresión.

## Stats

- API: **470/470** tests pass (+12 nuevos).
- Web: `tsc --noEmit` limpio.
- Sin cambios en frontend, sin migraciones.

## Test plan

- [ ] CI verde (Tests y type check + Vercel).
- [ ] Tras merge: el formulario `/register` carga los cursos en el selector "Curso del alumno".
- [ ] Si la página `/subjects` sigue mostrando sólo el curso matriculado en el entorno desplegado, ejecutar `pnpm --filter @vkbacademy/api prisma db seed` (data fix, ya no código) para poblar las 3 asignaturas por defecto: Matemáticas, Física y Química, Inglés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)