### PR TITLE
fix(web): dashboard de métricas del alumno queda en "Cargando" infinito

### DIFF
--- a/apps/web/src/pages/TutorStudentsPage.tsx
+++ b/apps/web/src/pages/TutorStudentsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { StudentAccessPanel } from '../components/tutor/StudentAccessPanel';
 import {

--- a/apps/web/src/pages/TutorStudentsPage.tsx
+++ b/apps/web/src/pages/TutorStudentsPage.tsx
@@ -352,10 +352,17 @@ function useStudentStats(studentId: string | null, from?: string, to?: string) {
 // ─── Componente: panel de detalle del alumno ───────────────────────────────────
 
 function StudentDetail({ student, periodDays }: { student: StudentSummary; periodDays: number }) {
-  const now = new Date();
-  const from =
-    periodDays > 0 ? new Date(now.getTime() - periodDays * 86400000).toISOString() : undefined;
-  const to = periodDays > 0 ? now.toISOString() : undefined;
+  // Memoizamos el rango de fechas: si recalculáramos `new Date()` en cada render,
+  // el ISO cambiaría siempre, el queryKey nunca se estabilizaría e isLoading no se
+  // resolvería jamás ("Cargando métricas..." infinito).
+  const { from, to } = useMemo(() => {
+    if (periodDays <= 0) return { from: undefined, to: undefined };
+    const now = Date.now();
+    return {
+      from: new Date(now - periodDays * 86400000).toISOString(),
+      to: new Date(now).toISOString(),
+    };
+  }, [periodDays]);
 
   const { data: stats, isLoading, isError } = useStudentStats(student.id, from, to);
 


### PR DESCRIPTION
## Problema

En la vista del tutor **Mis alumnos**, al seleccionar un alumno, la métrica quedaba en **"Cargando métricas..."** para siempre y no se renderizaba el dashboard.

## Causa

No era el backend (siempre devuelve un objeto `StudentStats` completo, con ceros si no hay actividad). En `StudentDetail`, el rango `from`/`to` se calculaba con `new Date()` en **cada render**, produciendo un ISO distinto cada vez. Eso cambiaba el `queryKey` de React Query continuamente → la query se reiniciaba sin parar → `isLoading` nunca se resolvía.

## Solución

Se memoiza el rango de fechas con `useMemo` dependiente de `periodDays`, estabilizando el `queryKey`. El dashboard ahora renderiza correctamente, incluso para alumnos sin datos (se muestran las métricas a cero que devuelve el backend).

## Verificación

- `pnpm --filter @vkbacademy/web exec tsc --noEmit` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)