### PR TITLE
feat(theory): temarios Winston, slides paso a paso y estetica estadio

### DIFF
--- a/apps/api/src/theory/theory.service.spec.ts
+++ b/apps/api/src/theory/theory.service.spec.ts
@@ -229,6 +229,34 @@ describe('TheoryService', () => {
       expect(prompt).toContain('3º ESO');
       expect(prompt).toContain('propiedades de logaritmos');
     });
+
+    it('el prompt exige la estructura Winston (promesa, cycling, fencing, ejemplos paso a paso, cierre)', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
+      youtube.findCandidates.mockResolvedValue([]);
+      prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
+
+      await service.generate('user-1', { courseId: 'course-1', topic: 't' });
+
+      const prompt = ai.generate.mock.calls[0][0] as string;
+      // Promesa de empoderamiento (W-OPEN-1) como primera lección
+      expect(prompt).toContain('Qué vas a conseguir');
+      expect(prompt).toContain('**Sabrás**');
+      // Cycling y fencing (W-TEACH-1 / W-TEACH-2)
+      expect(prompt).toContain('Cycling');
+      expect(prompt).toContain('🚧 **Esto SÍ / esto NO:**');
+      // Ejemplos paso a paso con estructura parseable
+      expect(prompt).toContain('MÍNIMO 3 ejemplos');
+      expect(prompt).toContain('**Enunciado:**');
+      expect(prompt).toContain('**Resultado:**');
+      expect(prompt).toContain('**Por qué funciona:**');
+      // Cierre de contribuciones (W-CLOSE-1), nunca despedidas
+      expect(prompt).toContain('Lo que te llevas');
+      expect(prompt).toContain('**Ya sabes**');
+      // Presupuesto ampliado para la estructura nueva
+      expect(ai.generate.mock.calls[0][1]).toBe(6000);
+    });
   });
 
   describe('listMine', () => {

--- a/apps/api/src/theory/theory.service.spec.ts
+++ b/apps/api/src/theory/theory.service.spec.ts
@@ -254,6 +254,9 @@ describe('TheoryService', () => {
       // Cierre de contribuciones (W-CLOSE-1), nunca despedidas
       expect(prompt).toContain('Lo que te llevas');
       expect(prompt).toContain('**Ya sabes**');
+      // Voz anti patrón-IA (humanizer): tono de entrenador y AIismos vetados
+      expect(prompt).toContain('anti patrón-IA');
+      expect(prompt).toContain('"En resumen"');
       // Presupuesto ampliado para la estructura nueva
       expect(ai.generate.mock.calls[0][1]).toBe(6000);
     });

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -256,6 +256,14 @@ ESTRUCTURA — metodología Winston de enseñanza, OBLIGATORIA:
 
 - CONTENT "Lo que te llevas" — cierre de contribuciones, espejo de la promesa inicial: lista de 3-4 items "- **Ya sabes** [la misma habilidad prometida al inicio]" + 1 frase final que empuje al siguiente paso (practicar con ejercicios o hacer el test). PROHIBIDO cerrar con "gracias", "espero que" o despedidas.
 
+VOZ Y ESTILO (anti patrón-IA) — escribe como un entrenador cercano en el vestuario, no como un manual:
+- Tutea siempre y habla directo al alumno ("mira", "ojo con esto", "ahora te toca a ti").
+- Varía el ritmo: frases cortas y punzantes mezcladas con alguna más larga. Nada de párrafos clónicos.
+- PROHIBIDO el relleno típico de IA: "En resumen", "En conclusión", "Es importante destacar", "cabe mencionar", "juega un papel crucial/fundamental", "sumérgete", "el fascinante mundo de", "no es solo X, es Y".
+- PROHIBIDO inflar la importancia del tema ("marca un antes y un después", "es clave para tu futuro").
+- Nada de guiones largos (—) como puntuación: usa coma, paréntesis o dos puntos.
+- Concreto siempre: números, objetos y situaciones reales de un adolescente (la paga, los entrenos, los videojuegos, las notas) antes que abstracciones.
+
 Reglas de formato:
 - INTRO/CONTENT/EXAMPLE: campo "body" obligatorio en markdown. NO incluir "ytQuery".
 - VIDEO: campo "ytQuery" obligatorio. NO incluir "body".

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -85,7 +85,7 @@ export class TheoryService {
     // casi siempre lo arregla). Ver `ai-json.ts`.
     let parsed: unknown;
     try {
-      parsed = await generateAiJson(this.ai, prompt, 4000, { attempts: 2, logger: this.logger });
+      parsed = await generateAiJson(this.ai, prompt, 6000, { attempts: 2, logger: this.logger });
     } catch (err) {
       this.logger.error('Error al parsear JSON de IA (teoría) tras reintentos:', err);
       throw new InternalServerErrorException(
@@ -93,6 +93,12 @@ export class TheoryService {
       );
     }
     const payload = this.validatePayload(parsed);
+
+    // Estructura Winston deseada pero no bloqueante: si la IA no la respeta se
+    // persiste igualmente (el deck degrada a slides normales) y queda traza.
+    if (payload.lessons[0]?.kind !== TheoryLessonKind.INTRO) {
+      this.logger.warn(`Temario sobre "${dto.topic}" sin promesa INTRO como primera lección`);
+    }
 
     // Resolver vídeo de YouTube para lecciones VIDEO. Para cada VIDEO pedimos
     // hasta 5 candidatos (ordenados por engagement+whitelist) y los guardamos
@@ -218,42 +224,50 @@ Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, si
   "title": "título limpio del temario (no repitas el tema literal)",
   "summary": "resumen del temario en 1-2 frases",
   "lessons": [
-    {
-      "kind": "INTRO",
-      "heading": "Introducción",
-      "body": "explicación introductoria en markdown (2-3 párrafos)"
-    },
-    {
-      "kind": "CONTENT",
-      "heading": "título de la sección de desarrollo",
-      "body": "explicación detallada en markdown (3-5 párrafos, puede usar listas y negritas)"
-    },
-    {
-      "kind": "EXAMPLE",
-      "heading": "Ejemplos",
-      "body": "ejemplos resueltos en markdown (al menos 2 ejemplos con paso a paso)"
-    },
-    {
-      "kind": "VIDEO",
-      "heading": "Vídeo recomendado",
-      "ytQuery": "consulta optimizada para buscar el mejor vídeo en YouTube sobre este tema"
-    }
+    { "kind": "INTRO", "heading": "Qué vas a conseguir", "body": "la promesa (ver ESTRUCTURA)" },
+    { "kind": "CONTENT", "heading": "título de la sección de desarrollo", "body": "desarrollo (ver ESTRUCTURA)" },
+    { "kind": "EXAMPLE", "heading": "Ejemplos paso a paso", "body": "mínimo 3 ejemplos resueltos (ver ESTRUCTURA)" },
+    { "kind": "VIDEO", "heading": "Vídeo recomendado", "ytQuery": "consulta optimizada para buscar el mejor vídeo en YouTube sobre este tema" },
+    { "kind": "CONTENT", "heading": "Lo que te llevas", "body": "cierre espejo de la promesa (ver ESTRUCTURA)" }
   ]
 }
 
-Reglas:
-- Mínimo 3 lecciones, máximo 6.
-- Estructura recomendada: 1 INTRO + 1-3 CONTENT + 1 EXAMPLE + 1 VIDEO (último).
+ESTRUCTURA — metodología Winston de enseñanza, OBLIGATORIA:
+- Entre 5 y 8 lecciones, en este orden: 1 INTRO "Qué vas a conseguir" (SIEMPRE la primera) + 1-3 CONTENT de desarrollo + 1 EXAMPLE + 1 VIDEO + 1 CONTENT "Lo que te llevas" (SIEMPRE la última).
+
+- INTRO "Qué vas a conseguir" — promesa de empoderamiento: qué sabrá HACER el alumno al final que no sabe ahora, y para qué le sirve. Formato: 1 frase corta que enganche + lista de 3-4 items con el formato exacto "- **Sabrás** [habilidad concreta]: te servirá para [uso real: el examen, el deporte o la vida diaria]". Sin definiciones todavía, sin índice.
+
+- CONTENT de desarrollo — en CADA lección de este tipo:
+  - Abre situando al alumno (puntuación verbal): "Ya tienes [lo anterior]. Ahora, bloque N: [lo que viene]." (1 frase).
+  - Cycling: el concepto central explicado 3 veces seguidas de forma distinta: (1) definición precisa, (2) analogía cotidiana o deportiva, (3) mini-ejemplo con números o caso concreto.
+  - Fencing: exactamente 1 callout \`> 🚧 **Esto SÍ / esto NO:** [concepto] ES [definición corta]. NO lo confundas con [concepto parecido]: [diferencia en 1 frase].\`
+  - Exactamente 1 callout ❓ con una pregunta que el alumno pueda intentar responder antes de seguir.
+  - Párrafos CORTOS (máximo ~40 palabras) separados por línea en blanco: cada párrafo se convierte en un fragmento de diapositiva.
+
+- EXAMPLE "Ejemplos paso a paso" — MÍNIMO 3 ejemplos resueltos, de dificultad creciente. CADA ejemplo con esta estructura markdown EXACTA:
+### 💪 Ejemplo N: [título corto]
+**Enunciado:** [planteamiento concreto]
+1. [primer paso: qué se hace y por qué, en 1-2 frases]
+2. [segundo paso]
+3. [tercer paso]
+(mínimo 3 pasos por ejemplo; añade más si el problema lo pide)
+**Resultado:** [solución final]
+**Por qué funciona:** [1-2 frases conectando el procedimiento con la teoría]
+
+- CONTENT "Lo que te llevas" — cierre de contribuciones, espejo de la promesa inicial: lista de 3-4 items "- **Ya sabes** [la misma habilidad prometida al inicio]" + 1 frase final que empuje al siguiente paso (practicar con ejercicios o hacer el test). PROHIBIDO cerrar con "gracias", "espero que" o despedidas.
+
+Reglas de formato:
 - INTRO/CONTENT/EXAMPLE: campo "body" obligatorio en markdown. NO incluir "ytQuery".
 - VIDEO: campo "ytQuery" obligatorio. NO incluir "body".
 - El markdown puede usar **negritas**, *cursivas*, listas con guiones, encabezados con ##.
 - Para fórmulas matemáticas USA SIEMPRE LaTeX: inline con $...$ (ej. $\\log_a b = c$) y bloques con $$...$$ para derivaciones o ecuaciones destacadas. NO escribas fórmulas en texto plano (NUNCA "log_a b = c"; SIEMPRE "$\\log_a b = c$").
-- **DIDÁCTICA — incluye callouts pedagógicos** intercalados en el body para hacer la lectura más activa. Formato OBLIGATORIO con blockquote markdown, emoji al inicio, etiqueta en negrita:
+- **DIDÁCTICA — callouts pedagógicos** intercalados en el body, con blockquote markdown, emoji al inicio y etiqueta en negrita:
   - \`> 💡 **Tip:** consejo práctico que ayude a recordar o aplicar el concepto.\`
   - \`> 🧠 **Recuerda:** dato/fórmula/regla clave que el alumno debe memorizar.\`
   - \`> ⚠️ **Cuidado:** error común a evitar o trampa habitual del tema.\`
   - \`> ❓ **Pregunta:** pregunta retórica para que el alumno se pare a pensar antes de seguir.\`
-  Mete entre 2 y 4 callouts en CADA lección INTRO/CONTENT/EXAMPLE, mezclando tipos. Cada callout en su propio párrafo (separado por línea en blanco). NO los pongas todos juntos al final — repártelos donde encajen pedagógicamente.
+  - \`> 🚧 **Esto SÍ / esto NO:** delimitación del concepto frente a otro parecido.\`
+  Mete entre 2 y 4 callouts en CADA lección INTRO/CONTENT/EXAMPLE (los 🚧 y ❓ obligatorios de cada CONTENT cuentan). Cada callout en su propio párrafo (separado por línea en blanco). NO los pongas todos juntos al final — repártelos donde encajen pedagógicamente.
 - Contenido curricular real y riguroso, adaptado al nivel ${schoolYearLabel || 'del curso'}.
 - "ytQuery" debe ser una búsqueda específica y descriptiva (ej. "demostración propiedades logaritmos bachillerato").
 - Solo devuelve JSON puro, sin markdown alrededor del JSON.`;

--- a/apps/web/src/components/theory/SlideView.tsx
+++ b/apps/web/src/components/theory/SlideView.tsx
@@ -24,9 +24,33 @@ export function SlideView({ slide, revealed, forPdf = false }: SlideViewProps) {
       return <ClosingSlide />;
     case 'video':
       return <VideoSlide slide={slide} forPdf={forPdf} />;
+    case 'example':
+      return <ExampleSlide slide={slide} revealed={revealed} forPdf={forPdf} />;
     default:
       return <ContentSlide slide={slide} revealed={revealed} forPdf={forPdf} />;
   }
+}
+
+/** Fragmento revelable (mismo mecanismo que usa el override del PDF). */
+function Frag({
+  shown,
+  delayIndex,
+  forPdf,
+  children,
+}: {
+  shown: boolean;
+  delayIndex: number;
+  forPdf: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={`tslides-frag${shown ? ' tslides-frag--shown' : ''}`}
+      style={{ transitionDelay: shown && !forPdf ? `${delayIndex * 40}ms` : undefined }}
+    >
+      {children}
+    </div>
+  );
 }
 
 function CoverSlide({ slide }: { slide: Slide }) {
@@ -53,7 +77,7 @@ function ContentSlide({
 }) {
   const blocks = slide.blocks ?? [];
   return (
-    <div className="tsl-content">
+    <div className={`tsl-content${slide.variant ? ` tsl-content--${slide.variant}` : ''}`}>
       <h2 className="tsl-heading">
         <span className="tsl-icon" aria-hidden>
           {slide.icon}
@@ -62,18 +86,75 @@ function ContentSlide({
         {slide.continued && <span className="tsl-cont">cont.</span>}
       </h2>
       <div className="tsl-body">
-        {blocks.map((block, i) => {
-          const shown = forPdf || i < revealed;
-          return (
-            <div
-              key={i}
-              className={`tslides-frag${shown ? ' tslides-frag--shown' : ''}`}
-              style={{ transitionDelay: shown && !forPdf ? `${i * 40}ms` : undefined }}
-            >
-              <TheoryMarkdown>{block}</TheoryMarkdown>
+        {blocks.map((block, i) => (
+          <Frag key={i} shown={forPdf || i < revealed} delayIndex={i} forPdf={forPdf}>
+            <TheoryMarkdown>{block}</TheoryMarkdown>
+          </Frag>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Ejemplo resuelto paso a paso: enunciado, pasos como tarjetas con número
+ * grande, resultado destacado y conexión con la teoría. Cada pieza es un
+ * fragmento revelable.
+ */
+function ExampleSlide({
+  slide,
+  revealed,
+  forPdf,
+}: {
+  slide: Slide;
+  revealed: number;
+  forPdf: boolean;
+}) {
+  const steps = slide.steps ?? [];
+  const resultIndex = 1 + steps.length;
+  const whyIndex = resultIndex + 1;
+  const shown = (i: number) => forPdf || i < revealed;
+
+  return (
+    <div className="tsl-content tsl-example">
+      <h2 className="tsl-heading">{slide.heading}</h2>
+      <div className="tsl-body">
+        <Frag shown={shown(0)} delayIndex={0} forPdf={forPdf}>
+          <div className="tsl-ex-statement">
+            <span className="tsl-ex-label">Enunciado</span>
+            <TheoryMarkdown>{slide.statement ?? ''}</TheoryMarkdown>
+          </div>
+        </Frag>
+        <ol className="tsl-ex-steps">
+          {steps.map((step, i) => (
+            <li key={i}>
+              <Frag shown={shown(i + 1)} delayIndex={i + 1} forPdf={forPdf}>
+                <div className="tsl-ex-step">
+                  <span className="tsl-ex-num" aria-hidden>
+                    {i + 1}
+                  </span>
+                  <div className="tsl-ex-step-body">
+                    <TheoryMarkdown>{step}</TheoryMarkdown>
+                  </div>
+                </div>
+              </Frag>
+            </li>
+          ))}
+        </ol>
+        <Frag shown={shown(resultIndex)} delayIndex={resultIndex} forPdf={forPdf}>
+          <div className="tsl-ex-result">
+            <span className="tsl-ex-label">Resultado</span>
+            <TheoryMarkdown>{slide.result ?? ''}</TheoryMarkdown>
+          </div>
+        </Frag>
+        {slide.why && (
+          <Frag shown={shown(whyIndex)} delayIndex={whyIndex} forPdf={forPdf}>
+            <div className="tsl-ex-why">
+              <span className="tsl-ex-label">Por qué funciona</span>
+              <TheoryMarkdown>{slide.why}</TheoryMarkdown>
             </div>
-          );
-        })}
+          </Frag>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/theory/TheorySlides.tsx
+++ b/apps/web/src/components/theory/TheorySlides.tsx
@@ -513,6 +513,111 @@ export const TSLIDES_CSS = `
     border-left-color: rgba(255,255,255,0.28);
   }
 
+  /* ── Variantes Winston: promesa (objetivos) y cierre (lo que te llevas) ── */
+  .tsl-content--objectives .tsl-body ul,
+  .tsl-content--takeaways .tsl-body ul {
+    list-style: none;
+    margin: 0 0 0.8em;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+  }
+  .tsl-content--objectives .tsl-body li,
+  .tsl-content--takeaways .tsl-body li {
+    position: relative;
+    margin: 0;
+    padding: 14px 18px 14px 58px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.14);
+    border-radius: 14px;
+    line-height: 1.5;
+  }
+  .tsl-content--objectives .tsl-body li::before,
+  .tsl-content--takeaways .tsl-body li::before {
+    content: '✓';
+    position: absolute;
+    left: 15px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--brand-glow);
+    color: var(--brand-light);
+    font-weight: 800;
+    font-size: 0.95rem;
+    display: grid;
+    place-items: center;
+  }
+  .tsl-content--takeaways .tsl-body li {
+    background: var(--brand-soft);
+    border-color: var(--brand);
+  }
+
+  /* ── Slide de ejemplo paso a paso ── */
+  .tsl-example .tsl-body { font-size: clamp(0.95rem, 1.9vw, 1.2rem); }
+  .tsl-ex-label {
+    display: block;
+    font-size: 0.68rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--brand-light);
+    margin-bottom: 6px;
+  }
+  .tsl-ex-statement, .tsl-ex-result, .tsl-ex-why {
+    border-radius: 14px;
+    padding: 14px 18px;
+    margin: 0 0 12px;
+  }
+  .tsl-ex-statement, .tsl-ex-result, .tsl-ex-why, .tsl-ex-step-body { line-height: 1.55; }
+  .tsl-ex-statement p, .tsl-ex-result p, .tsl-ex-why p, .tsl-ex-step-body p { margin: 0; }
+  .tsl-ex-statement {
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.16);
+  }
+  .tsl-ex-result {
+    background: var(--brand-soft);
+    border: 1px solid var(--brand);
+  }
+  .tsl-ex-why {
+    background: rgba(255,255,255,0.04);
+    border-left: 4px solid var(--brand-light);
+    border-radius: 6px 14px 14px 6px;
+  }
+  .tsl-ex-steps {
+    list-style: none;
+    margin: 0 0 12px;
+    padding: 0;
+    display: grid;
+    gap: 10px;
+  }
+  .tsl-ex-steps li { margin: 0; }
+  .tsl-ex-step {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 14px;
+    padding: 12px 16px;
+  }
+  .tsl-ex-num {
+    flex: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    font-family: 'Unbounded', 'Inter', sans-serif;
+    font-weight: 800;
+    font-size: 1.1rem;
+    color: var(--brand-light);
+    background: var(--brand-glow);
+    border: 1px solid var(--brand);
+  }
+  .tsl-ex-step-body { flex: 1; min-width: 0; }
+
   /* ── Slide de vídeo ── */
   .tsl-video-frame {
     position: relative;

--- a/apps/web/src/components/theory/TheorySlides.tsx
+++ b/apps/web/src/components/theory/TheorySlides.tsx
@@ -290,9 +290,12 @@ export const TSLIDES_CSS = `
     z-index: 1000;
     display: flex;
     flex-direction: column;
+    /* Fondo "modo estadio" del design system: focos + dot-grid LED + navy */
     background:
-      radial-gradient(120% 80% at 50% -10%, var(--brand-glow), transparent 60%),
-      linear-gradient(180deg, #080e1a 0%, #0d1b2a 60%, #152233 100%);
+      radial-gradient(120% 80% at 50% -10%, var(--brand-soft), transparent 55%),
+      radial-gradient(80% 60% at 90% 110%, rgba(255, 210, 77, 0.08), transparent 60%),
+      radial-gradient(rgba(255,255,255,0.045) 1px, transparent 1.4px) 0 0 / 15px 15px,
+      linear-gradient(180deg, var(--navy-950, #080e1a) 0%, var(--navy-800, #0d1b2a) 100%);
     color: #fff;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     -webkit-font-smoothing: antialiased;
@@ -306,7 +309,7 @@ export const TSLIDES_CSS = `
   .tslides-progress > span {
     display: block;
     height: 100%;
-    background: linear-gradient(90deg, var(--brand), var(--brand-light));
+    background: var(--gradient-signature, linear-gradient(90deg, var(--brand), var(--brand-light)));
     border-radius: 0 4px 4px 0;
     transition: width 0.35s cubic-bezier(0.2,0.8,0.25,1);
   }
@@ -346,9 +349,13 @@ export const TSLIDES_CSS = `
   }
   .tslides-actions button:hover { background: var(--brand-glow); transform: translateY(-1px); }
   .tslides-counter {
+    /* Marcador del estadio: display + ámbar LED */
+    font-family: var(--font-display, 'Inter');
     font-variant-numeric: tabular-nums;
-    font-size: 0.85rem;
-    color: rgba(255,255,255,0.65);
+    font-size: 1.1rem;
+    letter-spacing: 0.08em;
+    color: var(--amber-led, #ffd24d);
+    text-shadow: 0 0 14px rgba(255, 210, 77, 0.45);
     min-width: 54px;
     text-align: center;
   }
@@ -361,6 +368,17 @@ export const TSLIDES_CSS = `
     justify-content: center;
     overflow: hidden;
     padding: 8px 5vw;
+  }
+  /* Media cancha tenue al pie del escenario (textura del design system) */
+  .tslides-stage::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -2px;
+    height: 46%;
+    background: var(--court-lines) bottom center / min(640px, 80vw) auto no-repeat;
+    pointer-events: none;
   }
   .tslides-zone {
     position: absolute;
@@ -581,10 +599,11 @@ export const TSLIDES_CSS = `
     border: 1px solid var(--brand);
   }
   .tsl-ex-why {
-    background: rgba(255,255,255,0.04);
-    border-left: 4px solid var(--brand-light);
+    background: rgba(19, 175, 240, 0.07);
+    border-left: 4px solid var(--accent-cyan, #13aff0);
     border-radius: 6px 14px 14px 6px;
   }
+  .tsl-ex-why .tsl-ex-label { color: var(--accent-cyan-light, #46d4fe); }
   .tsl-ex-steps {
     list-style: none;
     margin: 0 0 12px;

--- a/apps/web/src/components/theory/theoryMarkdown.tsx
+++ b/apps/web/src/components/theory/theoryMarkdown.tsx
@@ -10,13 +10,14 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
 
-type CalloutKind = 'tip' | 'remember' | 'warning' | 'question' | 'default';
+type CalloutKind = 'tip' | 'remember' | 'warning' | 'question' | 'fence' | 'default';
 
 const CALLOUT_RULES: Array<{ test: RegExp; kind: CalloutKind }> = [
   { test: /^\s*💡/, kind: 'tip' },
   { test: /^\s*🧠/, kind: 'remember' },
   { test: /^\s*⚠️|^\s*⚠/, kind: 'warning' },
   { test: /^\s*❓/, kind: 'question' },
+  { test: /^\s*🚧/, kind: 'fence' },
 ];
 
 function flattenText(node: ReactNode): string {
@@ -84,6 +85,8 @@ export const THEORY_CALLOUT_CSS = `
   .theory-callout-warning::before   { content: '⚠️'; }
   .theory-callout-question  { background: rgba(20,184,166,0.10); border-left-color: #14b8a6; }
   .theory-callout-question::before  { content: '❓'; }
+  .theory-callout-fence     { background: var(--brand-soft); border-left-color: var(--brand); }
+  .theory-callout-fence::before     { content: '🚧'; }
   .theory-callout-default   {
     background: var(--color-bg);
     border-left-color: var(--color-border);

--- a/apps/web/src/utils/theorySlides.test.ts
+++ b/apps/web/src/utils/theorySlides.test.ts
@@ -193,6 +193,16 @@ describe('buildSlides — estructura Winston', () => {
     expect(slides.find((s) => s.kind === 'content')!.variant).toBe('takeaways');
   });
 
+  it('la promesa no se pagina aunque supere el presupuesto de caracteres', () => {
+    const body = `frase de arranque\n\n- **Sabrás** ${'x'.repeat(300)}\n- **Sabrás** ${'y'.repeat(300)}\n\n> 💡 **Tip:** entiende la regla única.`;
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'INTRO', heading: 'Qué vas a conseguir', body })]),
+    );
+    const content = slides.filter((s) => s.kind === 'content');
+    expect(content).toHaveLength(1);
+    expect(content[0].blocks).toHaveLength(3);
+  });
+
   it('compat: una INTRO clásica no lleva variante', () => {
     const slides = buildSlides(
       moduleWith([lesson({ kind: 'INTRO', heading: 'Introducción', body: 'hola' })]),

--- a/apps/web/src/utils/theorySlides.test.ts
+++ b/apps/web/src/utils/theorySlides.test.ts
@@ -4,7 +4,9 @@ import {
   buildSlides,
   fragmentCount,
   paginateBlocks,
+  parseExample,
   resolveVideoCandidates,
+  splitExampleChunks,
   splitMarkdownBlocks,
 } from './theorySlides';
 
@@ -128,7 +130,106 @@ describe('buildSlides', () => {
   });
 });
 
+const EXAMPLE_MD = `### 💪 Ejemplo 1: descuento de rebajas
+**Enunciado:** Unas zapatillas de 60 € tienen un 25 % de descuento. ¿Cuánto pagas?
+1. Calcula el 25 % de 60: $60 \\cdot 0{,}25 = 15$.
+2. Resta el descuento al precio: $60 - 15 = 45$.
+3. Comprueba que el resultado es menor que el original.
+**Resultado:** Pagas 45 €.
+**Por qué funciona:** El porcentaje es una fracción del total, así que multiplicar y restar equivale a quedarte con el 75 %.`;
+
+describe('splitExampleChunks', () => {
+  it('separa por encabezados ### conservando el preámbulo', () => {
+    const chunks = splitExampleChunks(`intro suelta\n\n### 💪 Ejemplo 1: a\ncuerpo\n### 💪 Ejemplo 2: b\ncuerpo`);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toBe('intro suelta');
+    expect(chunks[1].startsWith('### 💪 Ejemplo 1')).toBe(true);
+  });
+});
+
+describe('parseExample', () => {
+  it('parsea título, enunciado, pasos, resultado y porqué', () => {
+    const parsed = parseExample(EXAMPLE_MD)!;
+    expect(parsed).not.toBeNull();
+    expect(parsed.title).toBe('💪 Ejemplo 1: descuento de rebajas');
+    expect(parsed.statement).toContain('zapatillas');
+    expect(parsed.steps).toHaveLength(3);
+    expect(parsed.steps[1]).toContain('Resta el descuento');
+    expect(parsed.result).toBe('Pagas 45 €.');
+    expect(parsed.why).toContain('porcentaje');
+  });
+
+  it('une líneas de continuación al bloque activo', () => {
+    const md = `### Ejemplo\n**Enunciado:** primera línea\nsegunda línea\n1. paso uno\ncontinuación del paso\n2. paso dos\n**Resultado:** listo`;
+    const parsed = parseExample(md)!;
+    expect(parsed.statement).toBe('primera línea segunda línea');
+    expect(parsed.steps[0]).toBe('paso uno continuación del paso');
+  });
+
+  it('devuelve null sin encabezado ###', () => {
+    expect(parseExample('**Enunciado:** x\n1. a\n2. b\n**Resultado:** y')).toBeNull();
+  });
+
+  it('devuelve null con menos de 2 pasos o sin resultado (degrada a contenido)', () => {
+    expect(parseExample('### E\n**Enunciado:** x\n1. solo un paso\n**Resultado:** y')).toBeNull();
+    expect(parseExample('### E\n**Enunciado:** x\n1. a\n2. b')).toBeNull();
+  });
+});
+
+describe('buildSlides — estructura Winston', () => {
+  it('marca la INTRO "Qué vas a conseguir" como variante objectives con icono 🎯', () => {
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'INTRO', heading: 'Qué vas a conseguir', body: '- **Sabrás** x' })]),
+    );
+    const intro = slides.find((s) => s.kind === 'content')!;
+    expect(intro.variant).toBe('objectives');
+    expect(intro.icon).toBe('🎯');
+  });
+
+  it('marca "Lo que te llevas" como variante takeaways', () => {
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'CONTENT', heading: 'Lo que te llevas', body: '- **Ya sabes** x' })]),
+    );
+    expect(slides.find((s) => s.kind === 'content')!.variant).toBe('takeaways');
+  });
+
+  it('compat: una INTRO clásica no lleva variante', () => {
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'INTRO', heading: 'Introducción', body: 'hola' })]),
+    );
+    expect(slides.find((s) => s.kind === 'content')!.variant).toBeUndefined();
+  });
+
+  it('convierte una lección EXAMPLE estructurada en slides example con pasos', () => {
+    const body = `${EXAMPLE_MD}\n${EXAMPLE_MD.replace('Ejemplo 1', 'Ejemplo 2')}`;
+    const slides = buildSlides(moduleWith([lesson({ kind: 'EXAMPLE', heading: 'Ejemplos', body })]));
+    const examples = slides.filter((s) => s.kind === 'example');
+    expect(examples).toHaveLength(2);
+    expect(examples[0].steps).toHaveLength(3);
+    expect(examples[0].statement).toContain('zapatillas');
+    expect(examples[1].heading).toContain('Ejemplo 2');
+  });
+
+  it('compat: una lección EXAMPLE sin estructura degrada a slides de contenido', () => {
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'EXAMPLE', heading: 'Ejemplos', body: 'log(100) = 2 porque 10^2 = 100.' })]),
+    );
+    expect(slides.filter((s) => s.kind === 'example')).toHaveLength(0);
+    const content = slides.filter((s) => s.kind === 'content');
+    expect(content).toHaveLength(1);
+    expect(content[0].blocks).toEqual(['log(100) = 2 porque 10^2 = 100.']);
+  });
+});
+
 describe('fragmentCount', () => {
+  it('en slides example cuenta enunciado + pasos + resultado + porqué', () => {
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'EXAMPLE', heading: 'Ejemplos', body: EXAMPLE_MD })]),
+    );
+    const ex = slides.find((s) => s.kind === 'example')!;
+    expect(fragmentCount(ex)).toBe(1 + 3 + 1 + 1);
+  });
+
   it('cuenta los bloques de una slide de contenido', () => {
     const slides = buildSlides(moduleWith([lesson({ kind: 'CONTENT', body: 'uno\n\ndos' })]));
     const content = slides.find((s) => s.kind === 'content')!;

--- a/apps/web/src/utils/theorySlides.ts
+++ b/apps/web/src/utils/theorySlides.ts
@@ -281,7 +281,10 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
 
     const variant = contentVariant(lesson);
     const blocks = splitMarkdownBlocks(lesson.body ?? '');
-    const pages = blocks.length > 0 ? paginateBlocks(blocks) : [['']];
+    // La promesa y el cierre son checklists cortas y autocontenidas: siempre en
+    // una sola slide (paginarlas deja el callout huérfano en una slide "cont.").
+    const pages =
+      blocks.length === 0 ? [['']] : variant ? [blocks] : paginateBlocks(blocks);
     pages.forEach((pageBlocks, i) => {
       slides.push({
         id: `${lesson.id}-${i}`,

--- a/apps/web/src/utils/theorySlides.ts
+++ b/apps/web/src/utils/theorySlides.ts
@@ -6,6 +6,14 @@
 //   sobrecarguen. Cada bloque es un "fragmento" que se revela progresivamente.
 // - Las lecciones VIDEO se convierten en una slide de vídeo.
 // - Se añade una portada al principio y una slide de cierre al final.
+//
+// Estructura Winston (temarios nuevos, con fallback para los antiguos):
+// - La lección INTRO "Qué vas a conseguir" (promesa) y la CONTENT "Lo que te
+//   llevas" (cierre) se marcan con `variant` para renderizarse como checklist.
+// - Las lecciones EXAMPLE con la estructura pactada con la IA (### 💪 Ejemplo N +
+//   Enunciado + pasos numerados + Resultado + Por qué funciona) se convierten en
+//   slides `example` con pasos estructurados; si un bloque no parsea, degrada a
+//   slide de contenido normal.
 
 import type {
   TheoryLesson,
@@ -14,7 +22,10 @@ import type {
   TheoryVideoCandidate,
 } from '@vkbacademy/shared';
 
-export type SlideKind = 'cover' | 'content' | 'video' | 'closing';
+export type SlideKind = 'cover' | 'content' | 'video' | 'closing' | 'example';
+
+/** Variante visual de una slide de contenido (checklist Winston). */
+export type ContentVariant = 'objectives' | 'takeaways';
 
 export interface Slide {
   id: string;
@@ -34,6 +45,13 @@ export interface Slide {
   blocks?: string[];
   /** true si es continuación de una lección dividida en varias slides. */
   continued?: boolean;
+  /** Promesa inicial u "objetivos" / cierre "lo que te llevas". */
+  variant?: ContentVariant;
+  // example (ejercicio resuelto paso a paso)
+  statement?: string;
+  steps?: string[];
+  result?: string;
+  why?: string;
   // video
   candidates?: TheoryVideoCandidate[];
 }
@@ -86,6 +104,92 @@ export function paginateBlocks(blocks: string[], budget = MAX_SLIDE_CHARS): stri
   return pages;
 }
 
+const OBJECTIVES_RE = /qu[eé] vas a conseguir/i;
+const TAKEAWAYS_RE = /lo que te llevas/i;
+
+/**
+ * Detecta si una lección es la promesa inicial o el cierre Winston por su
+ * heading. Los temarios antiguos ("Introducción", …) no matchean y se
+ * renderizan como contenido normal.
+ */
+export function contentVariant(lesson: TheoryLesson): ContentVariant | undefined {
+  if (lesson.kind === 'INTRO' && OBJECTIVES_RE.test(lesson.heading)) return 'objectives';
+  if (TAKEAWAYS_RE.test(lesson.heading)) return 'takeaways';
+  return undefined;
+}
+
+export interface ParsedExample {
+  title: string;
+  statement: string;
+  steps: string[];
+  result: string;
+  why: string;
+}
+
+/** Divide el body de una lección EXAMPLE en trozos, uno por encabezado "###". */
+export function splitExampleChunks(md: string): string[] {
+  return md
+    .replace(/\r\n/g, '\n')
+    .split(/\n(?=###\s)/)
+    .map((chunk) => chunk.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Parsea un ejemplo con la estructura pactada con la IA (### título +
+ * **Enunciado:** + pasos numerados + **Resultado:** + **Por qué funciona:**).
+ * Devuelve null si el trozo no cumple lo mínimo (título, enunciado, ≥2 pasos y
+ * resultado) para que el llamador degrade a slide de contenido normal.
+ */
+export function parseExample(chunk: string): ParsedExample | null {
+  const lines = chunk.replace(/\r\n/g, '\n').split('\n');
+  const headingMatch = lines[0]?.match(/^###\s+(.+)$/);
+  if (!headingMatch) return null;
+
+  const title = headingMatch[1].trim();
+  let statement = '';
+  const steps: string[] = [];
+  let result = '';
+  let why = '';
+  let target: 'statement' | 'steps' | 'result' | 'why' | null = null;
+
+  const append = (acc: string, text: string) => (acc ? `${acc} ${text}` : text);
+
+  for (const raw of lines.slice(1)) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    const labeled = line.match(/^\*\*(Enunciado|Resultado|Por qué funciona)[:.]?\*\*[:.]?\s*(.*)$/i);
+    if (labeled) {
+      const label = labeled[1].toLowerCase();
+      target = label.startsWith('enunciado') ? 'statement' : label.startsWith('resultado') ? 'result' : 'why';
+      const rest = labeled[2].trim();
+      if (rest) {
+        if (target === 'statement') statement = append(statement, rest);
+        else if (target === 'result') result = append(result, rest);
+        else why = append(why, rest);
+      }
+      continue;
+    }
+
+    const stepMatch = line.match(/^\d+[.)]\s+(.*)$/);
+    if (stepMatch) {
+      steps.push(stepMatch[1].trim());
+      target = 'steps';
+      continue;
+    }
+
+    // Línea suelta: continuación del bloque activo (párrafos multilínea).
+    if (target === 'steps' && steps.length > 0) steps[steps.length - 1] = append(steps[steps.length - 1], line);
+    else if (target === 'statement') statement = append(statement, line);
+    else if (target === 'result') result = append(result, line);
+    else if (target === 'why') why = append(why, line);
+  }
+
+  if (!statement || steps.length < 2 || !result) return null;
+  return { title, statement, steps, result, why };
+}
+
 /**
  * Resuelve los candidatos de vídeo de una lección. Compat: lecciones antiguas
  * solo tienen youtubeId (sin lista de candidatos).
@@ -132,16 +236,61 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
       continue;
     }
 
+    if (lesson.kind === 'EXAMPLE') {
+      let emitted = 0;
+      for (const [i, chunk] of splitExampleChunks(lesson.body ?? '').entries()) {
+        const parsed = parseExample(chunk);
+        if (parsed) {
+          slides.push({
+            id: `${lesson.id}-ex${i}`,
+            kind: 'example',
+            heading: parsed.title,
+            statement: parsed.statement,
+            steps: parsed.steps,
+            result: parsed.result,
+            why: parsed.why,
+          });
+          emitted++;
+          continue;
+        }
+        // Trozo sin estructura de ejemplo (preámbulo o temario antiguo): paginar como contenido.
+        const pages = paginateBlocks(splitMarkdownBlocks(chunk));
+        pages.forEach((pageBlocks, j) => {
+          slides.push({
+            id: `${lesson.id}-${i}-${j}`,
+            kind: 'content',
+            icon: KIND_ICON.EXAMPLE,
+            heading: lesson.heading,
+            blocks: pageBlocks,
+            continued: emitted > 0 || j > 0,
+          });
+          emitted++;
+        });
+      }
+      if (emitted === 0) {
+        slides.push({
+          id: `${lesson.id}-0`,
+          kind: 'content',
+          icon: KIND_ICON.EXAMPLE,
+          heading: lesson.heading,
+          blocks: [''],
+        });
+      }
+      continue;
+    }
+
+    const variant = contentVariant(lesson);
     const blocks = splitMarkdownBlocks(lesson.body ?? '');
     const pages = blocks.length > 0 ? paginateBlocks(blocks) : [['']];
     pages.forEach((pageBlocks, i) => {
       slides.push({
         id: `${lesson.id}-${i}`,
         kind: 'content',
-        icon: KIND_ICON[lesson.kind],
+        icon: variant === 'objectives' ? '🎯' : variant === 'takeaways' ? '🏆' : KIND_ICON[lesson.kind],
         heading: lesson.heading,
         blocks: pageBlocks,
         continued: i > 0,
+        variant,
       });
     });
   }
@@ -163,7 +312,11 @@ function slideLabel(slide: Omit<Slide, 'index' | 'label'>, i: number): string {
   return slide.continued ? `${base} (cont.)` : base;
 }
 
-/** Nº de fragmentos revelables de una slide (los bloques de contenido). */
+/** Nº de fragmentos revelables de una slide (bloques o piezas del ejemplo). */
 export function fragmentCount(slide: Slide): number {
+  if (slide.kind === 'example') {
+    // enunciado + pasos + resultado + porqué (si existe)
+    return 1 + (slide.steps?.length ?? 0) + 1 + (slide.why ? 1 : 0);
+  }
   return slide.kind === 'content' ? (slide.blocks?.length ?? 0) : 0;
 }


### PR DESCRIPTION
## Qué cambia

Aplica la metodología Winston (MIT "How to Speak") a la generación de temarios de teoría y rediseña el deck de slides para alinearlo con el design system Híbrido Estadio.

### Contenido (apps/api, prompt de generación)
- **Promesa de empoderamiento** (W-OPEN-1): la primera lección pasa a ser "Qué vas a conseguir" con 3-4 items "Sabrás X: te servirá para Y".
- **Cycling** (W-TEACH-1): cada concepto explicado 3 veces (definición, analogía, mini-ejemplo).
- **Fencing** (W-TEACH-2): callout obligatorio 🚧 "Esto SÍ / esto NO" por lección CONTENT.
- **Puntuación verbal + pregunta retórica** por lección (W-TEACH-3/4).
- **Ejemplos paso a paso**: mínimo 3, con estructura fija (enunciado → pasos numerados → resultado → por qué funciona).
- **Cierre de contribuciones** (W-CLOSE-1): "Lo que te llevas", espejo de la promesa, sin despedidas.
- **Voz anti-IA** (humanizer): tono de entrenador que tutea, AIismos vetados ("En resumen", "juega un papel crucial", guiones largos...).
- maxTokens 4000 → 6000. Warning no bloqueante si la IA no respeta la estructura.

### Diseño (apps/web, deck)
- Slide de objetivos y cierre como **checklist visual** (variantes `objectives`/`takeaways`, sin paginar).
- Ejemplos como **slides propias** con tarjetas de pasos y número grande; parseo con fallback a slide normal si la IA no cumple la estructura (compat con temarios antiguos).
- **Estética estadio**: dot-grid LED, líneas de cancha, contador tipo marcador en ámbar LED, progreso con gradiente signature, acento cyan en "Por qué funciona". Todo con tokens, sin colores hardcodeados.
- Nuevo callout 🚧 (fence) en `theoryMarkdown`.
- Export PDF intacto: el revelado sigue sobre `.tslides-frag` y no hay `background-clip:text` nuevo.

## Verificación
- API: 511/511 tests (suite completa). Web: vitest 28/28 en `theorySlides` (el único rojo es `email-validation.spec.ts`, preexistente y ajeno a este diff). `tsc --noEmit` limpio.
- QA visual con Vite + mock: portada, objetivos, ejemplo paso a paso y cierre verificados en Chrome.
- El contenido generado real se validará en PRE tras el merge (no hay BD local).
