### PR TITLE
fix(school-years): garantiza niveles por defecto en cada arranque

### DIFF
--- a/apps/api/src/school-years/school-years.service.spec.ts
+++ b/apps/api/src/school-years/school-years.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { SchoolYearsService } from './school-years.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -7,6 +8,7 @@ import { PrismaService } from '../prisma/prisma.service';
 const mockPrisma = {
   schoolYear: {
     findMany: jest.fn(),
+    upsert: jest.fn(),
   },
 };
 
@@ -17,10 +19,7 @@ describe('SchoolYearsService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        SchoolYearsService,
-        { provide: PrismaService, useValue: mockPrisma },
-      ],
+      providers: [SchoolYearsService, { provide: PrismaService, useValue: mockPrisma }],
     }).compile();
 
     service = module.get<SchoolYearsService>(SchoolYearsService);
@@ -55,6 +54,46 @@ describe('SchoolYearsService', () => {
 
       expect(mockPrisma.schoolYear.findMany).toHaveBeenCalledTimes(1);
       expect(result).toEqual([]);
+    });
+  });
+
+  // ─── onApplicationBootstrap (ensure de niveles por defecto) ──────────────────
+
+  describe('onApplicationBootstrap', () => {
+    it('hace upsert idempotente de los 6 niveles educativos por defecto', async () => {
+      mockPrisma.schoolYear.upsert.mockResolvedValue({});
+
+      await service.onApplicationBootstrap();
+
+      // Un upsert por cada nivel: 1º ESO … 2º Bachillerato
+      expect(mockPrisma.schoolYear.upsert).toHaveBeenCalledTimes(6);
+
+      const names = mockPrisma.schoolYear.upsert.mock.calls.map(
+        ([arg]) => (arg as { where: { name: string } }).where.name,
+      );
+      expect(names).toEqual(['1eso', '2eso', '3eso', '4eso', '1bach', '2bach']);
+
+      // Cada llamada usa `where` por el campo único `name` y no borra nada
+      for (const [arg] of mockPrisma.schoolYear.upsert.mock.calls) {
+        const call = arg as {
+          where: { name: string };
+          create: { name: string; label: string };
+          update: Record<string, unknown>;
+        };
+        expect(call.where).toHaveProperty('name');
+        expect(call.create).toHaveProperty('label');
+      }
+    });
+
+    it('no relanza si un upsert falla (no debe tumbar el arranque)', async () => {
+      mockPrisma.schoolYear.upsert.mockRejectedValue(new Error('DB caída'));
+      // Silenciamos el log de error esperado para no ensuciar la salida de tests
+      const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+      await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      errorSpy.mockRestore();
     });
   });
 });

--- a/apps/api/src/school-years/school-years.service.ts
+++ b/apps/api/src/school-years/school-years.service.ts
@@ -1,11 +1,52 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
+/**
+ * Niveles educativos por defecto. Son datos de referencia que la app necesita
+ * para funcionar (el selector de "Curso del alumno" en el registro los lee).
+ * El orden refleja el orden pedagógico, no alfabético.
+ */
+const DEFAULT_SCHOOL_YEARS: ReadonlyArray<{ name: string; label: string }> = [
+  { name: '1eso', label: '1º ESO' },
+  { name: '2eso', label: '2º ESO' },
+  { name: '3eso', label: '3º ESO' },
+  { name: '4eso', label: '4º ESO' },
+  { name: '1bach', label: '1º Bachillerato' },
+  { name: '2bach', label: '2º Bachillerato' },
+];
+
 @Injectable()
-export class SchoolYearsService {
+export class SchoolYearsService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(SchoolYearsService.name);
+
   constructor(private readonly prisma: PrismaService) {}
 
   findAll() {
     return this.prisma.schoolYear.findMany({ orderBy: { name: 'asc' } });
+  }
+
+  /**
+   * Garantiza que los niveles por defecto existen en cualquier entorno
+   * (PRE, PROD, local o cualquiera nuevo) en cada arranque. Es idempotente:
+   * `name` es único, así que el upsert crea los que falten y no duplica los
+   * existentes. Resiliente: un fallo de BD no debe impedir el arranque de la
+   * API — se registra y se continúa (el siguiente deploy lo reintenta).
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    try {
+      for (const sy of DEFAULT_SCHOOL_YEARS) {
+        await this.prisma.schoolYear.upsert({
+          where: { name: sy.name },
+          update: { label: sy.label },
+          create: sy,
+        });
+      }
+    } catch (err) {
+      this.logger.error(
+        `No se pudieron garantizar los niveles por defecto: ${
+          err instanceof Error ? err.message : 'desconocido'
+        }`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Problema

En **PROD**, en `/register`, el selector "Curso del alumno" no deja seleccionar nada: aparece vacío (solo el placeholder).

## Causa raíz

No es un bug de UI, es un problema de datos. El selector se rellena con el endpoint público `GET /school-years`, que hace un `findMany` sin filtros. Comprobado en vivo:

- **PRE** `GET /school-years` → devuelve los 6 niveles ✅
- **PROD** `GET /school-years` → `[]` ❌

La tabla `SchoolYear` en la base de datos de PROD está **vacía**: nunca se sembró. Las migraciones del pipeline (`migrate-prod`) crean el esquema pero **no siembran datos**, y el `seed.ts` completo es destructivo (empieza con cascada de `deleteMany`), por lo que no puede ejecutarse contra PROD.

## Solución

`SchoolYearsService` implementa `OnApplicationBootstrap` y hace un **upsert idempotente** de los 6 niveles por defecto (1º ESO … 2º Bachillerato) en cada arranque de la API.

- **Idempotente**: `SchoolYear.name` es `@unique`; crea los que falten, no duplica.
- **Env-agnóstico**: corre en PRE, PROD, local y cualquier entorno nuevo — sin pasos manuales.
- **Self-healing**: si los niveles se borran, el siguiente deploy los restaura (una migración puntual no lo haría).
- **Resiliente**: un fallo de BD se registra y **no tumba el arranque** de la API.

No toca ningún otro dato. El módulo ya está registrado en `AppModule`, así que el hook se dispara solo.

## Despliegue

Al mergear → el job gated `deploy-prod` levanta la nueva imagen → el hook puebla la tabla `SchoolYear` en PROD → el registro vuelve a funcionar. Mismo efecto en PRE.

## Verificación

- TDD: test RED→GREEN para `onApplicationBootstrap` (upsert idempotente de los 6 + resiliencia ante fallo de BD).
- `pnpm --filter @vkbacademy/api test` → **475/475** en verde. `tsc --noEmit` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)