### PR TITLE
fix(api): /courses/subjects filtra por schoolYearId del alumno

### DIFF
--- a/apps/api/src/courses/courses.controller.ts
+++ b/apps/api/src/courses/courses.controller.ts
@@ -46,7 +46,7 @@ export class CoursesController {
   // (debe ir ANTES de @Get(':id') para que Nest lo resuelva como ruta estática)
   @Get('subjects')
   listSubjects(@CurrentUser() user: User) {
-    return this.coursesService.listAvailableSubjects(user.id);
+    return this.coursesService.listAvailableSubjects(user.id, user.schoolYearId ?? null);
   }
 
   @Post(':id/enroll')

--- a/apps/api/src/courses/courses.service.spec.ts
+++ b/apps/api/src/courses/courses.service.spec.ts
@@ -378,6 +378,28 @@ describe('CoursesService', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('filtra por schoolYearId del alumno: STUDENT 2ESO no ve cursos de 3ESO', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.enrollment.findMany.mockResolvedValue([]);
+
+      await service.listAvailableSubjects('u1', 'sy-2eso');
+
+      const where = mockPrisma.course.findMany.mock.calls[0][0].where;
+      expect(where.published).toBe(true);
+      expect(where.schoolYearId).toBe('sy-2eso');
+    });
+
+    it('sin schoolYearId del alumno (admin/tutor): no aplica filtro de nivel', async () => {
+      mockPrisma.course.findMany.mockResolvedValue([]);
+      mockPrisma.enrollment.findMany.mockResolvedValue([]);
+
+      await service.listAvailableSubjects('u1', null);
+
+      const where = mockPrisma.course.findMany.mock.calls[0][0].where;
+      expect(where.published).toBe(true);
+      expect(where.schoolYearId).toBeUndefined();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/courses/courses.service.ts
+++ b/apps/api/src/courses/courses.service.ts
@@ -194,13 +194,19 @@ export class CoursesService {
   }
 
   /**
-   * Lista las asignaturas disponibles para auto-matricularse: todos los cursos
-   * publicados, marcando si el alumno ya está matriculado.
+   * Lista las asignaturas disponibles para auto-matricularse: cursos publicados
+   * del nivel del alumno (schoolYearId), marcando si ya está matriculado.
+   * Si no se pasa schoolYearId (admin/tutor), no filtra por nivel.
    */
-  async listAvailableSubjects(userId: string) {
+  async listAvailableSubjects(userId: string, schoolYearId: string | null = null) {
+    const where: Record<string, unknown> = { published: true };
+    if (schoolYearId) {
+      where.schoolYearId = schoolYearId;
+    }
+
     const [courses, enrollments] = await Promise.all([
       this.prisma.course.findMany({
-        where: { published: true },
+        where,
         orderBy: [{ subject: 'asc' }, { title: 'asc' }],
         include: {
           schoolYear: { select: { id: true, label: true } },


### PR DESCRIPTION
## Summary
- Bug: alumno de 2ESO veía asignaturas de 3ESO en `/asignaturas` porque `listAvailableSubjects` devolvía todos los cursos publicados sin filtrar por nivel.
- Fix con TDD red-green: añadido parámetro `schoolYearId` a `CoursesService.listAvailableSubjects` y filtro en el `where` de Prisma. El controller pasa `user.schoolYearId`.
- Mantiene comportamiento para admin/tutor sin nivel: no aplica filtro.

## Tests
- **RED**: 2 tests nuevos en `courses.service.spec.ts`:
  - STUDENT 2ESO solo ve cursos de su `schoolYearId`.
  - Admin/tutor sin `schoolYearId` no aplica filtro de nivel.
- **GREEN**: 472/472 API tests verde (31 suites).

## Test plan
- [ ] CI verde (Tests + type check + Vercel)
- [ ] Manual: crear alumno 2ESO → /asignaturas muestra solo asignaturas 2ESO
- [ ] Manual: crear alumno 3ESO → /asignaturas muestra solo asignaturas 3ESO