### PR TITLE
feat(study): reordena el formulario de Estudiar y añade dificultad

### DIFF
--- a/apps/api/prisma/migrations/20260702095700_add_study_unit_difficulty/migration.sql
+++ b/apps/api/prisma/migrations/20260702095700_add_study_unit_difficulty/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "StudyUnit" ADD COLUMN     "difficulty" TEXT NOT NULL DEFAULT 'MEDIUM';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -678,6 +678,9 @@ model StudyUnit {
   topic     String // input crudo del alumno
   title     String // título limpio (se toma de la teoría generada)
   summary   String   @db.Text
+  /// Dificultad elegida por el alumno (EASY | MEDIUM | HARD). Gobierna la
+  /// generación de ejercicios y examen; se reutiliza al regenerar cada sección.
+  difficulty String  @default("MEDIUM")
   /// Ejercicios generados por IA, persistidos como JSON. Estructura:
   /// [{ statement, type: 'SINGLE'|'TRUE_FALSE'|'OPEN', options: string[], solution, explanation }]
   exercises Json?

--- a/apps/api/src/exams/ai-exams.service.ts
+++ b/apps/api/src/exams/ai-exams.service.ts
@@ -50,6 +50,13 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
+// Guía de dificultad inyectada en el prompt de generación del examen.
+const DIFFICULTY_GUIDANCE: Record<'EASY' | 'MEDIUM' | 'HARD', string> = {
+  EASY: 'Fácil: conceptos básicos y preguntas directas de una sola idea.',
+  MEDIUM: 'Media: aplicación de conceptos, con algún paso intermedio.',
+  HARD: 'Difícil: razonamiento avanzado, varios pasos y distractores plausibles.',
+};
+
 /**
  * Servicio de exámenes generados por IA por el propio alumno.
  *
@@ -100,6 +107,7 @@ export class AiExamsService {
       moduleTitle,
       dto.topic,
       dto.numQuestions,
+      dto.difficulty ?? 'MEDIUM',
     );
 
     this.logger.log(
@@ -439,6 +447,7 @@ export class AiExamsService {
     moduleTitle: string | undefined,
     topic: string,
     count: number,
+    difficulty: 'EASY' | 'MEDIUM' | 'HARD',
   ): string {
     const dist = this.getTypeDistribution(count);
     return `Genera un examen en español sobre el tema "${topic}".
@@ -446,6 +455,7 @@ export class AiExamsService {
 Curso: "${courseTitle}"
 ${schoolYearLabel ? `Nivel educativo: "${schoolYearLabel}" (sistema educativo español)` : ''}
 ${moduleTitle ? `Módulo: "${moduleTitle}"` : ''}
+Dificultad: ${DIFFICULTY_GUIDANCE[difficulty]}
 Número total de preguntas: ${count}
 
 ⚠️ DISTRIBUCIÓN POR TIPO — OBLIGATORIA, NO NEGOCIABLE:

--- a/apps/api/src/exams/dto/generate-ai-exam.dto.ts
+++ b/apps/api/src/exams/dto/generate-ai-exam.dto.ts
@@ -39,4 +39,9 @@ export class GenerateAiExamDto {
   @IsBoolean()
   @IsOptional()
   onlyOnce?: boolean;
+
+  /// Dificultad del examen a generar. Opcional (por defecto MEDIUM en el servicio).
+  @IsIn(['EASY', 'MEDIUM', 'HARD'])
+  @IsOptional()
+  difficulty?: 'EASY' | 'MEDIUM' | 'HARD';
 }

--- a/apps/api/src/exercises/dto/generate-exercises.dto.ts
+++ b/apps/api/src/exercises/dto/generate-exercises.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
+import { IsIn, IsInt, IsOptional, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
 
 export class GenerateExercisesDto {
   @IsString()
@@ -13,4 +13,9 @@ export class GenerateExercisesDto {
   @Min(1)
   @Max(20)
   count: number;
+
+  /// Dificultad del contenido a generar. Opcional (por defecto MEDIUM en el servicio).
+  @IsIn(['EASY', 'MEDIUM', 'HARD'])
+  @IsOptional()
+  difficulty?: 'EASY' | 'MEDIUM' | 'HARD';
 }

--- a/apps/api/src/exercises/exercises.service.ts
+++ b/apps/api/src/exercises/exercises.service.ts
@@ -33,6 +33,13 @@ export interface EvaluationResult {
 
 const VALID_VERDICTS: EvaluationVerdict[] = ['correct', 'partial', 'incorrect'];
 
+// Guía de dificultad inyectada en el prompt de generación.
+const DIFFICULTY_GUIDANCE: Record<'EASY' | 'MEDIUM' | 'HARD', string> = {
+  EASY: 'Fácil: conceptos básicos y ejercicios directos de una sola idea.',
+  MEDIUM: 'Media: aplicación de conceptos, con algún paso intermedio.',
+  HARD: 'Difícil: razonamiento avanzado, varios pasos y casos menos evidentes.',
+};
+
 /**
  * Genera ejercicios de práctica bajo demanda para un alumno matriculado
  * en un curso. Los ejercicios NO se persisten en BD — son efímeros, solo
@@ -75,6 +82,7 @@ export class ExercisesService {
       course.schoolYear?.label ?? '',
       dto.topic,
       dto.count,
+      dto.difficulty ?? 'MEDIUM',
     );
 
     this.logger.log(
@@ -95,7 +103,9 @@ export class ExercisesService {
 
   async evaluate(dto: EvaluateExerciseDto): Promise<EvaluationResult> {
     const prompt = this.buildEvaluationPrompt(dto);
-    this.logger.log(`Evaluando respuesta abierta para enunciado: "${dto.statement.slice(0, 60)}..."`);
+    this.logger.log(
+      `Evaluando respuesta abierta para enunciado: "${dto.statement.slice(0, 60)}..."`,
+    );
 
     const text = await this.ai.generate(prompt, 400);
 
@@ -152,11 +162,13 @@ El feedback debe ser pedagógico, directo y en segunda persona ("Has olvidado si
     schoolYearLabel: string,
     topic: string,
     count: number,
+    difficulty: 'EASY' | 'MEDIUM' | 'HARD',
   ): string {
     return `Genera ${count} ejercicios de práctica en español sobre el tema "${topic}".
 
 Curso: "${courseTitle}"
 ${schoolYearLabel ? `Nivel educativo: "${schoolYearLabel}" (sistema educativo español)` : ''}
+Dificultad: ${DIFFICULTY_GUIDANCE[difficulty]}
 
 Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, sin explicaciones adicionales fuera del JSON):
 {

--- a/apps/api/src/study/dto/create-study-unit.dto.ts
+++ b/apps/api/src/study/dto/create-study-unit.dto.ts
@@ -24,6 +24,9 @@ export class CreateStudyUnitDto {
   @Max(20, { message: 'Máximo 20 ejercicios' })
   numExercises: number;
 
+  @IsIn(['EASY', 'MEDIUM', 'HARD'], { message: 'difficulty debe ser EASY, MEDIUM o HARD' })
+  difficulty: 'EASY' | 'MEDIUM' | 'HARD';
+
   @IsInt()
   @IsIn([5, 10], { message: 'numQuestions debe ser 5 o 10' })
   numQuestions: 5 | 10;

--- a/apps/api/src/study/study.service.spec.ts
+++ b/apps/api/src/study/study.service.spec.ts
@@ -98,6 +98,7 @@ describe('StudyService', () => {
         courseId: 'course-1',
         topic: 't',
         numExercises: 1,
+        difficulty: 'MEDIUM',
         numQuestions: 5,
       });
       expect(prisma.studyUnit.create).toHaveBeenCalled();
@@ -110,6 +111,18 @@ describe('StudyService', () => {
         data: { studyUnitId: 'unit-1' },
       });
       expect(result.sections).toEqual({ theory: true, exercises: true, exam: true });
+      // La dificultad se persiste en la unidad y se propaga a ambos generadores.
+      expect(prisma.studyUnit.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ difficulty: 'MEDIUM' }) }),
+      );
+      expect(exercises.generate).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ difficulty: 'MEDIUM' }),
+      );
+      expect(aiExams.generate).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ difficulty: 'MEDIUM' }),
+      );
     });
 
     it('crea la unidad aunque falle una sección (examen) y la marca ausente', async () => {
@@ -119,6 +132,7 @@ describe('StudyService', () => {
         courseId: 'course-1',
         topic: 't',
         numExercises: 1,
+        difficulty: 'MEDIUM',
         numQuestions: 5,
       });
       expect(prisma.aiExamBank.update).not.toHaveBeenCalled();
@@ -135,6 +149,7 @@ describe('StudyService', () => {
           courseId: 'course-1',
           topic: 't',
           numExercises: 1,
+          difficulty: 'MEDIUM',
           numQuestions: 5,
         }),
       ).rejects.toThrow(InternalServerErrorException);
@@ -149,6 +164,7 @@ describe('StudyService', () => {
           courseId: 'course-1',
           topic: 't',
           numExercises: 1,
+          difficulty: 'MEDIUM',
           numQuestions: 5,
         }),
       ).rejects.toThrow('tx failed');
@@ -162,6 +178,7 @@ describe('StudyService', () => {
           courseId: 'course-1',
           topic: 't',
           numExercises: 1,
+          difficulty: 'MEDIUM',
           numQuestions: 5,
         }),
       ).rejects.toThrow(ForbiddenException);

--- a/apps/api/src/study/study.service.ts
+++ b/apps/api/src/study/study.service.ts
@@ -42,7 +42,14 @@ export class StudyService {
 
     // Unidad "cáscara": título/summary provisionales, se completan desde la teoría.
     const unit = await this.prisma.studyUnit.create({
-      data: { userId, courseId: dto.courseId, topic: dto.topic, title: dto.topic, summary: '' },
+      data: {
+        userId,
+        courseId: dto.courseId,
+        topic: dto.topic,
+        title: dto.topic,
+        summary: '',
+        difficulty: dto.difficulty,
+      },
     });
 
     // Las 3 secciones a la vez. allSettled: una que falle no tumba las demás.
@@ -52,6 +59,7 @@ export class StudyService {
         courseId: dto.courseId,
         topic: dto.topic,
         count: dto.numExercises,
+        difficulty: dto.difficulty,
       }),
       this.aiExams.generate(userId, {
         courseId: dto.courseId,
@@ -59,6 +67,7 @@ export class StudyService {
         numQuestions: dto.numQuestions,
         timeLimit: dto.timeLimit,
         onlyOnce: dto.onlyOnce,
+        difficulty: dto.difficulty,
       }),
     ]);
 
@@ -215,6 +224,7 @@ export class StudyService {
       courseId: unit.courseId,
       topic: unit.topic,
       count,
+      difficulty: unit.difficulty as 'EASY' | 'MEDIUM' | 'HARD',
     });
     await this.prisma.studyUnit.update({
       where: { id: unit.id },
@@ -232,6 +242,7 @@ export class StudyService {
       numQuestions: dto.numQuestions ?? 5,
       timeLimit: dto.timeLimit,
       onlyOnce: dto.onlyOnce,
+      difficulty: unit.difficulty as 'EASY' | 'MEDIUM' | 'HARD',
     });
     await this.prisma.aiExamBank.update({
       where: { id: bank.id },

--- a/apps/web/src/pages/StudyPage.tsx
+++ b/apps/web/src/pages/StudyPage.tsx
@@ -1,7 +1,14 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import type { StudyDifficulty } from '@vkbacademy/shared';
 import { useCourses } from '../hooks/useCourses';
 import { useMyStudyUnits, useCreateStudyUnit, useDeleteStudyUnit } from '../hooks/useStudy';
+
+const DIFFICULTIES: { value: StudyDifficulty; label: string }[] = [
+  { value: 'EASY', label: 'Fácil' },
+  { value: 'MEDIUM', label: 'Media' },
+  { value: 'HARD', label: 'Difícil' },
+];
 
 export default function StudyPage() {
   const navigate = useNavigate();
@@ -15,6 +22,7 @@ export default function StudyPage() {
   const [courseId, setCourseId] = useState('');
   const [topic, setTopic] = useState('');
   const [numExercises, setNumExercises] = useState(5);
+  const [difficulty, setDifficulty] = useState<StudyDifficulty>('MEDIUM');
   const [numQuestions, setNumQuestions] = useState<5 | 10>(5);
   const [useTimer, setUseTimer] = useState(false);
   const [timerMins, setTimerMins] = useState(15);
@@ -28,6 +36,7 @@ export default function StudyPage() {
         courseId,
         topic: topic.trim(),
         numExercises,
+        difficulty,
         numQuestions,
         timeLimit: useTimer ? Math.round(timerMins * 60) : undefined,
         onlyOnce,
@@ -52,36 +61,22 @@ export default function StudyPage() {
       </header>
 
       <form onSubmit={handleSubmit} style={s.form}>
-        <div style={s.row}>
-          <div className="field" style={{ flex: 2 }}>
-            <label htmlFor="courseId">Asignatura</label>
-            <select
-              id="courseId"
-              value={courseId}
-              onChange={(e) => setCourseId(e.target.value)}
-              required
-            >
-              <option value="">Selecciona una asignatura</option>
-              {courses.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.title}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="field" style={{ flex: 1 }}>
-            <label htmlFor="numExercises">Nº de ejercicios</label>
-            <input
-              id="numExercises"
-              type="number"
-              min={1}
-              max={20}
-              value={numExercises}
-              onChange={(e) =>
-                setNumExercises(Math.max(1, Math.min(20, Number(e.target.value) || 1)))
-              }
-            />
-          </div>
+        {/* Asignatura + tema */}
+        <div className="field">
+          <label htmlFor="courseId">Asignatura</label>
+          <select
+            id="courseId"
+            value={courseId}
+            onChange={(e) => setCourseId(e.target.value)}
+            required
+          >
+            <option value="">Selecciona una asignatura</option>
+            {courses.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.title}
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="field">
@@ -97,52 +92,91 @@ export default function StudyPage() {
           />
         </div>
 
-        <div className="field">
-          <label>Preguntas del examen</label>
-          <div style={{ display: 'flex', gap: 10 }}>
-            {([5, 10] as const).map((n) => (
-              <button
-                key={n}
-                type="button"
-                onClick={() => setNumQuestions(n)}
-                style={{ ...s.pill, ...(numQuestions === n ? s.pillActive : {}) }}
-              >
-                {n} preguntas
-              </button>
-            ))}
+        {/* Ejercicios */}
+        <div style={s.section}>
+          <h3 style={s.sectionTitle}>🧮 Ejercicios</h3>
+          <div style={s.row}>
+            <div className="field" style={{ flex: 1 }}>
+              <label htmlFor="numExercises">Nº de ejercicios</label>
+              <input
+                id="numExercises"
+                type="number"
+                min={1}
+                max={20}
+                value={numExercises}
+                onChange={(e) =>
+                  setNumExercises(Math.max(1, Math.min(20, Number(e.target.value) || 1)))
+                }
+              />
+            </div>
+            <div className="field" style={{ flex: 2 }}>
+              <label>Dificultad</label>
+              <div style={{ display: 'flex', gap: 10 }}>
+                {DIFFICULTIES.map((d) => (
+                  <button
+                    key={d.value}
+                    type="button"
+                    onClick={() => setDifficulty(d.value)}
+                    style={{ ...s.pill, ...(difficulty === d.value ? s.pillActive : {}) }}
+                  >
+                    {d.label}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
 
-        <label style={s.toggle}>
-          <input
-            type="checkbox"
-            checked={useTimer}
-            onChange={(e) => setUseTimer(e.target.checked)}
-          />
-          <span>⏱ Límite de tiempo</span>
-          {useTimer && (
-            <input
-              type="number"
-              min={1}
-              max={180}
-              value={timerMins}
-              onChange={(e) =>
-                setTimerMins(Math.min(180, Math.max(1, Number(e.target.value) || 1)))
-              }
-              style={s.timerInput}
-            />
-          )}
-          {useTimer && <span style={s.muted}>minutos</span>}
-        </label>
+        {/* Examen */}
+        <div style={s.section}>
+          <h3 style={s.sectionTitle}>🎓 Examen</h3>
+          <div className="field">
+            <label>Preguntas del examen</label>
+            <div style={{ display: 'flex', gap: 10 }}>
+              {([5, 10] as const).map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setNumQuestions(n)}
+                  style={{ ...s.pill, ...(numQuestions === n ? s.pillActive : {}) }}
+                >
+                  {n} preguntas
+                </button>
+              ))}
+            </div>
+          </div>
 
-        <label style={s.toggle}>
-          <input
-            type="checkbox"
-            checked={onlyOnce}
-            onChange={(e) => setOnlyOnce(e.target.checked)}
-          />
-          <span>🔒 Examen de un solo intento</span>
-        </label>
+          <label style={s.toggle}>
+            <input
+              type="checkbox"
+              checked={useTimer}
+              onChange={(e) => setUseTimer(e.target.checked)}
+            />
+            <span>⏱ Límite de tiempo</span>
+            {useTimer && (
+              <input
+                type="number"
+                min={1}
+                max={180}
+                value={timerMins}
+                onChange={(e) =>
+                  setTimerMins(Math.min(180, Math.max(1, Number(e.target.value) || 1)))
+                }
+                style={s.timerInput}
+              />
+            )}
+            {useTimer && <span style={s.muted}>minutos</span>}
+          </label>
+
+          <label style={s.toggle}>
+            <input
+              type="checkbox"
+              checked={onlyOnce}
+              onChange={(e) => setOnlyOnce(e.target.checked)}
+            />
+            <span>🔒 Examen de un solo intento</span>
+          </label>
+        </div>
 
         {apiErrorText && (
           <div style={s.errorBox}>
@@ -224,6 +258,16 @@ const s: Record<string, React.CSSProperties> = {
     padding: 24,
   },
   row: { display: 'flex', gap: 16, flexWrap: 'wrap' },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+    padding: 16,
+    border: '1px solid var(--color-border)',
+    borderRadius: 10,
+    background: 'var(--color-bg)',
+  },
+  sectionTitle: { margin: 0, fontSize: '0.95rem', fontWeight: 700, color: 'var(--color-text)' },
   textarea: {
     width: '100%',
     background: 'var(--color-surface)',

--- a/packages/shared/src/types/study.types.ts
+++ b/packages/shared/src/types/study.types.ts
@@ -1,5 +1,8 @@
 import type { TheoryModuleWithLessons } from './theory.types';
 
+// Dificultad de la unidad de estudio. Gobierna la generación de ejercicios y examen.
+export type StudyDifficulty = 'EASY' | 'MEDIUM' | 'HARD';
+
 // Ejercicio persistido en la unidad (misma forma que genera ExercisesService).
 export type StudyExerciseType = 'SINGLE' | 'TRUE_FALSE' | 'OPEN';
 
@@ -65,6 +68,7 @@ export interface CreateStudyUnitRequest {
   courseId: string;
   topic: string;
   numExercises: number;
+  difficulty: StudyDifficulty; // aplica a ejercicios y examen
   numQuestions: 5 | 10;
   timeLimit?: number; // segundos
   onlyOnce?: boolean;


### PR DESCRIPTION
Continuación sobre la feature "Estudiar" (mergeada en #49).

## Qué

- **Reordena el formulario de `StudyPage`** en tres secciones: **Asignatura + Tema** → **🧮 Ejercicios** (nº de ejercicios + dificultad) → **🎓 Examen** (preguntas 5/10 + timer + 1 intento).
- **Nuevo campo de dificultad** (`Fácil` / `Media` / `Difícil`, por defecto `Media`) bajo Ejercicios, que **gobierna la generación IA de ejercicios Y del examen**.

## Cómo

- `shared`: `StudyDifficulty` + `difficulty` en `CreateStudyUnitRequest`.
- `prisma`: columna `StudyUnit.difficulty` (`String`, default `MEDIUM`) — **migración aditiva** (`ADD COLUMN ... DEFAULT 'MEDIUM'`, sin riesgo para filas existentes).
- `api`: `difficulty` en `CreateStudyUnitDto` (obligatorio) y en los DTOs de ejercicios/examen (opcional). Se inyecta en ambos prompts (`ExercisesService` y `AiExamsService`) mediante una guía de dificultad.
- `StudyService`: persiste la dificultad en la unidad y la propaga en `create` y en las **regeneraciones** por sección (regenerar no resetea la dificultad).

## Testing

- API: **492/492** (incluye aserción de que la dificultad se propaga a ambos generadores y a la creación de la unidad).
- `tsc --noEmit` limpio en api / shared / web.
- ⚠️ Pendiente verificación manual del efecto real de la dificultad en la generación IA (los tests no ejercitan la IA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)