### PR TITLE
feat(study): landing secuencial de la unidad y PDF de apuntes imprimible

### DIFF
--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -228,12 +228,13 @@ Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, si
     { "kind": "CONTENT", "heading": "título de la sección de desarrollo", "body": "desarrollo (ver ESTRUCTURA)" },
     { "kind": "EXAMPLE", "heading": "Ejemplos paso a paso", "body": "mínimo 3 ejemplos resueltos (ver ESTRUCTURA)" },
     { "kind": "VIDEO", "heading": "Vídeo recomendado", "ytQuery": "consulta optimizada para buscar el mejor vídeo en YouTube sobre este tema" },
+    { "kind": "CONTENT", "heading": "Chuleta de repaso", "body": "resumen compacto de fórmulas y reglas clave (ver ESTRUCTURA)" },
     { "kind": "CONTENT", "heading": "Lo que te llevas", "body": "cierre espejo de la promesa (ver ESTRUCTURA)" }
   ]
 }
 
 ESTRUCTURA — metodología Winston de enseñanza, OBLIGATORIA:
-- Entre 5 y 8 lecciones, en este orden: 1 INTRO "Qué vas a conseguir" (SIEMPRE la primera) + 1-3 CONTENT de desarrollo + 1 EXAMPLE + 1 VIDEO + 1 CONTENT "Lo que te llevas" (SIEMPRE la última).
+- Entre 6 y 9 lecciones, en este orden: 1 INTRO "Qué vas a conseguir" (SIEMPRE la primera) + 1-3 CONTENT de desarrollo + 1 EXAMPLE + 1 VIDEO + 1 CONTENT "Chuleta de repaso" + 1 CONTENT "Lo que te llevas" (SIEMPRE la última).
 
 - INTRO "Qué vas a conseguir" — promesa de empoderamiento: qué sabrá HACER el alumno al final que no sabe ahora, y para qué le sirve. Formato: 1 frase corta que enganche + lista de 3-4 items con el formato exacto "- **Sabrás** [habilidad concreta]: te servirá para [uso real: el examen, el deporte o la vida diaria]". Sin definiciones todavía, sin índice.
 
@@ -253,6 +254,8 @@ ESTRUCTURA — metodología Winston de enseñanza, OBLIGATORIA:
 (mínimo 3 pasos por ejemplo; añade más si el problema lo pide)
 **Resultado:** [solución final]
 **Por qué funciona:** [1-2 frases conectando el procedimiento con la teoría]
+
+- CONTENT "Chuleta de repaso" — resumen de estudio antes del cierre: TODAS las fórmulas, reglas y definiciones clave del tema en formato compacto, pensado para releerse 5 minutos antes del examen. Lista de items cortos "- **[nombre]**: [fórmula o regla en 1 línea]" (con LaTeX si aplica) + exactamente 1 callout 🧠 con lo más importante de todo el tema. Sin párrafos largos ni contenido nuevo: solo condensa lo ya explicado.
 
 - CONTENT "Lo que te llevas" — cierre de contribuciones, espejo de la promesa inicial: lista de 3-4 items "- **Ya sabes** [la misma habilidad prometida al inicio]" + 1 frase final que empuje al siguiente paso (practicar con ejercicios o hacer el test). PROHIBIDO cerrar con "gracias", "espero que" o despedidas.
 

--- a/apps/web/src/components/theory/SlideView.tsx
+++ b/apps/web/src/components/theory/SlideView.tsx
@@ -241,8 +241,8 @@ function ClosingSlide() {
       </span>
       <h2 className="tsl-closing-title">¡Bien jugado!</h2>
       <p className="tsl-closing-sub">
-        Has terminado el temario. Descárgalo en PDF o envíatelo a WhatsApp para repasarlo cuando
-        quieras.
+        Apuntes completados. Ahora te toca: practica con los ejercicios y remata con el examen.
+        Descarga el PDF si quieres repasar sobre papel.
       </p>
     </div>
   );

