### PR TITLE
feat(web): oculta Retos y Certificados en la vista de tutor

### DIFF
--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -17,8 +17,6 @@ function buildNavLinks(role: Role | undefined): NavLink[] {
       ...base,
       { to: '/tutor/students', label: '👥 Mis alumnos' },
       { to: '/bookings', label: '📅 Reservas' },
-      { to: '/challenges', label: '🏆 Retos' },
-      { to: '/certificates', label: '📜 Certificados' },
       { to: '/profile', label: '👤 Mi perfil' },
     ];
   }


### PR DESCRIPTION
## Resumen

Elimina los enlaces **Retos** (`/challenges`) y **Certificados** (`/certificates`) del menú de navegación del rol **TUTOR**.

El tutor conserva: Inicio, Mis alumnos, Reservas y Mi perfil.

## Cambios

- `apps/web/src/layouts/AppLayout.tsx` — se quitan las dos entradas del array de navegación de `Role.TUTOR` en `buildNavLinks()`.

No se modifican los menús de otros roles (STUDENT mantiene Retos; ADMIN/SUPER_ADMIN mantienen Retos de admin).

## Verificación

- `pnpm --filter @vkbacademy/web exec tsc --noEmit` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)