--- a/apps/web/src/components/theory/SlideView.tsx
+++ b/apps/web/src/components/theory/SlideView.tsx
@@ -56,10 +56,8 @@ function Frag({
 function CoverSlide({ slide }: { slide: Slide }) {
   return (
     <div className="tsl-cover">
-      <span className="tsl-ball" aria-hidden>
-        🏀
-      </span>
-      <span className="tsl-cover-eyebrow">{slide.topic}</span>
+      <img className="tsl-logo" src="/brand/vkb-logo.png" alt="Vallekas Basket" />
+      <span className="tsl-cover-eyebrow">VKB Academy · {slide.topic}</span>
       <h1 className="tsl-cover-title">{slide.coverTitle}</h1>
       {slide.coverSubtitle && <p className="tsl-cover-sub">{slide.coverSubtitle}</p>}
     </div>
@@ -79,9 +77,6 @@ function ContentSlide({
   return (
     <div className={`tsl-content${slide.variant ? ` tsl-content--${slide.variant}` : ''}`}>
       <h2 className="tsl-heading">
-        <span className="tsl-icon" aria-hidden>
-          {slide.icon}
-        </span>
         {slide.heading}
         {slide.continued && <span className="tsl-cont">cont.</span>}
       </h2>
@@ -167,12 +162,7 @@ function VideoSlide({ slide, forPdf }: { slide: Slide; forPdf: boolean }) {
   if (candidates.length === 0) {
     return (
       <div className="tsl-content">
-        <h2 className="tsl-heading">
-          <span className="tsl-icon" aria-hidden>
-            ▶️
-          </span>
-          {slide.heading}
-        </h2>
+        <h2 className="tsl-heading">{slide.heading}</h2>
         <p className="tsl-muted">No se encontró un vídeo adecuado para este tema.</p>
       </div>
     );
@@ -182,12 +172,7 @@ function VideoSlide({ slide, forPdf }: { slide: Slide; forPdf: boolean }) {
 
   return (
     <div className="tsl-video">
-      <h2 className="tsl-heading">
-        <span className="tsl-icon" aria-hidden>
-          ▶️
-        </span>
-        {slide.heading}
-      </h2>
+      <h2 className="tsl-heading">{slide.heading}</h2>
 
       {forPdf ? (
         <div className="tsl-video-card">
@@ -236,9 +221,7 @@ function VideoSlide({ slide, forPdf }: { slide: Slide; forPdf: boolean }) {
 function ClosingSlide() {
   return (
     <div className="tsl-closing">
-      <span className="tsl-ball" aria-hidden>
-        🏀
-      </span>
+      <img className="tsl-logo" src="/brand/vkb-logo.png" alt="Vallekas Basket" />
       <h2 className="tsl-closing-title">¡Bien jugado!</h2>
       <p className="tsl-closing-sub">
         Apuntes completados. Ahora te toca: practica con los ejercicios y remata con el examen.

--- a/apps/web/src/components/theory/TheorySlides.tsx
+++ b/apps/web/src/components/theory/TheorySlides.tsx
@@ -428,14 +428,15 @@ export const TSLIDES_CSS = `
     align-items: center;
     gap: 14px;
   }
-  .tsl-ball {
-    font-size: clamp(48px, 9vw, 96px);
-    animation: tsl-bounce 2.4s ease-in-out infinite;
+  .tsl-logo {
+    width: clamp(110px, 18vw, 170px);
+    height: auto;
     filter: drop-shadow(0 14px 24px var(--brand-glow));
+    animation: tsl-float 3.2s ease-in-out infinite;
   }
-  @keyframes tsl-bounce {
-    0%, 100% { transform: translateY(0) rotate(-6deg); }
-    50% { transform: translateY(-16px) rotate(6deg); }
+  @keyframes tsl-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-10px); }
   }
   .tsl-cover-eyebrow {
     text-transform: uppercase;
@@ -488,7 +489,6 @@ export const TSLIDES_CSS = `
     gap: 12px;
     flex-wrap: wrap;
   }
-  .tsl-icon { font-size: 1.1em; }
   .tsl-cont {
     font-family: 'Inter', sans-serif;
     font-size: 0.6em;
@@ -826,7 +826,7 @@ export const TSLIDES_CSS = `
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .tslides-slide, .tsl-ball, .tslides-frag, .tslides-grid { animation: none; transition: none; }
+    .tslides-slide, .tsl-logo, .tslides-frag, .tslides-grid { animation: none; transition: none; }
     .tslides-frag { opacity: 1; transform: none; }
   }
 `;

--- a/apps/web/src/components/theory/TheoryView.tsx
+++ b/apps/web/src/components/theory/TheoryView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type {
   TheoryLesson,
   TheoryLessonKind,
@@ -7,6 +7,7 @@ import type {
 } from '@vkbacademy/shared';
 import { TheoryMarkdown, THEORY_CALLOUT_CSS } from './theoryMarkdown';
 import TheorySlides from './TheorySlides';
+import { buildSlides } from '../../utils/theorySlides';
 import { downloadTheoryPdf, shareTheoryPdf } from '../../utils/theoryPdf';
 
 const KIND_ICON: Record<TheoryLessonKind, string> = {
@@ -18,7 +19,10 @@ const KIND_ICON: Record<TheoryLessonKind, string> = {
 
 export default function TheoryView({ module }: { module: TheoryModuleWithLessons }) {
   const [showSlides, setShowSlides] = useState(false);
+  // La presentación es la fuente; los apuntes en texto quedan colapsados por defecto.
+  const [showArticle, setShowArticle] = useState(false);
   const [pdfBusy, setPdfBusy] = useState<'download' | 'share' | null>(null);
+  const slideCount = useMemo(() => buildSlides(module).length, [module]);
 
   async function handleDownload() {
     if (pdfBusy) return;
@@ -49,17 +53,31 @@ export default function TheoryView({ module }: { module: TheoryModuleWithLessons
       <style>
         {ANIMATIONS}
         {THEORY_CALLOUT_CSS}
+        {HERO_CSS}
       </style>
 
-      <div style={s.actions}>
+      <section className="theory-hero">
+        <span className="theory-hero-play" aria-hidden>
+          ▶
+        </span>
+        <div className="theory-hero-copy">
+          <h2 className="theory-hero-title">Presentación del temario</h2>
+          <p className="theory-hero-sub">
+            Empieza aquí: recorre los apuntes diapositiva a diapositiva, con ejemplos resueltos
+            paso a paso.
+          </p>
+          <span className="theory-hero-meta">{slideCount} diapositivas</span>
+        </div>
         <button
           type="button"
-          className="btn btn-primary"
+          className="btn btn-primary theory-hero-cta"
           onClick={() => setShowSlides(true)}
-          style={s.presentBtn}
         >
-          ▶ Presentación
+          ▶ Empezar
         </button>
+      </section>
+
+      <div style={s.actions}>
         <button
           type="button"
           onClick={handleDownload}
@@ -76,15 +94,25 @@ export default function TheoryView({ module }: { module: TheoryModuleWithLessons
         >
           {pdfBusy === 'share' ? '⏳ Generando…' : '📲 Enviar por WhatsApp'}
         </button>
+        <button
+          type="button"
+          onClick={() => setShowArticle((v) => !v)}
+          style={s.secondaryBtn}
+          aria-expanded={showArticle}
+        >
+          {showArticle ? '▴ Ocultar apuntes en texto' : '▾ Ver apuntes en texto'}
+        </button>
       </div>
 
       {showSlides && <TheorySlides module={module} onClose={() => setShowSlides(false)} />}
 
-      <article style={s.article}>
-        {module.lessons.map((lesson, idx) => (
-          <LessonSection key={lesson.id} lesson={lesson} index={idx} />
-        ))}
-      </article>
+      {showArticle && (
+        <article style={s.article}>
+          {module.lessons.map((lesson, idx) => (
+            <LessonSection key={lesson.id} lesson={lesson} index={idx} />
+          ))}
+        </article>
+      )}
     </div>
   );
 }
@@ -117,6 +145,46 @@ const ANIMATIONS = `
   @media (prefers-reduced-motion: reduce) {
     .theory-section { animation: none; }
   }
+`;
+
+// CTA protagonista de la presentación (zona dark del design system estadio).
+const HERO_CSS = `
+  .theory-hero {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    flex-wrap: wrap;
+    padding: 24px 26px;
+    border-radius: 16px;
+    color: #fff;
+    background:
+      radial-gradient(120% 90% at 50% -20%, var(--brand-soft), transparent 60%),
+      radial-gradient(rgba(255,255,255,0.05) 1px, transparent 1.4px) 0 0 / 14px 14px,
+      linear-gradient(180deg, var(--navy-950, #080e1a) 0%, var(--navy-800, #0d1b2a) 100%);
+    border: 1px solid rgba(255,255,255,0.08);
+  }
+  .theory-hero-play {
+    flex: none;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 1.6rem;
+    color: #fff;
+    background: var(--gradient-signature, var(--brand));
+    box-shadow: 0 0 24px var(--brand-glow);
+  }
+  .theory-hero-copy { flex: 1; min-width: 220px; display: flex; flex-direction: column; gap: 6px; }
+  .theory-hero-title { margin: 0; font-size: 1.15rem; font-weight: 800; }
+  .theory-hero-sub { margin: 0; font-size: 0.9rem; color: rgba(255,255,255,0.75); line-height: 1.5; }
+  .theory-hero-meta {
+    font-family: var(--font-display, inherit);
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    color: var(--amber-led, #ffd24d);
+  }
+  .theory-hero-cta { padding: 14px 28px; font-size: 1rem; font-weight: 800; flex: none; }
 `;
 
 function VideoLesson({ lesson }: { lesson: TheoryLesson }) {
@@ -195,9 +263,8 @@ function formatDuration(seconds: number): string {
 }
 
 const s: Record<string, React.CSSProperties> = {
-  wrap: { display: 'flex', flexDirection: 'column', gap: 24 },
+  wrap: { display: 'flex', flexDirection: 'column', gap: 20 },
   actions: { display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'center' },
-  presentBtn: { padding: '10px 18px', fontSize: '0.9rem', fontWeight: 700 },
   secondaryBtn: {
     background: 'var(--color-surface)',
     border: '1px solid var(--color-border)',

--- a/apps/web/src/components/theory/TheoryView.tsx
+++ b/apps/web/src/components/theory/TheoryView.tsx
@@ -1,23 +1,21 @@
 import { useMemo, useState } from 'react';
 import type {
   TheoryLesson,
-  TheoryLessonKind,
   TheoryModuleWithLessons,
   TheoryVideoCandidate,
 } from '@vkbacademy/shared';
 import { TheoryMarkdown, THEORY_CALLOUT_CSS } from './theoryMarkdown';
 import TheorySlides from './TheorySlides';
-import { buildSlides } from '../../utils/theorySlides';
+import { buildSlides, stripLeadingEmoji } from '../../utils/theorySlides';
 import { downloadTheoryPdf, shareTheoryPdf } from '../../utils/theoryPdf';
 
-const KIND_ICON: Record<TheoryLessonKind, string> = {
-  INTRO: '🧭',
-  CONTENT: '📚',
-  EXAMPLE: '💡',
-  VIDEO: '▶️',
-};
+interface TheoryViewProps {
+  module: TheoryModuleWithLessons;
+  /** Título del curso: cabecera y nombre de fichero del PDF. */
+  courseTitle: string;
+}
 
-export default function TheoryView({ module }: { module: TheoryModuleWithLessons }) {
+export default function TheoryView({ module, courseTitle }: TheoryViewProps) {
   const [showSlides, setShowSlides] = useState(false);
   // La presentación es la fuente; los apuntes en texto quedan colapsados por defecto.
   const [showArticle, setShowArticle] = useState(false);
@@ -28,7 +26,7 @@ export default function TheoryView({ module }: { module: TheoryModuleWithLessons
     if (pdfBusy) return;
     setPdfBusy('download');
     try {
-      await downloadTheoryPdf(module);
+      await downloadTheoryPdf(module, courseTitle);
     } catch {
       window.alert('No se pudo generar el PDF. Inténtalo de nuevo.');
     } finally {
@@ -40,7 +38,7 @@ export default function TheoryView({ module }: { module: TheoryModuleWithLessons
     if (pdfBusy) return;
     setPdfBusy('share');
     try {
-      await shareTheoryPdf(module);
+      await shareTheoryPdf(module, courseTitle);
     } catch {
       window.alert('No se pudo compartir el PDF. Inténtalo de nuevo.');
     } finally {
@@ -120,9 +118,7 @@ export default function TheoryView({ module }: { module: TheoryModuleWithLessons
 function LessonSection({ lesson, index }: { lesson: TheoryLesson; index: number }) {
   return (
     <section className="theory-section" style={{ ...s.section, animationDelay: `${index * 90}ms` }}>
-      <h2 style={s.sectionTitle}>
-        <span aria-hidden>{KIND_ICON[lesson.kind]}</span> {lesson.heading}
-      </h2>
+      <h2 style={s.sectionTitle}>{stripLeadingEmoji(lesson.heading)}</h2>
       {lesson.kind === 'VIDEO' ? (
         <VideoLesson lesson={lesson} />
       ) : (

--- a/apps/web/src/components/theory/theoryMarkdown.tsx
+++ b/apps/web/src/components/theory/theoryMarkdown.tsx
@@ -12,13 +12,28 @@ import 'katex/dist/katex.min.css';
 
 type CalloutKind = 'tip' | 'remember' | 'warning' | 'question' | 'fence' | 'default';
 
+// La IA marca cada callout con un emoji inicial; el emoji se elimina del render
+// (las slides van sin emoticonos) y el tipo se detecta por la etiqueta en texto.
+// Se conservan las reglas por emoji como respaldo (p. ej. emojis en medio de frase).
 const CALLOUT_RULES: Array<{ test: RegExp; kind: CalloutKind }> = [
   { test: /^\s*💡/, kind: 'tip' },
   { test: /^\s*🧠/, kind: 'remember' },
   { test: /^\s*⚠️|^\s*⚠/, kind: 'warning' },
   { test: /^\s*❓/, kind: 'question' },
   { test: /^\s*🚧/, kind: 'fence' },
+  { test: /^\s*Tip\b/i, kind: 'tip' },
+  { test: /^\s*Recuerda/i, kind: 'remember' },
+  { test: /^\s*Cuidado/i, kind: 'warning' },
+  { test: /^\s*Pregunta/i, kind: 'question' },
+  { test: /^\s*Esto S[IÍ]/i, kind: 'fence' },
 ];
+
+/** Quita los emojis con los que la IA abre los callouts (líneas "> 💡 ..."). */
+const CALLOUT_EMOJI_RE = /^(\s*>\s*)(?:[\p{Extended_Pictographic}\u{FE0F}\u{200D}]+\s*)/gmu;
+
+function stripCalloutEmojis(md: string): string {
+  return md.replace(CALLOUT_EMOJI_RE, '$1');
+}
 
 function flattenText(node: ReactNode): string {
   if (node == null || typeof node === 'boolean') return '';
@@ -52,7 +67,7 @@ export function TheoryMarkdown({ children }: { children: string }) {
       rehypePlugins={[rehypeKatex]}
       components={MARKDOWN_COMPONENTS}
     >
-      {children}
+      {stripCalloutEmojis(children)}
     </ReactMarkdown>
   );
 }
@@ -61,38 +76,23 @@ export function TheoryMarkdown({ children }: { children: string }) {
 export const THEORY_CALLOUT_CSS = `
   .theory-callout {
     margin: 1.1rem 0;
-    padding: 14px 16px 14px 52px;
+    padding: 14px 18px;
     border-radius: 12px;
     border-left: 4px solid;
-    position: relative;
     line-height: 1.55;
     animation: theory-callout-pop 0.45s ease-out backwards;
   }
   .theory-callout > p:first-child { margin-top: 0; }
   .theory-callout > p:last-child  { margin-bottom: 0; }
-  .theory-callout::before {
-    position: absolute;
-    left: 14px;
-    top: 12px;
-    font-size: 1.4rem;
-    line-height: 1;
-  }
   .theory-callout-tip       { background: rgba(234,179,8,0.10);  border-left-color: #eab308; }
-  .theory-callout-tip::before       { content: '💡'; }
   .theory-callout-remember  { background: rgba(99,102,241,0.10); border-left-color: #6366f1; }
-  .theory-callout-remember::before  { content: '🧠'; }
   .theory-callout-warning   { background: rgba(220,38,38,0.10);  border-left-color: #dc2626; }
-  .theory-callout-warning::before   { content: '⚠️'; }
   .theory-callout-question  { background: rgba(20,184,166,0.10); border-left-color: #14b8a6; }
-  .theory-callout-question::before  { content: '❓'; }
   .theory-callout-fence     { background: var(--brand-soft); border-left-color: var(--brand); }
-  .theory-callout-fence::before     { content: '🚧'; }
   .theory-callout-default   {
     background: var(--color-bg);
     border-left-color: var(--color-border);
-    padding-left: 16px;
   }
-  .theory-callout-default::before { content: ''; }
   @keyframes theory-callout-pop {
     0%   { opacity: 0; transform: scale(0.96); }
     60%  { opacity: 1; transform: scale(1.01); }

--- a/apps/web/src/pages/StudyUnitPage.tsx
+++ b/apps/web/src/pages/StudyUnitPage.tsx
@@ -244,7 +244,7 @@ function TheoryTab({ unit }: { unit: StudyUnitDetail }) {
       />
     );
   }
-  return <TheoryView module={unit.theory} />;
+  return <TheoryView module={unit.theory} courseTitle={unit.course.title} />;
 }
 
 function ExercisesTab({ unit }: { unit: StudyUnitDetail }) {

--- a/apps/web/src/pages/StudyUnitPage.tsx
+++ b/apps/web/src/pages/StudyUnitPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import type { StudyUnitDetail } from '@vkbacademy/shared';
 import {
@@ -17,11 +17,61 @@ import EmptyState from '../components/ui/EmptyState';
 
 type Tab = 'theory' | 'exercises' | 'exam';
 
-const TABS: { key: Tab; label: string; icon: string }[] = [
-  { key: 'theory', label: 'Teoría', icon: 'book' },
-  { key: 'exercises', label: 'Ejercicios', icon: 'target' },
-  { key: 'exam', label: 'Examen', icon: 'graduation' },
+// Itinerario secuencial de la unidad: primero apuntes, luego práctica, luego examen.
+const STEPS: { key: Tab; label: string; icon: string; desc: string }[] = [
+  { key: 'theory', label: 'Apuntes', icon: 'book', desc: 'Estudia el temario con la presentación' },
+  { key: 'exercises', label: 'Ejercicios', icon: 'target', desc: 'Practica lo que acabas de aprender' },
+  { key: 'exam', label: 'Examen', icon: 'graduation', desc: 'Demuestra lo que sabes' },
 ];
+
+const STEPPER_CSS = `
+  .unit-steps { display: flex; align-items: stretch; gap: 6px; margin-top: 10px; }
+  .unit-step {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 18px;
+    background: var(--color-surface);
+    border: 1.5px solid var(--color-border);
+    border-radius: 14px;
+    cursor: pointer;
+    text-align: left;
+    color: var(--color-text);
+    font-family: inherit;
+    transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+  }
+  .unit-step:hover { border-color: var(--brand); transform: translateY(-2px); }
+  .unit-step.is-active {
+    border-color: var(--brand);
+    background: var(--brand-soft);
+    box-shadow: 0 0 0 3px var(--brand-soft);
+  }
+  .unit-step-num {
+    flex: none;
+    width: 46px;
+    height: 46px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    line-height: 1;
+    color: var(--brand-deep);
+    background: var(--brand-soft);
+    border: 1px solid var(--brand);
+    transition: background 0.15s, color 0.15s;
+  }
+  .unit-step.is-active .unit-step-num { background: var(--brand); color: #fff; }
+  .unit-step-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+  .unit-step-title { display: inline-flex; align-items: center; gap: 6px; font-weight: 800; font-size: 1rem; }
+  .unit-step-desc { font-size: 0.8rem; color: var(--color-text-muted); line-height: 1.35; }
+  .unit-step-arrow { align-self: center; color: var(--color-text-muted); flex: none; display: grid; place-items: center; }
+  @media (max-width: 720px) {
+    .unit-steps { flex-direction: column; }
+    .unit-step-arrow { transform: rotate(90deg); }
+  }
+`;
 
 export default function StudyUnitPage() {
   const { id = '' } = useParams<{ id: string }>();
@@ -67,23 +117,38 @@ export default function StudyUnitPage() {
 
       <PageHeader variant="light" title={data.title} subtitle={data.summary} />
 
-      <nav style={s.tabs}>
-        {TABS.map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            onClick={() => setTab(t.key)}
-            className={`chip${tab === t.key ? ' active' : ''}`}
-            aria-pressed={tab === t.key}
-          >
-            <Icon name={t.icon} size={14} />
-            {t.label}
-            {!data.sections[t.key] && (
-              <span style={s.tabWarn} title="Sección no generada">
-                !
+      <style>{STEPPER_CSS}</style>
+      <nav className="unit-steps" aria-label="Itinerario de la unidad">
+        {STEPS.map((t, i) => (
+          <Fragment key={t.key}>
+            {i > 0 && (
+              <span className="unit-step-arrow" aria-hidden="true">
+                <Icon name="chevron-right" size={20} />
               </span>
             )}
-          </button>
+            <button
+              type="button"
+              onClick={() => setTab(t.key)}
+              className={`unit-step${tab === t.key ? ' is-active' : ''}`}
+              aria-current={tab === t.key ? 'step' : undefined}
+            >
+              <span className="unit-step-num" aria-hidden="true">
+                {i + 1}
+              </span>
+              <span className="unit-step-body">
+                <span className="unit-step-title">
+                  <Icon name={t.icon} size={16} />
+                  {t.label}
+                  {!data.sections[t.key] && (
+                    <span style={s.tabWarn} title="Sección no generada">
+                      !
+                    </span>
+                  )}
+                </span>
+                <span className="unit-step-desc">{t.desc}</span>
+              </span>
+            </button>
+          </Fragment>
         ))}
       </nav>
 
@@ -257,7 +322,7 @@ function ExamTab({ unit, onStart }: { unit: StudyUnitDetail; onStart: (bankId: s
 
 const s: Record<string, React.CSSProperties> = {
   page: {
-    maxWidth: 900,
+    maxWidth: 1040,
     margin: '0 auto',
     padding: '24px 16px 64px',
     display: 'flex',
@@ -280,12 +345,6 @@ const s: Record<string, React.CSSProperties> = {
     color: 'var(--color-text-muted)',
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
-  },
-  tabs: {
-    display: 'flex',
-    gap: 8,
-    flexWrap: 'wrap',
-    marginTop: 4,
   },
   tabWarn: { color: 'var(--color-error)', fontWeight: 800 },
   content: { display: 'flex', flexDirection: 'column', gap: 16, marginTop: 8 },

--- a/apps/web/src/utils/theoryPdf.ts
+++ b/apps/web/src/utils/theoryPdf.ts
@@ -1,10 +1,12 @@
-// Exportación del temario a PDF (una imagen por diapositiva, fidelidad visual
-// total: fórmulas KaTeX, colores y diseño VKB) y compartición por WhatsApp.
+// Exportación del temario a PDF imprimible (una imagen por diapositiva, con
+// fórmulas KaTeX) y compartición por WhatsApp. El PDF usa fondo blanco y paleta
+// casi blanco y negro (el deck en pantalla es oscuro, pero imprimirlo gasta
+// tinta y sale mal): la marca naranja queda solo en el pie de página.
 //
 // Estrategia: se renderiza un árbol React con TODAS las slides a tamaño fijo en
 // un contenedor fuera de pantalla, se captura cada página con html2canvas y se
 // componen en un jsPDF con páginas 16:9. Reutiliza SlideView (mismo render que
-// el deck) para no duplicar el diseño.
+// el deck) y se re-tematiza en claro vía PDF_OVERRIDE_CSS.
 
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -23,7 +25,7 @@ const PAGE_H = 720;
 const FOOTER_MARGIN = 64;
 const FOOTER_BASELINE = PAGE_H - 26; // línea de texto del pie
 const ORANGE = { r: 245, g: 145, b: 30 } as const; // #f5911e
-const FOOTER_MUTED = { r: 148, g: 163, b: 184 } as const; // slate-400, legible sobre fondo oscuro
+const FOOTER_MUTED = { r: 71, g: 85, b: 105 } as const; // slate-600, legible sobre fondo blanco
 
 function drawFooter(doc: JsPdf, pageNum: number, totalPages: number): void {
   // Línea fina naranja separando el pie del contenido
@@ -57,15 +59,16 @@ const PAGE_STYLE: React.CSSProperties = {
   padding: '56px 80px',
   boxSizing: 'border-box',
   overflow: 'hidden',
-  color: '#fff',
-  background:
-    'radial-gradient(120% 80% at 50% -10%, rgba(245,145,30,0.22), transparent 60%), linear-gradient(180deg, #080e1a 0%, #0d1b2a 60%, #152233 100%)',
+  color: '#111827',
+  background: '#ffffff',
 };
 
 // html2canvas no ejecuta animaciones CSS y no soporta background-clip:text.
 // Para el PDF: desactivamos animaciones/transiciones (callouts y fragmentos
 // quedarían en opacidad 0), forzamos todo visible y damos color sólido al
 // título de portada (el degradado-sobre-texto saldría como una caja).
+// Además, re-tematizamos en claro TODO el CSS del deck (pensado para fondo
+// navy): texto casi negro, tarjetas y callouts en grises, sin glows.
 const PDF_OVERRIDE_CSS = `
   .tslides-pdf-page *,
   .tslides-pdf-page *::before,
@@ -78,11 +81,47 @@ const PDF_OVERRIDE_CSS = `
     opacity: 1 !important;
     transform: none !important;
   }
+  .tslides-pdf-page { color: #111827; }
   .tslides-pdf-page .tsl-cover-title {
     background: none !important;
-    -webkit-text-fill-color: #fff !important;
-    color: #fff !important;
+    -webkit-text-fill-color: #111827 !important;
+    color: #111827 !important;
   }
+  .tslides-pdf-page .tsl-cover-eyebrow { color: #475569; }
+  .tslides-pdf-page .tsl-cover-sub,
+  .tslides-pdf-page .tsl-closing-sub { color: #475569; }
+  .tslides-pdf-page .tsl-closing-title { color: #111827; }
+  .tslides-pdf-page .tsl-ball { filter: none; }
+  .tslides-pdf-page .tsl-heading { color: #111827; }
+  .tslides-pdf-page .tsl-cont { color: #475569; border-color: #cbd5e1; }
+  .tslides-pdf-page .tsl-body { color: #111827; }
+  .tslides-pdf-page .tsl-body strong { color: #000; }
+  .tslides-pdf-page .tsl-body code { background: #f1f5f9; color: #111827; }
+  .tslides-pdf-page .tsl-muted { color: #475569; }
+  .tslides-pdf-page .theory-callout {
+    color: #111827;
+    background: #f8fafc !important;
+    border-left-color: #94a3b8 !important;
+  }
+  .tslides-pdf-page .tsl-content--objectives .tsl-body li,
+  .tslides-pdf-page .tsl-content--takeaways .tsl-body li {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+  .tslides-pdf-page .tsl-content--objectives .tsl-body li::before,
+  .tslides-pdf-page .tsl-content--takeaways .tsl-body li::before {
+    background: #e2e8f0;
+    color: #111827;
+  }
+  .tslides-pdf-page .tsl-ex-label { color: #334155; }
+  .tslides-pdf-page .tsl-ex-statement { background: #f8fafc; border-color: #cbd5e1; }
+  .tslides-pdf-page .tsl-ex-step { background: #f8fafc; border-color: #cbd5e1; }
+  .tslides-pdf-page .tsl-ex-num { background: #e2e8f0; border-color: #94a3b8; color: #111827; }
+  .tslides-pdf-page .tsl-ex-result { background: #f1f5f9; border: 1px solid #64748b; }
+  .tslides-pdf-page .tsl-ex-why { background: #f8fafc; border-left-color: #64748b; }
+  .tslides-pdf-page .tsl-ex-why .tsl-ex-label { color: #334155; }
+  .tslides-pdf-page .tsl-video-card { background: #f8fafc; border-color: #cbd5e1; }
+  .tslides-pdf-page .tsl-video-card-play { background: #e2e8f0; color: #111827; box-shadow: none; }
 `;
 
 function PdfPages({ slides }: { slides: Slide[] }) {
@@ -123,7 +162,7 @@ async function generateTheoryPdf(module: TheoryModuleWithLessons): Promise<JsPdf
     top: '0',
     width: `${PAGE_W}px`,
     display: 'block',
-    background: '#0d1b2a',
+    background: '#ffffff',
   } satisfies Partial<CSSStyleDeclaration>);
   document.body.appendChild(host);
 
@@ -153,7 +192,7 @@ async function generateTheoryPdf(module: TheoryModuleWithLessons): Promise<JsPdf
       }
       const canvas = await html2canvas(pages[i], {
         scale: 2,
-        backgroundColor: '#0d1b2a',
+        backgroundColor: '#ffffff',
         useCORS: true,
         logging: false,
         windowWidth: PAGE_W,

--- a/apps/web/src/utils/theoryPdf.ts
+++ b/apps/web/src/utils/theoryPdf.ts
@@ -20,12 +20,53 @@ import { THEORY_CALLOUT_CSS } from '../components/theory/theoryMarkdown';
 const PAGE_W = 1280;
 const PAGE_H = 720;
 
-// Footer de marca VKB, dibujado con jsPDF sobre cada página (independiente del
-// escalado del contenido, así aparece siempre y sin recortes).
+// Cabecera y pie de marca, dibujados con jsPDF sobre cada página (texto
+// vectorial: independiente del escalado del contenido y siempre nítido).
 const FOOTER_MARGIN = 64;
 const FOOTER_BASELINE = PAGE_H - 26; // línea de texto del pie
+const HEADER_H = 96; // banda superior con logo + VKB ACADEMY + título del curso
 const ORANGE = { r: 245, g: 145, b: 30 } as const; // #f5911e
 const FOOTER_MUTED = { r: 71, g: 85, b: 105 } as const; // slate-600, legible sobre fondo blanco
+const INK = { r: 17, g: 24, b: 39 } as const; // gray-900
+
+const LOGO_URL = '/brand/vkb-logo.png';
+
+/** Carga el logo como data URL para incrustarlo con jsPDF (null si falla). */
+async function loadLogoDataUrl(): Promise<string | null> {
+  try {
+    const blob = await fetch(LOGO_URL).then((r) => (r.ok ? r.blob() : null));
+    if (!blob) return null;
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Cabecera de cada página de contenido: logo + VKB ACADEMY + curso y tema. */
+function drawHeader(doc: JsPdf, logo: string | null, docTitle: string): void {
+  if (logo) {
+    doc.addImage(logo, 'PNG', FOOTER_MARGIN, 14, 64, 64);
+  }
+  const textX = FOOTER_MARGIN + (logo ? 80 : 0);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(24);
+  doc.setTextColor(ORANGE.r, ORANGE.g, ORANGE.b);
+  doc.text('VKB ACADEMY', textX, 42);
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(16);
+  doc.setTextColor(INK.r, INK.g, INK.b);
+  doc.text(docTitle, textX, 68);
+
+  doc.setDrawColor(ORANGE.r, ORANGE.g, ORANGE.b);
+  doc.setLineWidth(1.5);
+  doc.line(FOOTER_MARGIN, HEADER_H - 6, PAGE_W - FOOTER_MARGIN, HEADER_H - 6);
+}
 
 function drawFooter(doc: JsPdf, pageNum: number, totalPages: number): void {
   // Línea fina naranja separando el pie del contenido
@@ -50,18 +91,22 @@ function drawFooter(doc: JsPdf, pageNum: number, totalPages: number): void {
   });
 }
 
-const PAGE_STYLE: React.CSSProperties = {
+const PAGE_BASE_STYLE: React.CSSProperties = {
   width: PAGE_W,
   height: PAGE_H,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: '56px 80px',
   boxSizing: 'border-box',
   overflow: 'hidden',
   color: '#111827',
   background: '#ffffff',
 };
+
+// Las páginas de contenido reservan la banda superior para la cabecera de
+// marca (dibujada con jsPDF); la portada no lleva cabecera y va centrada.
+const PAGE_STYLE: React.CSSProperties = { ...PAGE_BASE_STYLE, padding: '112px 80px 64px' };
+const COVER_PAGE_STYLE: React.CSSProperties = { ...PAGE_BASE_STYLE, padding: '56px 80px' };
 
 // html2canvas no ejecuta animaciones CSS y no soporta background-clip:text.
 // Para el PDF: desactivamos animaciones/transiciones (callouts y fragmentos
@@ -91,7 +136,7 @@ const PDF_OVERRIDE_CSS = `
   .tslides-pdf-page .tsl-cover-sub,
   .tslides-pdf-page .tsl-closing-sub { color: #475569; }
   .tslides-pdf-page .tsl-closing-title { color: #111827; }
-  .tslides-pdf-page .tsl-ball { filter: none; }
+  .tslides-pdf-page .tsl-logo { filter: none; }
   .tslides-pdf-page .tsl-heading { color: #111827; }
   .tslides-pdf-page .tsl-cont { color: #475569; border-color: #cbd5e1; }
   .tslides-pdf-page .tsl-body { color: #111827; }
@@ -132,7 +177,11 @@ function PdfPages({ slides }: { slides: Slide[] }) {
     ...slides.map((slide) =>
       createElement(
         'div',
-        { key: slide.id, className: 'tslides-pdf-page', style: PAGE_STYLE },
+        {
+          key: slide.id,
+          className: 'tslides-pdf-page',
+          style: slide.kind === 'cover' ? COVER_PAGE_STYLE : PAGE_STYLE,
+        },
         createElement(
           'div',
           { className: 'tslides-inner', style: { width: '100%', maxWidth: 1080 } },
@@ -143,15 +192,27 @@ function PdfPages({ slides }: { slides: Slide[] }) {
   );
 }
 
+/** Título del documento: "Curso - Tema" (cabecera del PDF y nombre del fichero). */
+function buildDocTitle(module: TheoryModuleWithLessons, courseTitle: string): string {
+  const topic = module.topic.trim();
+  const capitalized = topic.charAt(0).toUpperCase() + topic.slice(1);
+  return `${courseTitle} - ${capitalized}`;
+}
+
 /** Renderiza las slides fuera de pantalla y genera el documento PDF. */
-async function generateTheoryPdf(module: TheoryModuleWithLessons): Promise<JsPdf> {
+async function generateTheoryPdf(
+  module: TheoryModuleWithLessons,
+  courseTitle: string,
+): Promise<JsPdf> {
   // Carga diferida: html2canvas/jsPDF solo se descargan al exportar (no en el bundle inicial).
-  const [{ default: JsPDFCtor }, { default: html2canvas }] = await Promise.all([
+  const [{ default: JsPDFCtor }, { default: html2canvas }, logo] = await Promise.all([
     import('jspdf'),
     import('html2canvas'),
+    loadLogoDataUrl(),
   ]);
 
   const slides = buildSlides(module);
+  const docTitle = buildDocTitle(module, courseTitle);
 
   const host = document.createElement('div');
   host.className = 'tslides';
@@ -169,38 +230,47 @@ async function generateTheoryPdf(module: TheoryModuleWithLessons): Promise<JsPdf
   const root = createRoot(host);
   root.render(createElement(PdfPages, { slides }));
 
-  // Esperar a que carguen fuentes (incl. KaTeX) y a que React pinte el markdown.
+  // Esperar a que carguen fuentes (incl. KaTeX), imágenes (logo) y a que React
+  // pinte el markdown.
   try {
     await document.fonts.ready;
   } catch {
     /* fonts.ready no soportado: continuar */
   }
   await new Promise((resolve) => setTimeout(resolve, 400));
+  await Promise.all(
+    Array.from(host.querySelectorAll('img')).map((img) => img.decode().catch(() => undefined)),
+  );
 
   const pages = Array.from(host.querySelectorAll<HTMLElement>('.tslides-pdf-page'));
   const doc = new JsPDFCtor({ orientation: 'landscape', unit: 'px', format: [PAGE_W, PAGE_H] });
 
   try {
     for (let i = 0; i < pages.length; i++) {
+      const isCover = slides[i]?.kind === 'cover';
       // Escalar el contenido para que no se recorte en la página (no hay scroll en PDF).
       const inner = pages[i].querySelector<HTMLElement>('.tslides-inner');
       if (inner) {
-        const availH = PAGE_H - 112; // padding vertical (56 × 2)
+        const availH = isCover ? PAGE_H - 112 : PAGE_H - HEADER_H - 80; // padding vertical
         const availW = PAGE_W - 160; // padding horizontal (80 × 2)
         const scale = Math.min(1, availH / inner.scrollHeight, availW / inner.scrollWidth);
         inner.style.transform = scale < 1 ? `scale(${scale})` : '';
       }
+      // scale 3 para texto nítido al imprimir (a scale 2 salía borroso). JPEG en
+      // calidad alta: jsPDF incrusta los PNG como píxeles sin comprimir (~24 MB
+      // por página); a 3x los artefactos JPEG son invisibles.
       const canvas = await html2canvas(pages[i], {
-        scale: 2,
+        scale: 3,
         backgroundColor: '#ffffff',
         useCORS: true,
         logging: false,
         windowWidth: PAGE_W,
         windowHeight: PAGE_H,
       });
-      const img = canvas.toDataURL('image/jpeg', 0.92);
+      const img = canvas.toDataURL('image/jpeg', 0.95);
       if (i > 0) doc.addPage([PAGE_W, PAGE_H], 'landscape');
       doc.addImage(img, 'JPEG', 0, 0, PAGE_W, PAGE_H);
+      if (!isCover) drawHeader(doc, logo, docTitle);
       drawFooter(doc, i + 1, pages.length);
     }
   } finally {
@@ -211,23 +281,22 @@ async function generateTheoryPdf(module: TheoryModuleWithLessons): Promise<JsPdf
   return doc;
 }
 
-/** Nombre de fichero seguro a partir del título del temario. */
-export function theoryPdfFilename(module: TheoryModuleWithLessons): string {
-  const base =
-    (module.title || module.topic || 'temario')
-      .toLowerCase()
-      .normalize('NFD')
-      .replace(/[̀-ͯ]/g, '')
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 60) || 'temario';
-  return `temario-${base}.pdf`;
+/** Nombre de fichero legible: "Curso - Tema.pdf" (mismo título que la cabecera). */
+export function theoryPdfFilename(module: TheoryModuleWithLessons, courseTitle: string): string {
+  const base = buildDocTitle(module, courseTitle)
+    .replace(/[\\/:*?"<>|]+/g, '')
+    .trim()
+    .slice(0, 120);
+  return `${base || 'Temario'}.pdf`;
 }
 
 /** Genera y descarga el PDF del temario. */
-export async function downloadTheoryPdf(module: TheoryModuleWithLessons): Promise<void> {
-  const doc = await generateTheoryPdf(module);
-  doc.save(theoryPdfFilename(module));
+export async function downloadTheoryPdf(
+  module: TheoryModuleWithLessons,
+  courseTitle: string,
+): Promise<void> {
+  const doc = await generateTheoryPdf(module, courseTitle);
+  doc.save(theoryPdfFilename(module, courseTitle));
 }
 
 type ShareResult = 'shared' | 'downloaded';
@@ -237,9 +306,12 @@ type ShareResult = 'shared' | 'downloaded';
  * usuario elige WhatsApp y se envía el PDF real). En desktop u otros casos cae
  * a descargar el PDF y abrir WhatsApp con un mensaje para adjuntarlo a mano.
  */
-export async function shareTheoryPdf(module: TheoryModuleWithLessons): Promise<ShareResult> {
-  const doc = await generateTheoryPdf(module);
-  const filename = theoryPdfFilename(module);
+export async function shareTheoryPdf(
+  module: TheoryModuleWithLessons,
+  courseTitle: string,
+): Promise<ShareResult> {
+  const doc = await generateTheoryPdf(module, courseTitle);
+  const filename = theoryPdfFilename(module, courseTitle);
   const blob = doc.output('blob');
   const file = new File([blob], filename, { type: 'application/pdf' });
 

--- a/apps/web/src/utils/theorySlides.test.ts
+++ b/apps/web/src/utils/theorySlides.test.ts
@@ -151,7 +151,7 @@ describe('parseExample', () => {
   it('parsea título, enunciado, pasos, resultado y porqué', () => {
     const parsed = parseExample(EXAMPLE_MD)!;
     expect(parsed).not.toBeNull();
-    expect(parsed.title).toBe('💪 Ejemplo 1: descuento de rebajas');
+    expect(parsed.title).toBe('Ejemplo 1: descuento de rebajas');
     expect(parsed.statement).toContain('zapatillas');
     expect(parsed.steps).toHaveLength(3);
     expect(parsed.steps[1]).toContain('Resta el descuento');
@@ -177,13 +177,12 @@ describe('parseExample', () => {
 });
 
 describe('buildSlides — estructura Winston', () => {
-  it('marca la INTRO "Qué vas a conseguir" como variante objectives con icono 🎯', () => {
+  it('marca la INTRO "Qué vas a conseguir" como variante objectives', () => {
     const slides = buildSlides(
       moduleWith([lesson({ kind: 'INTRO', heading: 'Qué vas a conseguir', body: '- **Sabrás** x' })]),
     );
     const intro = slides.find((s) => s.kind === 'content')!;
     expect(intro.variant).toBe('objectives');
-    expect(intro.icon).toBe('🎯');
   });
 
   it('marca "Lo que te llevas" como variante takeaways', () => {

--- a/apps/web/src/utils/theorySlides.ts
+++ b/apps/web/src/utils/theorySlides.ts
@@ -17,7 +17,6 @@
 
 import type {
   TheoryLesson,
-  TheoryLessonKind,
   TheoryModuleWithLessons,
   TheoryVideoCandidate,
 } from '@vkbacademy/shared';
@@ -39,7 +38,6 @@ export interface Slide {
   coverSubtitle?: string;
   topic?: string;
   // content
-  icon?: string;
   heading?: string;
   /** Bloques de markdown; cada uno se revela como un fragmento. */
   blocks?: string[];
@@ -56,15 +54,16 @@ export interface Slide {
   candidates?: TheoryVideoCandidate[];
 }
 
-export const KIND_ICON: Record<TheoryLessonKind, string> = {
-  INTRO: '🧭',
-  CONTENT: '📚',
-  EXAMPLE: '💡',
-  VIDEO: '▶️',
-};
-
 /** Presupuesto de caracteres por slide antes de empezar una nueva. */
 const MAX_SLIDE_CHARS = 480;
+
+/**
+ * Elimina emojis iniciales de un heading (la IA marca los ejemplos con 💪 y
+ * los temarios antiguos traen iconos): las slides van sin emoticonos.
+ */
+export function stripLeadingEmoji(text: string): string {
+  return text.replace(/^[\p{Extended_Pictographic}\u{FE0F}\u{200D}\s]+/u, '').trim() || text;
+}
 
 /** Separa un markdown en bloques de nivel superior (párrafos, listas, callouts…). */
 export function splitMarkdownBlocks(md: string): string[] {
@@ -146,7 +145,7 @@ export function parseExample(chunk: string): ParsedExample | null {
   const headingMatch = lines[0]?.match(/^###\s+(.+)$/);
   if (!headingMatch) return null;
 
-  const title = headingMatch[1].trim();
+  const title = stripLeadingEmoji(headingMatch[1].trim());
   let statement = '';
   const steps: string[] = [];
   let result = '';
@@ -229,8 +228,7 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
       slides.push({
         id: lesson.id,
         kind: 'video',
-        icon: KIND_ICON.VIDEO,
-        heading: lesson.heading,
+        heading: stripLeadingEmoji(lesson.heading),
         candidates: resolveVideoCandidates(lesson),
       });
       continue;
@@ -259,8 +257,7 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
           slides.push({
             id: `${lesson.id}-${i}-${j}`,
             kind: 'content',
-            icon: KIND_ICON.EXAMPLE,
-            heading: lesson.heading,
+            heading: stripLeadingEmoji(lesson.heading),
             blocks: pageBlocks,
             continued: emitted > 0 || j > 0,
           });
@@ -271,8 +268,7 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
         slides.push({
           id: `${lesson.id}-0`,
           kind: 'content',
-          icon: KIND_ICON.EXAMPLE,
-          heading: lesson.heading,
+          heading: stripLeadingEmoji(lesson.heading),
           blocks: [''],
         });
       }
@@ -289,8 +285,7 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
       slides.push({
         id: `${lesson.id}-${i}`,
         kind: 'content',
-        icon: variant === 'objectives' ? '🎯' : variant === 'takeaways' ? '🏆' : KIND_ICON[lesson.kind],
-        heading: lesson.heading,
+        heading: stripLeadingEmoji(lesson.heading),
         blocks: pageBlocks,
         continued: i > 0,
         variant,


### PR DESCRIPTION
Bloque "Mejorar interfaz de cursos generados" (tasks/todo.md, pedido 03/07).

## Cambios

- **Stepper secuencial protagonista** en `StudyUnitPage`: los tres chips pequeños de Teoría/Ejercicios/Examen pasan a ser tres tarjetas grandes numeradas (1 Apuntes → 2 Ejercicios → 3 Examen) con descripción y flechas, que guían el flujo de estudio. La página se ensancha a 1040px.
- **La presentación es la fuente**: hero oscuro (zona dark del design system) con CTA "Empezar" y nº de diapositivas. Los apuntes en formato scroll quedan colapsados tras "Ver apuntes en texto" (no se eliminan, por si alguien prefiere leer).
- **PDF imprimible**: `theoryPdf.ts` pasa de fondo navy a fondo blanco con contenido casi blanco y negro (tarjetas y callouts en grises, KaTeX oscuro); la marca naranja queda solo en la línea y el "VKB ACADEMY" del pie. Bonus: el PDF pesa ~60% menos (1,85 MB vs ~5 MB).
- **Cierre del temario ampliado**: el prompt de `theory.service.ts` añade una lección CONTENT "Chuleta de repaso" (fórmulas y reglas clave en formato compacto + callout 🧠) antes de "Lo que te llevas". Estructura pasa de 5-8 a 6-9 lecciones.
- **Cierre del deck** ("¡Bien jugado!") ahora empuja al siguiente paso: ejercicios y examen.

## Verificación

- API: 511/511 tests (incl. las aserciones del prompt Winston, que son `toContain` y siguen verdes).
- Web: `tsc --noEmit` limpio; vitest 91/92 (el fallo es `email-validation.spec.ts`, preexistente y documentado en el todo).
- QA visual en Chrome con Vite + mock (patrón de tasks/lessons.md): stepper, hero, toggle de apuntes, slide "Chuleta de repaso" con LaTeX, cierre nuevo, y PDF descargado e inspeccionado página a página (portada, contenido, ejemplo, chuleta, checklist en claro).

Nota: los callouts del deck duplican el emoji (::before + texto); preexistente, ya anotado en el todo.
