### PR TITLE
feat(study-plans): simulacro multi-tema con temario oficial y temas propios

### DIFF
--- a/apps/api/prisma/migrations/20260706120000_add_study_plan_multi_topic/migration.sql
+++ b/apps/api/prisma/migrations/20260706120000_add_study_plan_multi_topic/migration.sql
@@ -1,0 +1,72 @@
+-- CreateEnum
+CREATE TYPE "StudyTopicSource" AS ENUM ('OFFICIAL', 'CUSTOM');
+
+-- AlterTable
+ALTER TABLE "TheoryModule" ADD COLUMN     "studyPlanTopicId" TEXT;
+
+-- AlterTable
+ALTER TABLE "AiExamBank" ADD COLUMN     "studyPlanId" TEXT;
+
+-- AlterTable
+ALTER TABLE "AiExamQuestion" ADD COLUMN     "topicLabel" TEXT;
+
+-- CreateTable
+CREATE TABLE "StudyPlan" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL DEFAULT '',
+    "difficulty" TEXT NOT NULL DEFAULT 'MEDIUM',
+    "exercises" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StudyPlan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StudyPlanTopic" (
+    "id" TEXT NOT NULL,
+    "planId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "source" "StudyTopicSource" NOT NULL,
+    "moduleId" TEXT,
+    "title" TEXT NOT NULL,
+    "subject" TEXT,
+    "contextCourseId" TEXT NOT NULL,
+
+    CONSTRAINT "StudyPlanTopic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "StudyPlan_userId_createdAt_idx" ON "StudyPlan"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "StudyPlan_userId_courseId_idx" ON "StudyPlan"("userId", "courseId");
+
+-- CreateIndex
+CREATE INDEX "StudyPlanTopic_planId_order_idx" ON "StudyPlanTopic"("planId", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TheoryModule_studyPlanTopicId_key" ON "TheoryModule"("studyPlanTopicId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AiExamBank_studyPlanId_key" ON "AiExamBank"("studyPlanId");
+
+-- AddForeignKey
+ALTER TABLE "TheoryModule" ADD CONSTRAINT "TheoryModule_studyPlanTopicId_fkey" FOREIGN KEY ("studyPlanTopicId") REFERENCES "StudyPlanTopic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiExamBank" ADD CONSTRAINT "AiExamBank_studyPlanId_fkey" FOREIGN KEY ("studyPlanId") REFERENCES "StudyPlan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StudyPlan" ADD CONSTRAINT "StudyPlan_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StudyPlan" ADD CONSTRAINT "StudyPlan_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StudyPlanTopic" ADD CONSTRAINT "StudyPlanTopic_planId_fkey" FOREIGN KEY ("planId") REFERENCES "StudyPlan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StudyPlanTopic" ADD CONSTRAINT "StudyPlanTopic_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "Module"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -112,6 +112,7 @@ model User {
   theoryModules     TheoryModule[]
   aiExamBanks       AiExamBank[]
   studyUnits        StudyUnit[]
+  studyPlans        StudyPlan[]
 
   @@index([schoolYearId])
   @@index([tutorId])
@@ -157,6 +158,7 @@ model Course {
   theoryModules TheoryModule[] @relation("CourseTheoryModules")
   aiExamBanks   AiExamBank[]   @relation("CourseAiExamBanks")
   studyUnits    StudyUnit[]    @relation("CourseStudyUnits")
+  studyPlans    StudyPlan[]    @relation("CourseStudyPlans")
 
   @@index([schoolYearId])
 }
@@ -187,12 +189,13 @@ model Module {
   order    Int
   courseId String
 
-  course        Course         @relation(fields: [courseId], references: [id], onDelete: Cascade)
-  lessons       Lesson[]
-  examQuestions ExamQuestion[] @relation("ModuleExamQuestions")
-  examAttempts  ExamAttempt[]  @relation("ModuleExamAttempts")
-  certificates  Certificate[]  @relation("ModuleCertificates")
-  aiExamBanks   AiExamBank[]   @relation("ModuleAiExamBanks")
+  course          Course           @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  lessons         Lesson[]
+  examQuestions   ExamQuestion[]   @relation("ModuleExamQuestions")
+  examAttempts    ExamAttempt[]    @relation("ModuleExamAttempts")
+  certificates    Certificate[]    @relation("ModuleCertificates")
+  aiExamBanks     AiExamBank[]     @relation("ModuleAiExamBanks")
+  studyPlanTopics StudyPlanTopic[] @relation("ModuleStudyPlanTopics")
 
   @@index([courseId, order])
 }
@@ -591,6 +594,10 @@ model TheoryModule {
   studyUnitId String?    @unique
   studyUnit   StudyUnit? @relation(fields: [studyUnitId], references: [id], onDelete: Cascade)
 
+  // Tema de un plan de estudio multi-tema: cada tema tiene su propio deck 1:1
+  studyPlanTopicId String?         @unique
+  studyPlanTopic   StudyPlanTopic? @relation(fields: [studyPlanTopicId], references: [id], onDelete: Cascade)
+
   @@index([userId, courseId])
   @@index([userId, createdAt])
 }
@@ -640,6 +647,10 @@ model AiExamBank {
   studyUnitId String?    @unique
   studyUnit   StudyUnit? @relation(fields: [studyUnitId], references: [id], onDelete: Cascade)
 
+  // Examen combinado de un plan de estudio multi-tema (1:1 con el plan)
+  studyPlanId String?    @unique
+  studyPlan   StudyPlan? @relation(fields: [studyPlanId], references: [id], onDelete: Cascade)
+
   @@index([userId, createdAt])
   @@index([userId, courseId])
 }
@@ -652,6 +663,9 @@ model AiExamQuestion {
   order       Int
   /// Explicación pedagógica generada por la IA, mostrada tras submit.
   explanation String?      @db.Text
+  /// Tema del plan multi-tema al que pertenece la pregunta (cobertura por tema
+  /// y "pregunta del tema X" en correcciones). Null en bancos del flujo un-tema.
+  topicLabel  String?
 
   bank    AiExamBank     @relation(fields: [bankId], references: [id], onDelete: Cascade)
   answers AiExamAnswer[]
@@ -699,4 +713,55 @@ model StudyUnit {
 
   @@index([userId, createdAt])
   @@index([userId, courseId])
+}
+
+// ─────────────────────────────────────────────────────────
+// PLAN DE ESTUDIO MULTI-TEMA (alumno) — combina N temas
+// (oficiales del temario o libres) en teoría por tema +
+// ejercicios y examen combinados. Personal (scoped por userId).
+// Flujo adicional: no sustituye a StudyUnit (un-tema).
+// ─────────────────────────────────────────────────────────
+
+enum StudyTopicSource {
+  OFFICIAL // Module del temario oficial del curso
+  CUSTOM // texto libre del alumno
+}
+
+model StudyPlan {
+  id       String @id @default(cuid())
+  userId   String
+  courseId String // asignatura base (curso matriculado desde el que se crea el plan)
+  title    String // "Simulacro: Fracciones · Ecuaciones · Proporcionalidad" (generado)
+  summary  String @db.Text @default("")
+  /// Dificultad elegida por el alumno (EASY | MEDIUM | HARD).
+  difficulty String @default("MEDIUM")
+  /// Ejercicios combinados generados por IA; cada item lleva topicLabel para agrupar en UI.
+  exercises Json?
+  createdAt DateTime @default(now())
+
+  user     User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  course   Course           @relation("CourseStudyPlans", fields: [courseId], references: [id], onDelete: Cascade)
+  topics   StudyPlanTopic[]
+  examBank AiExamBank? // vía AiExamBank.studyPlanId
+
+  @@index([userId, createdAt])
+  @@index([userId, courseId])
+}
+
+model StudyPlanTopic {
+  id       String           @id @default(cuid())
+  planId   String
+  order    Int
+  source   StudyTopicSource
+  moduleId String? // source=OFFICIAL: Module del temario oficial
+  title    String // título del tema (copiado del Module o texto libre del alumno)
+  subject  String? // source=CUSTOM fuera de asignatura: subject declarado
+  /// Curso usado como contexto de generación (module.course | curso base | curso matriculado del subject)
+  contextCourseId String
+
+  plan         StudyPlan     @relation(fields: [planId], references: [id], onDelete: Cascade)
+  module       Module?       @relation("ModuleStudyPlanTopics", fields: [moduleId], references: [id], onDelete: SetNull)
+  theoryModule TheoryModule? // vía TheoryModule.studyPlanTopicId
+
+  @@index([planId, order])
 }

--- a/apps/api/src/ai/topic-distribution.ts
+++ b/apps/api/src/ai/topic-distribution.ts
@@ -1,0 +1,8 @@
+// Reparto determinista de N items entre T temas: base floor(N/T) por tema,
+// el resto (N % T) se asigna de uno en uno a los primeros temas.
+// Compartido por la generación multi-tema de ejercicios y exámenes.
+export function splitAcrossTopics(count: number, topicCount: number): number[] {
+  const base = Math.floor(count / topicCount);
+  const rest = count % topicCount;
+  return Array.from({ length: topicCount }, (_, i) => base + (i < rest ? 1 : 0));
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -28,6 +28,7 @@ import { ExercisesModule } from './exercises/exercises.module';
 import { TheoryModule } from './theory/theory.module';
 import { UsernameModule } from './username/username.module';
 import { StudyModule } from './study/study.module';
+import { StudyPlansModule } from './study-plans/study-plans.module';
 import { MustChangePasswordInterceptor } from './auth/interceptors/must-change-password.interceptor';
 
 @Module({
@@ -76,6 +77,7 @@ import { MustChangePasswordInterceptor } from './auth/interceptors/must-change-p
     ExercisesModule,
     TheoryModule,
     StudyModule,
+    StudyPlansModule,
     UsernameModule,
   ],
   providers: [

--- a/apps/api/src/certificates/certificates.service.spec.ts
+++ b/apps/api/src/certificates/certificates.service.spec.ts
@@ -319,6 +319,39 @@ describe('CertificatesService', () => {
       expect(mockPrisma.certificate.create).not.toHaveBeenCalled();
     });
 
+    it('NO emite certificado si el intento procede de un banco IA — aunque el score sea ≥ 50', async () => {
+      mockPrisma.examAttempt.findUnique.mockResolvedValue({
+        courseId: 'course1',
+        moduleId: null,
+        aiExamBankId: 'bank1',
+      });
+
+      await service.issueExamCertificate('user1', 'attempt1', 100);
+
+      expect(mockPrisma.certificate.findFirst).not.toHaveBeenCalled();
+      expect(mockPrisma.certificate.create).not.toHaveBeenCalled();
+    });
+
+    it('sigue emitiendo certificado para intentos oficiales con aiExamBankId null — no regresión', async () => {
+      mockPrisma.examAttempt.findUnique.mockResolvedValue({
+        courseId: 'course1',
+        moduleId: null,
+        aiExamBankId: null,
+      });
+      mockPrisma.certificate.findFirst.mockResolvedValue(null);
+      mockPrisma.certificate.create.mockResolvedValue({});
+
+      await service.issueExamCertificate('user1', 'attempt1', 80);
+
+      expect(mockPrisma.certificate.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: CertificateType.COURSE_EXAM,
+          }),
+        }),
+      );
+    });
+
     it('guarda el examScore en el certificado', async () => {
       mockPrisma.examAttempt.findUnique.mockResolvedValue({
         courseId: null,

--- a/apps/api/src/certificates/certificates.service.ts
+++ b/apps/api/src/certificates/certificates.service.ts
@@ -140,10 +140,14 @@ export class CertificatesService {
 
     const attempt = await this.prisma.examAttempt.findUnique({
       where: { id: attemptId },
-      select: { courseId: true, moduleId: true },
+      select: { courseId: true, moduleId: true, aiExamBankId: true },
     });
 
     if (!attempt) return;
+
+    // Los bancos generados por IA (flujo de estudio del alumno) no emiten
+    // certificados oficiales: solo los exámenes curados por admin.
+    if (attempt.aiExamBankId) return;
 
     if (attempt.courseId) {
       await this.issueCertificate(

--- a/apps/api/src/exams/ai-exams.service.ts
+++ b/apps/api/src/exams/ai-exams.service.ts
@@ -9,6 +9,7 @@ import { QuestionType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AiProviderService } from '../ai/ai-provider.service';
 import { generateAiJson } from '../ai/ai-json';
+import { splitAcrossTopics } from '../ai/topic-distribution';
 import { GenerateAiExamDto } from './dto/generate-ai-exam.dto';
 
 // ─── Tipos del payload IA ────────────────────────────────────────────────────
@@ -25,11 +26,22 @@ interface AiQuestionPayload {
   type: AiExamQuestionType;
   answers: AiAnswerPayload[];
   explanation?: string;
+  // Solo en el flujo multi-tema (StudyPlan): tema al que pertenece la pregunta.
+  topicLabel?: string;
 }
 
 interface AiExamPayload {
   title: string;
   questions: AiQuestionPayload[];
+}
+
+export interface GenerateAiExamForTopicsParams {
+  courseId: string;
+  topics: string[];
+  numQuestions: number;
+  timeLimit?: number;
+  onlyOnce?: boolean;
+  difficulty?: 'EASY' | 'MEDIUM' | 'HARD';
 }
 
 // ─── Snapshot que vive dentro de ExamAttempt.questionsSnapshot ──────────────
@@ -38,6 +50,8 @@ interface QuestionSnapshot {
   id: string;
   text: string;
   type: string;
+  // Tema de la pregunta en exámenes multi-tema; ausente en el resto.
+  topicLabel?: string | null;
   answers: { id: string; text: string; isCorrect: boolean }[];
 }
 
@@ -162,6 +176,98 @@ export class AiExamsService {
     return this.serializeBank(bank, { includeIsCorrect: false, attemptCount: 0 });
   }
 
+  /**
+   * Variante multi-tema (flujo StudyPlan): una sola llamada IA que reparte las
+   * preguntas entre los temas (base floor(N/T), resto a los primeros)
+   * manteniendo la distribución global de tipos, y etiqueta cada pregunta con
+   * su `topicLabel`. La validación exige cobertura ≥1 pregunta por tema; si la
+   * IA no la respeta, se regenera (hasta 2 generaciones en total).
+   */
+  async generateForTopics(userId: string, params: GenerateAiExamForTopicsParams) {
+    const course = await this.prisma.course.findUnique({
+      where: { id: params.courseId },
+      include: { schoolYear: true },
+    });
+    if (!course) throw new NotFoundException(`Curso "${params.courseId}" no encontrado`);
+
+    const enrollment = await this.prisma.enrollment.findFirst({
+      where: { userId, courseId: params.courseId },
+    });
+    if (!enrollment) throw new ForbiddenException('No estás matriculado en este curso');
+
+    const prompt = this.buildMultiTopicPrompt(
+      course.title,
+      course.schoolYear?.label ?? '',
+      params.topics,
+      params.numQuestions,
+      params.difficulty ?? 'MEDIUM',
+    );
+
+    this.logger.log(
+      `Generando examen IA multi-tema: ${params.numQuestions} preguntas sobre ${params.topics.length} temas (curso "${course.title}")`,
+    );
+
+    const maxTokens = Math.min(8000, 600 + params.numQuestions * 350);
+
+    // El reparto por tema es más frágil que el examen un-tema, así que aquí la
+    // validación semántica (cobertura/etiquetas) también reintenta, no solo el parseo.
+    let payload: AiExamPayload | null = null;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= 2 && !payload; attempt++) {
+      try {
+        const parsed = await generateAiJson(this.ai, prompt, maxTokens, {
+          attempts: 1,
+          logger: this.logger,
+        });
+        payload = this.validateTopicsPayload(parsed, params.numQuestions, params.topics);
+      } catch (err) {
+        lastErr = err;
+        this.logger.warn(
+          `Examen multi-tema inválido (generación ${attempt}/2): ${err instanceof Error ? err.message : 'desconocido'}`,
+        );
+      }
+    }
+    if (!payload) {
+      this.logger.error('Error al generar examen multi-tema tras reintentos:', lastErr);
+      throw new InternalServerErrorException(
+        `El agente IA devolvió un formato inválido: ${lastErr instanceof Error ? lastErr.message : 'desconocido'}`,
+      );
+    }
+
+    const joinedTopics = params.topics.join(' · ');
+    const bank = await this.prisma.aiExamBank.create({
+      data: {
+        userId,
+        courseId: params.courseId,
+        moduleId: null,
+        topic: joinedTopics.slice(0, 500),
+        title: payload.title.trim().slice(0, 200) || joinedTopics.slice(0, 200),
+        numQuestions: params.numQuestions,
+        timeLimit: params.timeLimit ?? null,
+        onlyOnce: params.onlyOnce ?? false,
+        questions: {
+          create: payload.questions.map((q, qIdx) => ({
+            text: q.text,
+            type: q.type as QuestionType,
+            order: qIdx,
+            explanation: q.explanation ?? null,
+            topicLabel: q.topicLabel?.trim() ?? null,
+            answers: {
+              create: q.answers.map((a, aIdx) => ({
+                text: a.text,
+                isCorrect: a.isCorrect,
+                order: aIdx,
+              })),
+            },
+          })),
+        },
+      },
+      include: this.bankInclude(),
+    });
+
+    return this.serializeBank(bank, { includeIsCorrect: false, attemptCount: 0 });
+  }
+
   // ─── Listar bancos del alumno ───────────────────────────────────────────
 
   async listMyBanks(userId: string) {
@@ -254,6 +360,7 @@ export class AiExamsService {
       id: q.id,
       text: q.text,
       type: q.type,
+      topicLabel: q.topicLabel ?? null,
       answers: shuffle(q.answers.map((a) => ({ id: a.id, text: a.text, isCorrect: a.isCorrect }))),
     }));
 
@@ -320,6 +427,7 @@ export class AiExamsService {
         type: string;
         order: number;
         explanation: string | null;
+        topicLabel: string | null;
         answers: { id: string; text: string; isCorrect: boolean; order: number }[];
       }[];
     },
@@ -341,6 +449,7 @@ export class AiExamsService {
         text: q.text,
         type: q.type,
         order: q.order,
+        topicLabel: q.topicLabel,
         ...(opts.includeIsCorrect && { explanation: q.explanation }),
         answers: q.answers.map((a) => ({
           id: a.id,
@@ -418,6 +527,42 @@ export class AiExamsService {
     }
 
     return p as AiExamPayload;
+  }
+
+  /**
+   * Validación del examen multi-tema: todo lo del examen normal + cada
+   * pregunta lleva un topicLabel EXACTO de la lista y todo tema tiene ≥1
+   * pregunta (cobertura obligatoria).
+   */
+  private validateTopicsPayload(
+    parsed: unknown,
+    expectedCount: number,
+    topics: string[],
+  ): AiExamPayload {
+    const payload = this.validatePayload(parsed, expectedCount);
+
+    const perTopicCount = new Map<string, number>(topics.map((t) => [t.trim(), 0]));
+    for (const [idx, q] of payload.questions.entries()) {
+      const label = typeof q.topicLabel === 'string' ? q.topicLabel.trim() : '';
+      if (!perTopicCount.has(label)) {
+        throw new InternalServerErrorException(
+          `Pregunta ${idx + 1}: topicLabel inválido "${q.topicLabel ?? ''}" (debe ser uno de los temas pedidos)`,
+        );
+      }
+      q.topicLabel = label;
+      perTopicCount.set(label, perTopicCount.get(label)! + 1);
+    }
+
+    const uncovered = [...perTopicCount.entries()]
+      .filter(([, count]) => count === 0)
+      .map(([topic]) => topic);
+    if (uncovered.length > 0) {
+      throw new InternalServerErrorException(
+        `El examen no cubre todos los temas: faltan preguntas de ${uncovered.join(', ')}`,
+      );
+    }
+
+    return payload;
   }
 
   /**
@@ -510,6 +655,94 @@ Reglas estrictas:
 - TRUE_FALSE: exactamente 2 opciones ["Verdadero", "Falso"], solo una con isCorrect=true.
 - Los enunciados deben ser claros, precisos y adecuados al nivel ${schoolYearLabel || 'del curso'}.
 - Contenido curricular real relacionado con "${topic}".
+- "explanation" pedagógica y breve (1-2 frases) — el alumno la verá tras corregir.
+- Solo devuelve JSON puro, sin markdown ni texto adicional.`;
+  }
+
+  private buildMultiTopicPrompt(
+    courseTitle: string,
+    schoolYearLabel: string,
+    topics: string[],
+    count: number,
+    difficulty: 'EASY' | 'MEDIUM' | 'HARD',
+  ): string {
+    const dist = this.getTypeDistribution(count);
+    const perTopic = splitAcrossTopics(count, topics.length);
+    const repartoLines = topics
+      .map((t, i) => `- "${t}": ${perTopic[i]} pregunta${perTopic[i] === 1 ? '' : 's'}`)
+      .join('\n');
+
+    return `Genera un examen en español que COMBINE varios temas, como un examen real de evaluación.
+
+Curso: "${courseTitle}"
+${schoolYearLabel ? `Nivel educativo: "${schoolYearLabel}" (sistema educativo español)` : ''}
+Dificultad: ${DIFFICULTY_GUIDANCE[difficulty]}
+Número total de preguntas: ${count}
+
+⚠️ REPARTO POR TEMA — OBLIGATORIO, NO NEGOCIABLE:
+${repartoLines}
+
+Cada pregunta lleva un campo "topicLabel" con el tema al que pertenece, copiado EXACTAMENTE de la lista anterior (mismas mayúsculas, tildes y espacios). Si un topicLabel no coincide con un tema de la lista, o algún tema se queda sin preguntas, la respuesta será RECHAZADA.
+
+⚠️ DISTRIBUCIÓN POR TIPO (sobre el total) — OBLIGATORIA, NO NEGOCIABLE:
+- ${dist.single} preguntas de tipo "SINGLE" (una sola respuesta correcta entre 3-4 opciones)
+- ${dist.multiple} preguntas de tipo "MULTIPLE" (varias respuestas correctas, entre 4 opciones)
+- ${dist.trueFalse} preguntas de tipo "TRUE_FALSE" (verdadero/falso)
+
+Si devuelves todas las preguntas del mismo tipo, la respuesta será RECHAZADA.
+Si no respetas el reparto exacto, la respuesta será RECHAZADA.
+
+Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, sin explicaciones adicionales fuera del JSON):
+{
+  "title": "Título breve del examen (máx. 80 caracteres)",
+  "questions": [
+    {
+      "topicLabel": "${topics[0]}",
+      "text": "Enunciado claro de la pregunta",
+      "type": "SINGLE",
+      "answers": [
+        { "text": "opción A", "isCorrect": true },
+        { "text": "opción B", "isCorrect": false },
+        { "text": "opción C", "isCorrect": false },
+        { "text": "opción D", "isCorrect": false }
+      ],
+      "explanation": "Por qué la opción correcta es la correcta (1-2 frases pedagógicas)"
+    },
+    {
+      "topicLabel": "${topics[0]}",
+      "text": "Enunciado de pregunta de respuesta múltiple — usa fórmulas como 'selecciona TODAS las que apliquen' o '¿cuáles de las siguientes...?'",
+      "type": "MULTIPLE",
+      "answers": [
+        { "text": "opción A", "isCorrect": true },
+        { "text": "opción B", "isCorrect": true },
+        { "text": "opción C", "isCorrect": false },
+        { "text": "opción D", "isCorrect": false }
+      ],
+      "explanation": "Justificación pedagógica"
+    },
+    {
+      "topicLabel": "${topics[topics.length - 1]}",
+      "text": "Afirmación a juzgar como verdadera o falsa",
+      "type": "TRUE_FALSE",
+      "answers": [
+        { "text": "Verdadero", "isCorrect": true },
+        { "text": "Falso", "isCorrect": false }
+      ],
+      "explanation": "Por qué es verdadera (o falsa)"
+    }
+  ]
+}
+
+Reglas estrictas:
+- Devuelve EXACTAMENTE ${count} preguntas — ni una más, ni una menos.
+- Respeta exactamente el reparto por tema indicado arriba: cada tema con su número de preguntas.
+- Respeta exactamente el reparto por tipo: ${dist.single} SINGLE + ${dist.multiple} MULTIPLE + ${dist.trueFalse} TRUE_FALSE (sobre el total, no por tema).
+- Mezcla temas y tipos en orden variado (no agrupar todas las preguntas de un tema juntas).
+- SINGLE: 3 o 4 opciones, exactamente 1 con isCorrect=true.
+- MULTIPLE: 4 opciones, 2 o 3 con isCorrect=true. El enunciado debe dejar claro que hay varias correctas.
+- TRUE_FALSE: exactamente 2 opciones ["Verdadero", "Falso"], solo una con isCorrect=true.
+- Los enunciados deben ser claros, precisos y adecuados al nivel ${schoolYearLabel || 'del curso'}.
+- Contenido curricular real relacionado con cada tema.
 - "explanation" pedagógica y breve (1-2 frases) — el alumno la verá tras corregir.
 - Solo devuelve JSON puro, sin markdown ni texto adicional.`;
   }

--- a/apps/api/src/exams/exams.service.ts
+++ b/apps/api/src/exams/exams.service.ts
@@ -16,6 +16,8 @@ interface QuestionSnapshot {
   id: string;
   text: string;
   type: string;
+  // Tema de la pregunta en exámenes IA multi-tema; ausente en el resto.
+  topicLabel?: string | null;
   answers: { id: string; text: string; isCorrect: boolean }[];
 }
 
@@ -258,6 +260,8 @@ export class ExamsService {
       return {
         questionId: q.id,
         questionText: q.text,
+        // Tema de la pregunta (exámenes multi-tema); null en el resto.
+        topicLabel: q.topicLabel ?? null,
         // Compatibilidad: primer seleccionado/correcto en los campos antiguos.
         selectedAnswerId: selectedIds[0] ?? null,
         selectedAnswerText: selectedAnswers[0]?.text ?? null,

--- a/apps/api/src/exercises/exercises.service.ts
+++ b/apps/api/src/exercises/exercises.service.ts
@@ -8,6 +8,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { AiProviderService } from '../ai/ai-provider.service';
 import { generateAiJson } from '../ai/ai-json';
+import { splitAcrossTopics } from '../ai/topic-distribution';
 import { GenerateExercisesDto } from './dto/generate-exercises.dto';
 import { EvaluateExerciseDto } from './dto/evaluate-exercise.dto';
 
@@ -23,6 +24,22 @@ export interface GeneratedExercise {
 
 export interface GenerateExercisesResult {
   exercises: GeneratedExercise[];
+}
+
+// Ejercicio del flujo multi-tema (StudyPlan): etiquetado con su tema.
+export interface GeneratedTopicExercise extends GeneratedExercise {
+  topicLabel: string;
+}
+
+export interface GenerateTopicExercisesResult {
+  exercises: GeneratedTopicExercise[];
+}
+
+export interface GenerateExercisesForTopicsParams {
+  courseId: string;
+  topics: string[];
+  count: number;
+  difficulty?: 'EASY' | 'MEDIUM' | 'HARD';
 }
 
 export type EvaluationVerdict = 'correct' | 'partial' | 'incorrect';
@@ -106,6 +123,56 @@ export class ExercisesService {
     return this.validateExercisesResult(parsed);
   }
 
+  /**
+   * Variante multi-tema (flujo StudyPlan): una sola llamada IA que reparte
+   * `count` ejercicios entre los temas (base floor(count/T), resto a los
+   * primeros) y etiqueta cada uno con su `topicLabel` para agrupar en UI.
+   */
+  async generateForTopics(
+    userId: string,
+    params: GenerateExercisesForTopicsParams,
+  ): Promise<GenerateTopicExercisesResult> {
+    const course = await this.prisma.course.findUnique({
+      where: { id: params.courseId },
+      include: { schoolYear: true },
+    });
+    if (!course) {
+      throw new NotFoundException(`Curso "${params.courseId}" no encontrado`);
+    }
+
+    const enrollment = await this.prisma.enrollment.findFirst({
+      where: { userId, courseId: params.courseId },
+    });
+    if (!enrollment) {
+      throw new ForbiddenException('No estás matriculado en este curso');
+    }
+
+    const prompt = this.buildMultiTopicPrompt(
+      course.title,
+      course.schoolYear?.label ?? '',
+      params.topics,
+      params.count,
+      params.difficulty ?? 'MEDIUM',
+    );
+
+    this.logger.log(
+      `Generando ${params.count} ejercicios multi-tema (${params.topics.length} temas) para curso "${course.title}"`,
+    );
+
+    const maxTokens = Math.min(8000, 200 + params.count * 250);
+
+    let parsed: unknown;
+    try {
+      parsed = await generateAiJson(this.ai, prompt, maxTokens, { attempts: 2, logger: this.logger });
+    } catch (err) {
+      this.logger.error('Error al parsear JSON de IA (ejercicios multi-tema) tras reintentos:', err);
+      throw new InternalServerErrorException(
+        `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
+      );
+    }
+    return this.validateTopicExercisesResult(parsed, params.topics);
+  }
+
   async evaluate(dto: EvaluateExerciseDto): Promise<EvaluationResult> {
     const prompt = this.buildEvaluationPrompt(dto);
     this.logger.log(
@@ -129,6 +196,24 @@ export class ExercisesService {
       throw new InternalServerErrorException('La respuesta no contiene un array `exercises`');
     }
     return parsed as GenerateExercisesResult;
+  }
+
+  private validateTopicExercisesResult(
+    parsed: unknown,
+    topics: string[],
+  ): GenerateTopicExercisesResult {
+    const result = this.validateExercisesResult(parsed);
+    const validLabels = new Set(topics.map((t) => t.trim()));
+    for (const [idx, ex] of (result.exercises as GeneratedTopicExercise[]).entries()) {
+      const label = typeof ex.topicLabel === 'string' ? ex.topicLabel.trim() : '';
+      if (!validLabels.has(label)) {
+        throw new InternalServerErrorException(
+          `Ejercicio ${idx + 1}: topicLabel inválido "${ex.topicLabel ?? ''}" (debe ser uno de los temas pedidos)`,
+        );
+      }
+      ex.topicLabel = label;
+    }
+    return result as GenerateTopicExercisesResult;
   }
 
   private validateEvaluationResult(parsed: unknown): EvaluationResult {
@@ -210,6 +295,72 @@ Reglas:
 - OPEN: campo "options" vacío []; "solution" contiene la respuesta o pasos resueltos
 - Los enunciados deben ser claros, precisos y adecuados al nivel ${schoolYearLabel || 'del curso'}
 - Contenido curricular real relacionado con "${topic}"
+- "explanation" debe ayudar al alumno a entender por qué la respuesta es correcta
+- Solo devuelve JSON puro, sin markdown ni texto adicional`;
+  }
+
+  private buildMultiTopicPrompt(
+    courseTitle: string,
+    schoolYearLabel: string,
+    topics: string[],
+    count: number,
+    difficulty: 'EASY' | 'MEDIUM' | 'HARD',
+  ): string {
+    const perTopic = splitAcrossTopics(count, topics.length);
+    const repartoLines = topics
+      .map((t, i) => `- "${t}": ${perTopic[i]} ejercicio${perTopic[i] === 1 ? '' : 's'}`)
+      .join('\n');
+
+    return `Genera ${count} ejercicios de práctica en español que combinen VARIOS temas, como en un examen real.
+
+Curso: "${courseTitle}"
+${schoolYearLabel ? `Nivel educativo: "${schoolYearLabel}" (sistema educativo español)` : ''}
+Dificultad: ${DIFFICULTY_GUIDANCE[difficulty]}
+
+⚠️ REPARTO POR TEMA — OBLIGATORIO, NO NEGOCIABLE:
+${repartoLines}
+
+Cada ejercicio lleva un campo "topicLabel" con el tema al que pertenece, copiado EXACTAMENTE de la lista anterior (mismas mayúsculas, tildes y espacios). Si un topicLabel no coincide con un tema de la lista, la respuesta será RECHAZADA.
+
+Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, sin explicaciones adicionales fuera del JSON):
+{
+  "exercises": [
+    {
+      "topicLabel": "${topics[0]}",
+      "statement": "enunciado del ejercicio",
+      "type": "SINGLE",
+      "options": ["opción A", "opción B", "opción C"],
+      "solution": "opción A",
+      "explanation": "por qué la opción A es correcta"
+    },
+    {
+      "topicLabel": "${topics[0]}",
+      "statement": "enunciado",
+      "type": "TRUE_FALSE",
+      "options": ["Verdadero", "Falso"],
+      "solution": "Verdadero",
+      "explanation": "explicación de por qué es verdadero"
+    },
+    {
+      "topicLabel": "${topics[topics.length - 1]}",
+      "statement": "enunciado de un ejercicio abierto",
+      "type": "OPEN",
+      "options": [],
+      "solution": "respuesta correcta o pasos resueltos",
+      "explanation": "explicación detallada del razonamiento"
+    }
+  ]
+}
+
+Reglas:
+- Respeta el reparto exacto de ejercicios por tema indicado arriba
+- Agrupa los ejercicios por tema en el orden de la lista
+- Mezcla los 3 tipos (SINGLE, TRUE_FALSE, OPEN) cuando sea apropiado para cada tema
+- SINGLE: 3-4 opciones, exactamente 1 correcta (la propiedad "solution" debe coincidir con una de las opciones)
+- TRUE_FALSE: opciones siempre ["Verdadero", "Falso"], solución coincide
+- OPEN: campo "options" vacío []; "solution" contiene la respuesta o pasos resueltos
+- Los enunciados deben ser claros, precisos y adecuados al nivel ${schoolYearLabel || 'del curso'}
+- Contenido curricular real relacionado con cada tema
 - "explanation" debe ayudar al alumno a entender por qué la respuesta es correcta
 - Solo devuelve JSON puro, sin markdown ni texto adicional`;
   }

--- a/apps/api/src/exercises/exercises.service.ts
+++ b/apps/api/src/exercises/exercises.service.ts
@@ -161,16 +161,31 @@ export class ExercisesService {
 
     const maxTokens = Math.min(8000, 200 + params.count * 250);
 
-    let parsed: unknown;
-    try {
-      parsed = await generateAiJson(this.ai, prompt, maxTokens, { attempts: 2, logger: this.logger });
-    } catch (err) {
-      this.logger.error('Error al parsear JSON de IA (ejercicios multi-tema) tras reintentos:', err);
+    // Como en el examen multi-tema: el reparto por tema es frágil, así que la
+    // validación semántica (etiquetas + cobertura) también reintenta, no solo el parseo.
+    let result: GenerateTopicExercisesResult | null = null;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= 2 && !result; attempt++) {
+      try {
+        const parsed = await generateAiJson(this.ai, prompt, maxTokens, {
+          attempts: 1,
+          logger: this.logger,
+        });
+        result = this.validateTopicExercisesResult(parsed, params.topics, params.count);
+      } catch (err) {
+        lastErr = err;
+        this.logger.warn(
+          `Ejercicios multi-tema inválidos (generación ${attempt}/2): ${err instanceof Error ? err.message : 'desconocido'}`,
+        );
+      }
+    }
+    if (!result) {
+      this.logger.error('Error al generar ejercicios multi-tema tras reintentos:', lastErr);
       throw new InternalServerErrorException(
-        `El agente IA devolvió un formato inválido: ${err instanceof Error ? err.message : 'desconocido'}`,
+        `El agente IA devolvió un formato inválido: ${lastErr instanceof Error ? lastErr.message : 'desconocido'}`,
       );
     }
-    return this.validateTopicExercisesResult(parsed, params.topics);
+    return result;
   }
 
   async evaluate(dto: EvaluateExerciseDto): Promise<EvaluationResult> {
@@ -201,17 +216,32 @@ export class ExercisesService {
   private validateTopicExercisesResult(
     parsed: unknown,
     topics: string[],
+    count: number,
   ): GenerateTopicExercisesResult {
     const result = this.validateExercisesResult(parsed);
-    const validLabels = new Set(topics.map((t) => t.trim()));
+    const perTopicCount = new Map<string, number>(topics.map((t) => [t.trim(), 0]));
     for (const [idx, ex] of (result.exercises as GeneratedTopicExercise[]).entries()) {
       const label = typeof ex.topicLabel === 'string' ? ex.topicLabel.trim() : '';
-      if (!validLabels.has(label)) {
+      if (!perTopicCount.has(label)) {
         throw new InternalServerErrorException(
           `Ejercicio ${idx + 1}: topicLabel inválido "${ex.topicLabel ?? ''}" (debe ser uno de los temas pedidos)`,
         );
       }
       ex.topicLabel = label;
+      perTopicCount.set(label, perTopicCount.get(label)! + 1);
+    }
+
+    // Cobertura: si hay ejercicios suficientes, ningún tema puede quedarse a cero
+    // (misma regla que el examen multi-tema).
+    if (count >= topics.length) {
+      const uncovered = [...perTopicCount.entries()]
+        .filter(([, n]) => n === 0)
+        .map(([topic]) => topic);
+      if (uncovered.length > 0) {
+        throw new InternalServerErrorException(
+          `Los ejercicios no cubren todos los temas: faltan ejercicios de ${uncovered.join(', ')}`,
+        );
+      }
     }
     return result as GenerateTopicExercisesResult;
   }

--- a/apps/api/src/study-plans/dto/create-study-plan.dto.spec.ts
+++ b/apps/api/src/study-plans/dto/create-study-plan.dto.spec.ts
@@ -1,0 +1,76 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateStudyPlanDto } from './create-study-plan.dto';
+
+// Valida el payload igual que el ValidationPipe global (criterio 3).
+async function validateDto(payload: Record<string, unknown>) {
+  const dto = plainToInstance(CreateStudyPlanDto, payload);
+  return validate(dto);
+}
+
+const validPayload = {
+  courseId: 'course-1',
+  topics: [{ title: 'Fracciones' }],
+  numExercises: 5,
+  difficulty: 'MEDIUM',
+  numQuestions: 5,
+};
+
+describe('CreateStudyPlanDto', () => {
+  it('acepta un payload válido con tema propio', async () => {
+    const errors = await validateDto(validPayload);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('acepta un payload válido con tema oficial (moduleId) y mezcla', async () => {
+    const errors = await validateDto({
+      ...validPayload,
+      topics: [{ moduleId: 'mod-1' }, { title: 'Proporcionalidad' }],
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rechaza topics vacío (ArrayMinSize)', async () => {
+    const errors = await validateDto({ ...validPayload, topics: [] });
+    expect(errors.some((e) => e.property === 'topics')).toBe(true);
+  });
+
+  it('rechaza 7 temas (ArrayMaxSize 6)', async () => {
+    const errors = await validateDto({
+      ...validPayload,
+      topics: Array.from({ length: 7 }, (_, i) => ({ title: `tema número ${i}` })),
+    });
+    expect(errors.some((e) => e.property === 'topics')).toBe(true);
+  });
+
+  it('rechaza un tema sin moduleId ni title', async () => {
+    const errors = await validateDto({ ...validPayload, topics: [{}] });
+    expect(errors.some((e) => e.property === 'topics')).toBe(true);
+  });
+
+  it('rechaza un title de menos de 3 caracteres', async () => {
+    const errors = await validateDto({ ...validPayload, topics: [{ title: 'ab' }] });
+    expect(errors.some((e) => e.property === 'topics')).toBe(true);
+  });
+
+  it('rechaza numQuestions fuera de {5, 10}', async () => {
+    const errors = await validateDto({ ...validPayload, numQuestions: 7 });
+    expect(errors.some((e) => e.property === 'numQuestions')).toBe(true);
+  });
+
+  it('rechaza numExercises fuera de rango (0 y 21)', async () => {
+    expect((await validateDto({ ...validPayload, numExercises: 0 })).length).toBeGreaterThan(0);
+    expect((await validateDto({ ...validPayload, numExercises: 21 })).length).toBeGreaterThan(0);
+  });
+
+  it('rechaza difficulty desconocida', async () => {
+    const errors = await validateDto({ ...validPayload, difficulty: 'EXTREME' });
+    expect(errors.some((e) => e.property === 'difficulty')).toBe(true);
+  });
+
+  it('rechaza timeLimit fuera de rango', async () => {
+    expect((await validateDto({ ...validPayload, timeLimit: 30 })).length).toBeGreaterThan(0);
+    expect((await validateDto({ ...validPayload, timeLimit: 20000 })).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/study-plans/dto/create-study-plan.dto.ts
+++ b/apps/api/src/study-plans/dto/create-study-plan.dto.ts
@@ -1,0 +1,74 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+
+/**
+ * Tema del plan: moduleId (tema oficial del temario) XOR title (tema propio).
+ * `@ValidateIf` exige al menos uno de los dos; la exclusión mutua estricta
+ * (no ambos a la vez) se comprueba en el service.
+ */
+export class StudyPlanTopicInputDto {
+  @ValidateIf((o: StudyPlanTopicInputDto) => !o.title)
+  @IsString({ message: 'Cada tema necesita moduleId (tema oficial) o title (tema propio)' })
+  moduleId?: string;
+
+  @ValidateIf((o: StudyPlanTopicInputDto) => !o.moduleId)
+  @IsString({ message: 'Cada tema necesita moduleId (tema oficial) o title (tema propio)' })
+  @MinLength(3, { message: 'El tema debe tener al menos 3 caracteres' })
+  @MaxLength(200, { message: 'El tema es demasiado largo (máx. 200 caracteres)' })
+  title?: string;
+
+  // Materia declarada cuando el tema propio es de otra asignatura matriculada.
+  @IsOptional()
+  @IsString()
+  @MaxLength(100, { message: 'La materia es demasiado larga (máx. 100 caracteres)' })
+  subject?: string;
+}
+
+export class CreateStudyPlanDto {
+  @IsString()
+  courseId: string;
+
+  @IsArray()
+  @ArrayMinSize(1, { message: 'Elige al menos 1 tema' })
+  @ArrayMaxSize(6, { message: 'Máximo 6 temas por plan' })
+  @ValidateNested({ each: true })
+  @Type(() => StudyPlanTopicInputDto)
+  topics: StudyPlanTopicInputDto[];
+
+  @IsInt()
+  @Min(1, { message: 'Mínimo 1 ejercicio' })
+  @Max(20, { message: 'Máximo 20 ejercicios' })
+  numExercises: number;
+
+  @IsIn(['EASY', 'MEDIUM', 'HARD'], { message: 'difficulty debe ser EASY, MEDIUM o HARD' })
+  difficulty: 'EASY' | 'MEDIUM' | 'HARD';
+
+  @IsInt()
+  @IsIn([5, 10], { message: 'numQuestions debe ser 5 o 10' })
+  numQuestions: 5 | 10;
+
+  @IsInt()
+  @Min(60, { message: 'El tiempo mínimo es 60 segundos' })
+  @Max(10800, { message: 'El tiempo máximo es 10800 segundos (3 h)' })
+  @IsOptional()
+  timeLimit?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  onlyOnce?: boolean;
+}

--- a/apps/api/src/study-plans/study-plans.controller.ts
+++ b/apps/api/src/study-plans/study-plans.controller.ts
@@ -1,0 +1,73 @@
+import { Body, Controller, Delete, Get, HttpCode, Param, Post, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { User } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { StudyPlansService } from './study-plans.service';
+import { CreateStudyPlanDto } from './dto/create-study-plan.dto';
+import { RegenerateExercisesDto } from '../study/dto/regenerate-exercises.dto';
+import { RegenerateExamDto } from '../study/dto/regenerate-exam.dto';
+
+@Controller('study-plans')
+@UseGuards(JwtAuthGuard)
+export class StudyPlansController {
+  constructor(private readonly studyPlans: StudyPlansService) {}
+
+  // Creación completa = N teorías + ejercicios + examen (hasta 8 llamadas IA),
+  // lo más caro de toda la app: límite estricto de 5/hora por usuario.
+  /** Crea un plan multi-tema generando teoría por tema + ejercicios y examen combinados. */
+  @Post()
+  @Throttle({ default: { ttl: 3600000, limit: 5 } })
+  create(@CurrentUser() user: User, @Body() dto: CreateStudyPlanDto) {
+    return this.studyPlans.create(user.id, dto);
+  }
+
+  /** Lista los planes multi-tema del alumno. */
+  @Get('mine')
+  listMine(@CurrentUser() user: User) {
+    return this.studyPlans.listMine(user.id);
+  }
+
+  /** Detalle completo de un plan (solo el dueño; examen sin isCorrect). */
+  @Get(':id')
+  getById(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.studyPlans.getById(user.id, id);
+  }
+
+  /** Borra un plan (cascade a temas, teorías y examen). */
+  @Delete(':id')
+  @HttpCode(204)
+  async remove(@CurrentUser() user: User, @Param('id') id: string) {
+    await this.studyPlans.deleteById(user.id, id);
+  }
+
+  // Regeneraciones = 1 llamada IA por sección: límite más laxo de 30/hora.
+  /** Regenera el deck de teoría de UN tema del plan. */
+  @Post(':id/topics/:topicId/theory')
+  @Throttle({ default: { ttl: 3600000, limit: 30 } })
+  regenTopicTheory(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Param('topicId') topicId: string,
+  ) {
+    return this.studyPlans.regenerateTopicTheory(user.id, id, topicId);
+  }
+
+  /** Regenera los ejercicios combinados (acepta count opcional). */
+  @Post(':id/exercises')
+  @Throttle({ default: { ttl: 3600000, limit: 30 } })
+  regenExercises(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() dto: RegenerateExercisesDto,
+  ) {
+    return this.studyPlans.regenerateExercises(user.id, id, dto);
+  }
+
+  /** Regenera el examen combinado (acepta numQuestions/timeLimit/onlyOnce opcionales). */
+  @Post(':id/exam')
+  @Throttle({ default: { ttl: 3600000, limit: 30 } })
+  regenExam(@CurrentUser() user: User, @Param('id') id: string, @Body() dto: RegenerateExamDto) {
+    return this.studyPlans.regenerateExam(user.id, id, dto);
+  }
+}

--- a/apps/api/src/study-plans/study-plans.module.ts
+++ b/apps/api/src/study-plans/study-plans.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { TheoryModule } from '../theory/theory.module';
+import { ExercisesModule } from '../exercises/exercises.module';
+import { ExamsModule } from '../exams/exams.module';
+import { StudyPlansController } from './study-plans.controller';
+import { StudyPlansService } from './study-plans.service';
+
+@Module({
+  imports: [PrismaModule, TheoryModule, ExercisesModule, ExamsModule],
+  controllers: [StudyPlansController],
+  providers: [StudyPlansService],
+})
+export class StudyPlansModule {}

--- a/apps/api/src/study-plans/study-plans.service.spec.ts
+++ b/apps/api/src/study-plans/study-plans.service.spec.ts
@@ -19,8 +19,8 @@ describe('StudyPlansService', () => {
       findUnique: jest.Mock;
       findMany: jest.Mock;
     };
-    theoryModule: { update: jest.Mock };
-    aiExamBank: { update: jest.Mock };
+    theoryModule: { update: jest.Mock; delete: jest.Mock };
+    aiExamBank: { update: jest.Mock; delete: jest.Mock };
     $transaction: jest.Mock;
   };
   let theory: { generate: jest.Mock; getById: jest.Mock; deleteById: jest.Mock };
@@ -119,8 +119,14 @@ describe('StudyPlansService', () => {
         findUnique: jest.fn(),
         findMany: jest.fn().mockResolvedValue([]),
       },
-      theoryModule: { update: jest.fn().mockResolvedValue({}) },
-      aiExamBank: { update: jest.fn().mockResolvedValue({}) },
+      theoryModule: {
+        update: jest.fn().mockResolvedValue({}),
+        delete: jest.fn().mockResolvedValue({}),
+      },
+      aiExamBank: {
+        update: jest.fn().mockResolvedValue({}),
+        delete: jest.fn().mockResolvedValue({}),
+      },
       $transaction: jest.fn((ops: unknown[]) => Promise.all(ops)),
     };
     theory = {
@@ -409,6 +415,28 @@ describe('StudyPlansService', () => {
 
       await expect(service.create('user-1', dto)).rejects.toThrow('conexión perdida');
       expect(prisma.studyPlan.delete).toHaveBeenCalledWith({ where: { id: 'plan-1' } });
+      // Los artefactos generados pero sin enlazar tampoco quedan huérfanos
+      expect(prisma.theoryModule.delete).toHaveBeenCalledWith({ where: { id: 'tm-1' } });
+      expect(prisma.aiExamBank.delete).toHaveBeenCalledWith({ where: { id: 'bank-1' } });
+    });
+
+    it('rechaza con 422 si numExercises < número de temas', async () => {
+      await expect(
+        service.create('user-1', {
+          ...dto,
+          numQuestions: 10,
+          numExercises: 5,
+          topics: [
+            { title: 'tema uno' },
+            { title: 'tema dos' },
+            { title: 'tema tres' },
+            { title: 'tema cuatro' },
+            { title: 'tema cinco' },
+            { title: 'tema seis' },
+          ],
+        }),
+      ).rejects.toThrow(UnprocessableEntityException);
+      expect(prisma.studyPlan.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/study-plans/study-plans.service.spec.ts
+++ b/apps/api/src/study-plans/study-plans.service.spec.ts
@@ -1,0 +1,475 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { StudyPlansService } from './study-plans.service';
+
+describe('StudyPlansService', () => {
+  let prisma: {
+    course: { findUnique: jest.Mock };
+    enrollment: { findFirst: jest.Mock; findMany: jest.Mock };
+    module: { findUnique: jest.Mock };
+    studyPlan: {
+      create: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+    };
+    theoryModule: { update: jest.Mock };
+    aiExamBank: { update: jest.Mock };
+    $transaction: jest.Mock;
+  };
+  let theory: { generate: jest.Mock; getById: jest.Mock; deleteById: jest.Mock };
+  let exercises: { generateForTopics: jest.Mock };
+  let aiExams: { generateForTopics: jest.Mock; getBank: jest.Mock; deleteBank: jest.Mock };
+  let service: StudyPlansService;
+
+  const theoryResult = { id: 'tm-1', title: 'Fracciones', summary: 'resumen', lessons: [] };
+  const examResult = {
+    id: 'bank-1',
+    title: 'Simulacro',
+    topic: 'Fracciones · Ecuaciones',
+    numQuestions: 5,
+    timeLimit: null,
+    onlyOnce: false,
+    attemptCount: 0,
+    questions: [],
+  };
+  const exercisesResult = {
+    exercises: [
+      {
+        topicLabel: 'Fracciones',
+        statement: 'x',
+        type: 'OPEN',
+        options: [],
+        solution: 'y',
+        explanation: 'z',
+      },
+    ],
+  };
+
+  // Matrículas: curso base de Matemáticas; opcionalmente también Lengua.
+  const mathEnrollment = {
+    id: 'enr-1',
+    courseId: 'course-mates',
+    course: { id: 'course-mates', subject: 'Matemáticas' },
+  };
+  const lenguaEnrollment = {
+    id: 'enr-2',
+    courseId: 'course-lengua',
+    course: { id: 'course-lengua', subject: 'Lengua' },
+  };
+
+  function stubPlanForGetById(over: Record<string, unknown> = {}) {
+    prisma.studyPlan.findUnique.mockResolvedValue({
+      id: 'plan-1',
+      userId: 'user-1',
+      courseId: 'course-mates',
+      title: 'Simulacro: Fracciones',
+      summary: 'resumen',
+      difficulty: 'MEDIUM',
+      createdAt: new Date(),
+      exercises: exercisesResult.exercises,
+      course: { id: 'course-mates', title: 'Matemáticas 3º ESO' },
+      topics: [
+        {
+          id: 'topic-0',
+          order: 0,
+          source: 'CUSTOM',
+          moduleId: null,
+          title: 'Fracciones',
+          subject: null,
+          contextCourseId: 'course-mates',
+          theoryModule: { id: 'tm-1' },
+        },
+      ],
+      examBank: { id: 'bank-1' },
+      ...over,
+    });
+  }
+
+  beforeEach(() => {
+    prisma = {
+      course: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'course-mates', title: 'Matemáticas 3º ESO' }),
+      },
+      enrollment: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'enr-1' }),
+        findMany: jest.fn().mockResolvedValue([mathEnrollment]),
+      },
+      module: { findUnique: jest.fn() },
+      studyPlan: {
+        create: jest.fn().mockResolvedValue({
+          id: 'plan-1',
+          topics: [
+            {
+              id: 'topic-0',
+              order: 0,
+              title: 'Fracciones',
+              contextCourseId: 'course-mates',
+            },
+          ],
+        }),
+        update: jest.fn().mockResolvedValue({}),
+        delete: jest.fn().mockResolvedValue({}),
+        findUnique: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      theoryModule: { update: jest.fn().mockResolvedValue({}) },
+      aiExamBank: { update: jest.fn().mockResolvedValue({}) },
+      $transaction: jest.fn((ops: unknown[]) => Promise.all(ops)),
+    };
+    theory = {
+      generate: jest.fn().mockResolvedValue(theoryResult),
+      getById: jest.fn().mockResolvedValue(theoryResult),
+      deleteById: jest.fn().mockResolvedValue(undefined),
+    };
+    exercises = { generateForTopics: jest.fn().mockResolvedValue(exercisesResult) };
+    aiExams = {
+      generateForTopics: jest.fn().mockResolvedValue(examResult),
+      getBank: jest.fn().mockResolvedValue(examResult),
+      deleteBank: jest.fn().mockResolvedValue({ ok: true }),
+    };
+    service = new StudyPlansService(
+      prisma as never,
+      theory as never,
+      exercises as never,
+      aiExams as never,
+    );
+  });
+
+  // ─── resolveAndAssertTopics: regla de coherencia (criterio 2) ─────────────
+
+  describe('resolveAndAssertTopics', () => {
+    it('rechaza con 422 un tema con subject de una materia NO matriculada, listando las válidas', async () => {
+      // Matriculado solo en Matemáticas → "lengua" no es coherente
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [
+          { title: 'análisis morfológico', subject: 'lengua' },
+        ]),
+      ).rejects.toThrow(UnprocessableEntityException);
+
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [
+          { title: 'análisis morfológico', subject: 'lengua' },
+        ]),
+      ).rejects.toThrow(/Materias válidas: Matemáticas/);
+    });
+
+    it('acepta un tema con subject matriculado, ignorando mayúsculas y acentos', async () => {
+      // "matematicas" (sin tilde, minúsculas) debe casar con "Matemáticas"
+      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+        { title: 'ecuaciones de segundo grado', subject: 'matematicas' },
+      ]);
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].source).toBe('CUSTOM');
+      expect(resolved[0].contextCourseId).toBe('course-mates');
+      expect(resolved[0].subject).toBe('matematicas');
+    });
+
+    it('atribuye a la asignatura base un tema libre sin subject', async () => {
+      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+        { title: 'proporcionalidad' },
+      ]);
+      expect(resolved[0]).toMatchObject({
+        source: 'CUSTOM',
+        moduleId: null,
+        title: 'proporcionalidad',
+        subject: null,
+        contextCourseId: 'course-mates',
+      });
+    });
+
+    it('resuelve un tema de otra asignatura matriculada con el contexto de esa asignatura', async () => {
+      // Matriculado en Mates + Lengua → "análisis morfológico" (lengua) es coherente
+      prisma.enrollment.findMany.mockResolvedValue([mathEnrollment, lenguaEnrollment]);
+
+      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+        { title: 'análisis morfológico', subject: 'lengua' },
+      ]);
+      expect(resolved[0].contextCourseId).toBe('course-lengua');
+      expect(resolved[0].source).toBe('CUSTOM');
+    });
+
+    it('resuelve un tema oficial (moduleId) copiando título y curso del módulo', async () => {
+      prisma.module.findUnique.mockResolvedValue({
+        id: 'mod-1',
+        title: 'Tema 1 — Fracciones',
+        courseId: 'course-mates',
+      });
+
+      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+        { moduleId: 'mod-1' },
+      ]);
+      expect(resolved[0]).toMatchObject({
+        source: 'OFFICIAL',
+        moduleId: 'mod-1',
+        title: 'Tema 1 — Fracciones',
+        contextCourseId: 'course-mates',
+      });
+    });
+
+    it('rechaza con 404 un moduleId inexistente', async () => {
+      prisma.module.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [{ moduleId: 'mod-fake' }]),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rechaza con 403 un módulo de un curso donde el alumno NO está matriculado', async () => {
+      prisma.module.findUnique.mockResolvedValue({
+        id: 'mod-2',
+        title: 'Sintaxis',
+        courseId: 'course-lengua', // solo matriculado en Mates
+      });
+
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [{ moduleId: 'mod-2' }]),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rechaza con 422 temas duplicados por moduleId', async () => {
+      prisma.module.findUnique.mockResolvedValue({
+        id: 'mod-1',
+        title: 'Fracciones',
+        courseId: 'course-mates',
+      });
+
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [
+          { moduleId: 'mod-1' },
+          { moduleId: 'mod-1' },
+        ]),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('rechaza con 422 temas duplicados por título normalizado (acentos/mayúsculas)', async () => {
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [
+          { title: 'Ecuaciones' },
+          { title: '  ecuaciónes '.replace('ó', 'o') }, // "ecuaciones" normalizado
+        ]),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('rechaza con 400 un tema con moduleId y title a la vez', async () => {
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [
+          { moduleId: 'mod-1', title: 'Fracciones' },
+        ]),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rechaza con 400 un subject acompañando a un moduleId', async () => {
+      await expect(
+        service.resolveAndAssertTopics('user-1', 'course-mates', [
+          { moduleId: 'mod-1', subject: 'lengua' } as never,
+        ]),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── create: orquestación y fallos (criterio 5) ────────────────────────────
+
+  describe('create', () => {
+    const dto = {
+      courseId: 'course-mates',
+      topics: [{ title: 'Fracciones' }],
+      numExercises: 5,
+      difficulty: 'MEDIUM' as const,
+      numQuestions: 5 as const,
+    };
+
+    it('rechaza con 422 si numQuestions < número de temas', async () => {
+      await expect(
+        service.create('user-1', {
+          ...dto,
+          numQuestions: 5,
+          topics: [
+            { title: 'tema uno' },
+            { title: 'tema dos' },
+            { title: 'tema tres' },
+            { title: 'tema cuatro' },
+            { title: 'tema cinco' },
+            { title: 'tema seis' },
+          ],
+        }),
+      ).rejects.toThrow(UnprocessableEntityException);
+      expect(prisma.studyPlan.create).not.toHaveBeenCalled();
+    });
+
+    it('crea el plan, genera teoría con el contexto de cada tema y enlaza las secciones', async () => {
+      stubPlanForGetById();
+      const result = await service.create('user-1', dto);
+
+      expect(prisma.studyPlan.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: 'Simulacro: Fracciones',
+            difficulty: 'MEDIUM',
+          }),
+        }),
+      );
+      expect(theory.generate).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-mates',
+        topic: 'Fracciones',
+      });
+      expect(exercises.generateForTopics).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ topics: ['Fracciones'], count: 5, difficulty: 'MEDIUM' }),
+      );
+      expect(aiExams.generateForTopics).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ topics: ['Fracciones'], numQuestions: 5 }),
+      );
+      expect(prisma.theoryModule.update).toHaveBeenCalledWith({
+        where: { id: 'tm-1' },
+        data: { studyPlanTopicId: 'topic-0' },
+      });
+      expect(prisma.aiExamBank.update).toHaveBeenCalledWith({
+        where: { id: 'bank-1' },
+        data: { studyPlanId: 'plan-1' },
+      });
+      expect(result.sections).toEqual({ theory: true, exercises: true, exam: true });
+    });
+
+    it('la teoría de cada tema usa su contextCourseId (tema de otra asignatura)', async () => {
+      prisma.enrollment.findMany.mockResolvedValue([mathEnrollment, lenguaEnrollment]);
+      prisma.studyPlan.create.mockResolvedValue({
+        id: 'plan-1',
+        topics: [
+          { id: 'topic-0', order: 0, title: 'Fracciones', contextCourseId: 'course-mates' },
+          {
+            id: 'topic-1',
+            order: 1,
+            title: 'análisis morfológico',
+            contextCourseId: 'course-lengua',
+          },
+        ],
+      });
+      stubPlanForGetById();
+
+      await service.create('user-1', {
+        ...dto,
+        topics: [{ title: 'Fracciones' }, { title: 'análisis morfológico', subject: 'lengua' }],
+      });
+
+      expect(theory.generate).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-mates',
+        topic: 'Fracciones',
+      });
+      expect(theory.generate).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-lengua',
+        topic: 'análisis morfológico',
+      });
+    });
+
+    it('fallo parcial: si la teoría falla pero el resto no, el plan se crea sin ese enlace', async () => {
+      theory.generate.mockRejectedValue(new Error('IA caída'));
+      stubPlanForGetById({
+        topics: [
+          {
+            id: 'topic-0',
+            order: 0,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'Fracciones',
+            subject: null,
+            contextCourseId: 'course-mates',
+            theoryModule: null, // sin deck
+          },
+        ],
+      });
+
+      const result = await service.create('user-1', dto);
+
+      expect(prisma.studyPlan.delete).not.toHaveBeenCalled();
+      expect(prisma.theoryModule.update).not.toHaveBeenCalled();
+      expect(prisma.aiExamBank.update).toHaveBeenCalled(); // el examen sí se enlaza
+      expect(result.sections.theory).toBe(false);
+      expect(result.topics[0].hasTheory).toBe(false);
+    });
+
+    it('fallo total: si TODO falla, borra la cáscara y lanza 500 (sin plan huérfano)', async () => {
+      theory.generate.mockRejectedValue(new Error('IA caída'));
+      exercises.generateForTopics.mockRejectedValue(new Error('IA caída'));
+      aiExams.generateForTopics.mockRejectedValue(new Error('IA caída'));
+
+      await expect(service.create('user-1', dto)).rejects.toThrow(InternalServerErrorException);
+      expect(prisma.studyPlan.delete).toHaveBeenCalledWith({ where: { id: 'plan-1' } });
+    });
+
+    it('si el enlace transaccional falla, borra la cáscara y propaga el error', async () => {
+      prisma.$transaction.mockRejectedValue(new Error('conexión perdida'));
+
+      await expect(service.create('user-1', dto)).rejects.toThrow('conexión perdida');
+      expect(prisma.studyPlan.delete).toHaveBeenCalledWith({ where: { id: 'plan-1' } });
+    });
+  });
+
+  // ─── getById / deleteById: ownership ────────────────────────────────────────
+
+  describe('getById', () => {
+    it('lanza 404 si el plan no existe', async () => {
+      prisma.studyPlan.findUnique.mockResolvedValue(null);
+      await expect(service.getById('user-1', 'plan-fake')).rejects.toThrow(NotFoundException);
+    });
+
+    it('lanza 403 si el plan es de otro usuario', async () => {
+      stubPlanForGetById({ userId: 'user-2' });
+      await expect(service.getById('user-1', 'plan-1')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('devuelve el examen vía aiExams.getBank (serialización sin isCorrect)', async () => {
+      stubPlanForGetById();
+      const result = await service.getById('user-1', 'plan-1');
+      // getBank es el único camino al examen: su serialización ya oculta isCorrect
+      expect(aiExams.getBank).toHaveBeenCalledWith('user-1', 'bank-1');
+      expect(result.exam).toBe(examResult);
+      expect(JSON.stringify(result.exam)).not.toContain('isCorrect');
+    });
+  });
+
+  describe('regenerateTopicTheory', () => {
+    it('regenera el deck de un tema fallido y lo enlaza al tema', async () => {
+      stubPlanForGetById({
+        topics: [
+          {
+            id: 'topic-0',
+            order: 0,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'Fracciones',
+            subject: null,
+            contextCourseId: 'course-mates',
+            theoryModule: null,
+          },
+        ],
+      });
+
+      await service.regenerateTopicTheory('user-1', 'plan-1', 'topic-0');
+
+      expect(theory.deleteById).not.toHaveBeenCalled(); // no había deck previo
+      expect(theory.generate).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-mates',
+        topic: 'Fracciones',
+      });
+      expect(prisma.theoryModule.update).toHaveBeenCalledWith({
+        where: { id: 'tm-1' },
+        data: { studyPlanTopicId: 'topic-0' },
+      });
+    });
+
+    it('lanza 404 si el tema no pertenece al plan', async () => {
+      stubPlanForGetById();
+      await expect(
+        service.regenerateTopicTheory('user-1', 'plan-1', 'topic-ajeno'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/study-plans/study-plans.service.ts
+++ b/apps/api/src/study-plans/study-plans.service.ts
@@ -186,6 +186,12 @@ export class StudyPlansService {
           `necesitas numQuestions ≥ ${dto.topics.length}`,
       );
     }
+    if (dto.numExercises < dto.topics.length) {
+      throw new UnprocessableEntityException(
+        `Debe haber al menos 1 ejercicio por tema: con ${dto.topics.length} temas ` +
+          `necesitas numExercises ≥ ${dto.topics.length}`,
+      );
+    }
 
     const resolvedTopics = await this.resolveAndAssertTopics(userId, dto.courseId, dto.topics);
 
@@ -288,8 +294,21 @@ export class StudyPlansService {
     try {
       await this.prisma.$transaction(ops);
     } catch (err) {
-      // Si el enlace transaccional falla, no dejar un plan cáscara huérfano.
-      await this.prisma.studyPlan.delete({ where: { id: plan.id } });
+      // Si el enlace transaccional falla, no dejar huérfanos: ni el plan cáscara
+      // ni los decks/banco ya generados pero sin enlazar (quedarían sueltos en la
+      // biblioteca del alumno, indistinguibles de los creados a mano).
+      const generatedTheoryIds = theoryResults.flatMap((r) =>
+        r.status === 'fulfilled' ? [r.value.id] : [],
+      );
+      await Promise.allSettled([
+        ...generatedTheoryIds.map((theoryId) =>
+          this.prisma.theoryModule.delete({ where: { id: theoryId } }),
+        ),
+        ...(examRes.status === 'fulfilled'
+          ? [this.prisma.aiExamBank.delete({ where: { id: examRes.value.id } })]
+          : []),
+        this.prisma.studyPlan.delete({ where: { id: plan.id } }),
+      ]);
       throw err;
     }
 
@@ -393,11 +412,12 @@ export class StudyPlansService {
     const topic = plan.topics.find((t) => t.id === topicId);
     if (!topic) throw new NotFoundException('Tema no encontrado en este plan');
 
-    if (topic.theoryModule) await this.theory.deleteById(userId, topic.theoryModule.id);
+    // Generar primero: si la IA falla, el deck anterior (si existía) queda intacto.
     const theory = await this.theory.generate(userId, {
       courseId: topic.contextCourseId,
       topic: topic.title,
     });
+    if (topic.theoryModule) await this.theory.deleteById(userId, topic.theoryModule.id);
     await this.prisma.theoryModule.update({
       where: { id: theory.id },
       data: { studyPlanTopicId: topic.id },
@@ -409,7 +429,13 @@ export class StudyPlansService {
   async regenerateExercises(userId: string, planId: string, dto: RegenerateExercisesDto) {
     const plan = await this.requireOwnedPlan(userId, planId);
     const prevCount = Array.isArray(plan.exercises) ? (plan.exercises as unknown[]).length : 0;
-    const count = dto.count ?? (prevCount > 0 ? prevCount : 5);
+    const count = dto.count ?? (prevCount > 0 ? prevCount : Math.max(5, plan.topics.length));
+    if (count < plan.topics.length) {
+      throw new UnprocessableEntityException(
+        `Debe haber al menos 1 ejercicio por tema: con ${plan.topics.length} temas ` +
+          `necesitas count ≥ ${plan.topics.length}`,
+      );
+    }
     const res = await this.exercises.generateForTopics(userId, {
       courseId: plan.courseId,
       topics: plan.topics.map((t) => t.title),
@@ -433,7 +459,7 @@ export class StudyPlansService {
           `necesitas numQuestions ≥ ${plan.topics.length}`,
       );
     }
-    if (plan.examBank) await this.aiExams.deleteBank(userId, plan.examBank.id);
+    // Generar primero: si la IA falla, el banco anterior (si existía) queda intacto.
     const bank = await this.aiExams.generateForTopics(userId, {
       courseId: plan.courseId,
       topics: plan.topics.map((t) => t.title),
@@ -442,6 +468,7 @@ export class StudyPlansService {
       onlyOnce: dto.onlyOnce ?? plan.examBank?.onlyOnce,
       difficulty: plan.difficulty as 'EASY' | 'MEDIUM' | 'HARD',
     });
+    if (plan.examBank) await this.aiExams.deleteBank(userId, plan.examBank.id);
     await this.prisma.aiExamBank.update({
       where: { id: bank.id },
       data: { studyPlanId: plan.id },

--- a/apps/api/src/study-plans/study-plans.service.ts
+++ b/apps/api/src/study-plans/study-plans.service.ts
@@ -1,0 +1,491 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { Prisma, StudyTopicSource } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { TheoryService } from '../theory/theory.service';
+import { ExercisesService, GeneratedTopicExercise } from '../exercises/exercises.service';
+import { AiExamsService } from '../exams/ai-exams.service';
+import { CreateStudyPlanDto, StudyPlanTopicInputDto } from './dto/create-study-plan.dto';
+import { RegenerateExercisesDto } from '../study/dto/regenerate-exercises.dto';
+import { RegenerateExamDto } from '../study/dto/regenerate-exam.dto';
+
+// Tema del payload ya resuelto contra matrículas y temario (regla de coherencia).
+export interface ResolvedTopic {
+  source: StudyTopicSource;
+  moduleId: string | null;
+  title: string;
+  subject: string | null;
+  contextCourseId: string;
+}
+
+/**
+ * Plan de estudio multi-tema: combina N temas (oficiales del temario o libres)
+ * en teoría POR TEMA (N decks) + ejercicios y examen COMBINADOS (1 llamada
+ * cada uno), simulando exámenes reales. Flujo adicional al un-tema
+ * (StudyService/StudyUnit), que no se toca. Personal (scoped por userId).
+ */
+@Injectable()
+export class StudyPlansService {
+  private readonly logger = new Logger(StudyPlansService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly theory: TheoryService,
+    private readonly exercises: ExercisesService,
+    private readonly aiExams: AiExamsService,
+  ) {}
+
+  // Normalización para comparar materias y detectar duplicados: minúsculas y sin acentos.
+  private normalize(s: string): string {
+    return s
+      .trim()
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '');
+  }
+
+  private async assertEnrolled(userId: string, courseId: string): Promise<void> {
+    const course = await this.prisma.course.findUnique({ where: { id: courseId } });
+    if (!course) throw new NotFoundException(`Curso "${courseId}" no encontrado`);
+    const enrollment = await this.prisma.enrollment.findFirst({ where: { userId, courseId } });
+    if (!enrollment) throw new ForbiddenException('No estás matriculado en este curso');
+  }
+
+  /**
+   * Regla de coherencia (determinista, sin IA) — única fuente de verdad, se
+   * ejecuta dentro del create. Para cada tema del payload, en orden:
+   *  1. moduleId (OFFICIAL): válido si el alumno está matriculado en el curso
+   *     del módulo (base u otro). contextCourseId = curso del módulo.
+   *  2. title sin subject (CUSTOM in-subject): coherente por construcción,
+   *     se atribuye a la asignatura base. contextCourseId = curso base.
+   *  3. title con subject (CUSTOM fuera de asignatura): válido si y solo si el
+   *     alumno está matriculado en ≥1 curso de esa materia (comparación
+   *     normalizada). contextCourseId = primer curso matriculado de la materia.
+   * Además: sin temas duplicados (mismo moduleId o mismo título normalizado).
+   */
+  async resolveAndAssertTopics(
+    userId: string,
+    baseCourseId: string,
+    topics: StudyPlanTopicInputDto[],
+  ): Promise<ResolvedTopic[]> {
+    const enrollments = await this.prisma.enrollment.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'asc' },
+      include: { course: { select: { id: true, subject: true } } },
+    });
+    const enrolledCourseIds = new Set(enrollments.map((e) => e.courseId));
+
+    const resolved: ResolvedTopic[] = [];
+    for (const input of topics) {
+      const hasModule = typeof input.moduleId === 'string' && input.moduleId.length > 0;
+      const hasTitle = typeof input.title === 'string' && input.title.trim().length > 0;
+      if (hasModule === hasTitle) {
+        throw new BadRequestException(
+          'Cada tema debe llevar moduleId (tema oficial) o title (tema propio), pero no ambos',
+        );
+      }
+      if (!hasTitle && input.subject) {
+        throw new BadRequestException(
+          'subject solo puede acompañar a un tema propio (title), no a un tema oficial',
+        );
+      }
+
+      if (hasModule) {
+        // 1. Tema oficial del temario
+        const module = await this.prisma.module.findUnique({
+          where: { id: input.moduleId },
+          select: { id: true, title: true, courseId: true },
+        });
+        if (!module) {
+          throw new NotFoundException(`Módulo "${input.moduleId}" no encontrado`);
+        }
+        if (!enrolledCourseIds.has(module.courseId)) {
+          throw new ForbiddenException(
+            `No estás matriculado en el curso al que pertenece el tema "${module.title}"`,
+          );
+        }
+        resolved.push({
+          source: StudyTopicSource.OFFICIAL,
+          moduleId: module.id,
+          title: module.title,
+          subject: null,
+          contextCourseId: module.courseId,
+        });
+      } else if (!input.subject) {
+        // 2. Tema propio sin materia: se atribuye a la asignatura base
+        resolved.push({
+          source: StudyTopicSource.CUSTOM,
+          moduleId: null,
+          title: input.title!.trim(),
+          subject: null,
+          contextCourseId: baseCourseId,
+        });
+      } else {
+        // 3. Tema propio de otra asignatura: exige matrícula en esa materia
+        const wanted = this.normalize(input.subject);
+        const match = enrollments.find(
+          (e) => e.course.subject && this.normalize(e.course.subject) === wanted,
+        );
+        if (!match) {
+          const subjects = [
+            ...new Set(
+              enrollments
+                .map((e) => e.course.subject)
+                .filter((s): s is string => !!s && s.trim().length > 0),
+            ),
+          ];
+          throw new UnprocessableEntityException(
+            `El tema "${input.title!.trim()}" está etiquetado como "${input.subject.trim()}", ` +
+              `pero no estás matriculado en ninguna asignatura de esa materia. ` +
+              `Materias válidas: ${subjects.join(', ') || '(ninguna)'}`,
+          );
+        }
+        resolved.push({
+          source: StudyTopicSource.CUSTOM,
+          moduleId: null,
+          title: input.title!.trim(),
+          subject: input.subject.trim(),
+          contextCourseId: match.courseId,
+        });
+      }
+    }
+
+    // Sin temas duplicados: mismo módulo o mismo título normalizado
+    const seenModules = new Set<string>();
+    const seenTitles = new Set<string>();
+    for (const topic of resolved) {
+      if (topic.moduleId) {
+        if (seenModules.has(topic.moduleId)) {
+          throw new UnprocessableEntityException(`Tema duplicado: "${topic.title}"`);
+        }
+        seenModules.add(topic.moduleId);
+      }
+      const normTitle = this.normalize(topic.title);
+      if (seenTitles.has(normTitle)) {
+        throw new UnprocessableEntityException(`Tema duplicado: "${topic.title}"`);
+      }
+      seenTitles.add(normTitle);
+    }
+
+    return resolved;
+  }
+
+  async create(userId: string, dto: CreateStudyPlanDto) {
+    await this.assertEnrolled(userId, dto.courseId);
+
+    if (dto.numQuestions < dto.topics.length) {
+      throw new UnprocessableEntityException(
+        `El examen debe tener al menos 1 pregunta por tema: con ${dto.topics.length} temas ` +
+          `necesitas numQuestions ≥ ${dto.topics.length}`,
+      );
+    }
+
+    const resolvedTopics = await this.resolveAndAssertTopics(userId, dto.courseId, dto.topics);
+
+    // Plan "cáscara" + temas en una transacción (nested create)
+    const plan = await this.prisma.studyPlan.create({
+      data: {
+        userId,
+        courseId: dto.courseId,
+        title: this.buildTitle(resolvedTopics),
+        summary: '',
+        difficulty: dto.difficulty,
+        topics: {
+          create: resolvedTopics.map((t, i) => ({
+            order: i,
+            source: t.source,
+            moduleId: t.moduleId,
+            title: t.title,
+            subject: t.subject,
+            contextCourseId: t.contextCourseId,
+          })),
+        },
+      },
+      include: { topics: { orderBy: { order: 'asc' } } },
+    });
+
+    // N teorías (una por tema, con su curso de contexto) + ejercicios y examen
+    // combinados. allSettled: una sección que falle no tumba las demás.
+    const topicTitles = plan.topics.map((t) => t.title);
+    const [theoryResults, [exercisesRes], [examRes]] = await Promise.all([
+      Promise.allSettled(
+        plan.topics.map((t) =>
+          this.theory.generate(userId, { courseId: t.contextCourseId, topic: t.title }),
+        ),
+      ),
+      Promise.allSettled([
+        this.exercises.generateForTopics(userId, {
+          courseId: dto.courseId,
+          topics: topicTitles,
+          count: dto.numExercises,
+          difficulty: dto.difficulty,
+        }),
+      ]),
+      Promise.allSettled([
+        this.aiExams.generateForTopics(userId, {
+          courseId: dto.courseId,
+          topics: topicTitles,
+          numQuestions: dto.numQuestions,
+          timeLimit: dto.timeLimit,
+          onlyOnce: dto.onlyOnce,
+          difficulty: dto.difficulty,
+        }),
+      ]),
+    ]);
+
+    const allFailed =
+      theoryResults.every((r) => r.status === 'rejected') &&
+      exercisesRes.status === 'rejected' &&
+      examRes.status === 'rejected';
+    if (allFailed) {
+      this.logger.error('Todas las secciones fallaron al generar el plan de estudio');
+      await this.prisma.studyPlan.delete({ where: { id: plan.id } });
+      throw new InternalServerErrorException(
+        'No se pudo generar ninguna sección. Inténtalo de nuevo en unos segundos.',
+      );
+    }
+
+    // Enlace transaccional de lo logrado; lo fallido queda regenerable por sección.
+    const ops: Prisma.PrismaPromise<unknown>[] = [];
+    const data: Prisma.StudyPlanUpdateInput = {};
+    const summaries: string[] = [];
+    theoryResults.forEach((res, i) => {
+      if (res.status === 'fulfilled') {
+        ops.push(
+          this.prisma.theoryModule.update({
+            where: { id: res.value.id },
+            data: { studyPlanTopicId: plan.topics[i].id },
+          }) as unknown as Prisma.PrismaPromise<unknown>,
+        );
+        if (res.value.summary) summaries.push(res.value.summary);
+      }
+    });
+    if (exercisesRes.status === 'fulfilled') {
+      data.exercises = exercisesRes.value.exercises as unknown as Prisma.InputJsonValue;
+    }
+    if (examRes.status === 'fulfilled') {
+      ops.push(
+        this.prisma.aiExamBank.update({
+          where: { id: examRes.value.id },
+          data: { studyPlanId: plan.id },
+        }) as unknown as Prisma.PrismaPromise<unknown>,
+      );
+    }
+    data.summary = summaries.join(' · ').slice(0, 600);
+    ops.push(
+      this.prisma.studyPlan.update({
+        where: { id: plan.id },
+        data,
+      }) as unknown as Prisma.PrismaPromise<unknown>,
+    );
+    try {
+      await this.prisma.$transaction(ops);
+    } catch (err) {
+      // Si el enlace transaccional falla, no dejar un plan cáscara huérfano.
+      await this.prisma.studyPlan.delete({ where: { id: plan.id } });
+      throw err;
+    }
+
+    return this.getById(userId, plan.id);
+  }
+
+  private buildTitle(topics: { title: string }[]): string {
+    return `Simulacro: ${topics.map((t) => t.title).join(' · ')}`.slice(0, 200);
+  }
+
+  async listMine(userId: string) {
+    const plans = await this.prisma.studyPlan.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        course: { select: { id: true, title: true } },
+        topics: {
+          orderBy: { order: 'asc' },
+          include: { theoryModule: { select: { id: true } } },
+        },
+        examBank: { select: { id: true } },
+      },
+    });
+    return plans.map((p) => ({
+      id: p.id,
+      title: p.title,
+      summary: p.summary,
+      difficulty: p.difficulty,
+      createdAt: p.createdAt.toISOString(),
+      course: p.course,
+      topics: p.topics.map((t) => this.serializeTopic(t)),
+      sections: {
+        theory: p.topics.length > 0 && p.topics.every((t) => !!t.theoryModule),
+        exercises: Array.isArray(p.exercises) && (p.exercises as unknown[]).length > 0,
+        exam: !!p.examBank,
+      },
+    }));
+  }
+
+  async getById(userId: string, id: string) {
+    const plan = await this.prisma.studyPlan.findUnique({
+      where: { id },
+      include: {
+        course: { select: { id: true, title: true } },
+        topics: {
+          orderBy: { order: 'asc' },
+          include: { theoryModule: { select: { id: true } } },
+        },
+        examBank: { select: { id: true } },
+      },
+    });
+    if (!plan) throw new NotFoundException('Plan de estudio no encontrado');
+    if (plan.userId !== userId) throw new ForbiddenException('No tienes acceso a este plan');
+
+    const topics = await Promise.all(
+      plan.topics.map(async (t) => ({
+        ...this.serializeTopic(t),
+        theory: t.theoryModule ? await this.theory.getById(userId, t.theoryModule.id) : null,
+      })),
+    );
+    // getBank serializa SIN isCorrect (mismo camino que StudyService.getById)
+    const exam = plan.examBank ? await this.aiExams.getBank(userId, plan.examBank.id) : null;
+    const exercises = Array.isArray(plan.exercises)
+      ? (plan.exercises as unknown as GeneratedTopicExercise[])
+      : null;
+
+    return {
+      id: plan.id,
+      title: plan.title,
+      summary: plan.summary,
+      difficulty: plan.difficulty,
+      createdAt: plan.createdAt.toISOString(),
+      course: plan.course,
+      topics,
+      sections: {
+        theory: topics.length > 0 && topics.every((t) => t.hasTheory),
+        exercises: !!exercises && exercises.length > 0,
+        exam: !!exam,
+      },
+      exercises,
+      exam,
+    };
+  }
+
+  async deleteById(userId: string, id: string): Promise<void> {
+    const plan = await this.prisma.studyPlan.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    });
+    if (!plan) throw new NotFoundException('Plan de estudio no encontrado');
+    if (plan.userId !== userId) throw new ForbiddenException('No tienes acceso a este plan');
+    // Cascade: topics → decks de teoría; examBank vía studyPlanId
+    await this.prisma.studyPlan.delete({ where: { id } });
+  }
+
+  // ── Regeneración por sección (para reintentar tras un fallo de IA) ──
+
+  /** Regenera el deck de teoría de UN tema del plan. */
+  async regenerateTopicTheory(userId: string, planId: string, topicId: string) {
+    const plan = await this.requireOwnedPlan(userId, planId);
+    const topic = plan.topics.find((t) => t.id === topicId);
+    if (!topic) throw new NotFoundException('Tema no encontrado en este plan');
+
+    if (topic.theoryModule) await this.theory.deleteById(userId, topic.theoryModule.id);
+    const theory = await this.theory.generate(userId, {
+      courseId: topic.contextCourseId,
+      topic: topic.title,
+    });
+    await this.prisma.theoryModule.update({
+      where: { id: theory.id },
+      data: { studyPlanTopicId: topic.id },
+    });
+    return this.getById(userId, planId);
+  }
+
+  /** Regenera los ejercicios combinados del plan. */
+  async regenerateExercises(userId: string, planId: string, dto: RegenerateExercisesDto) {
+    const plan = await this.requireOwnedPlan(userId, planId);
+    const prevCount = Array.isArray(plan.exercises) ? (plan.exercises as unknown[]).length : 0;
+    const count = dto.count ?? (prevCount > 0 ? prevCount : 5);
+    const res = await this.exercises.generateForTopics(userId, {
+      courseId: plan.courseId,
+      topics: plan.topics.map((t) => t.title),
+      count,
+      difficulty: plan.difficulty as 'EASY' | 'MEDIUM' | 'HARD',
+    });
+    await this.prisma.studyPlan.update({
+      where: { id: plan.id },
+      data: { exercises: res.exercises as unknown as Prisma.InputJsonValue },
+    });
+    return this.getById(userId, planId);
+  }
+
+  /** Regenera el examen combinado del plan. */
+  async regenerateExam(userId: string, planId: string, dto: RegenerateExamDto) {
+    const plan = await this.requireOwnedPlan(userId, planId);
+    const numQuestions = dto.numQuestions ?? plan.examBank?.numQuestions ?? 5;
+    if (numQuestions < plan.topics.length) {
+      throw new UnprocessableEntityException(
+        `El examen debe tener al menos 1 pregunta por tema: con ${plan.topics.length} temas ` +
+          `necesitas numQuestions ≥ ${plan.topics.length}`,
+      );
+    }
+    if (plan.examBank) await this.aiExams.deleteBank(userId, plan.examBank.id);
+    const bank = await this.aiExams.generateForTopics(userId, {
+      courseId: plan.courseId,
+      topics: plan.topics.map((t) => t.title),
+      numQuestions,
+      timeLimit: dto.timeLimit ?? plan.examBank?.timeLimit ?? undefined,
+      onlyOnce: dto.onlyOnce ?? plan.examBank?.onlyOnce,
+      difficulty: plan.difficulty as 'EASY' | 'MEDIUM' | 'HARD',
+    });
+    await this.prisma.aiExamBank.update({
+      where: { id: bank.id },
+      data: { studyPlanId: plan.id },
+    });
+    return this.getById(userId, planId);
+  }
+
+  // ── Helpers ──
+
+  private serializeTopic(topic: {
+    id: string;
+    order: number;
+    source: StudyTopicSource;
+    moduleId: string | null;
+    title: string;
+    subject: string | null;
+    theoryModule: { id: string } | null;
+  }) {
+    return {
+      id: topic.id,
+      order: topic.order,
+      source: topic.source,
+      moduleId: topic.moduleId,
+      title: topic.title,
+      subject: topic.subject,
+      hasTheory: !!topic.theoryModule,
+    };
+  }
+
+  private async requireOwnedPlan(userId: string, id: string) {
+    const plan = await this.prisma.studyPlan.findUnique({
+      where: { id },
+      include: {
+        topics: {
+          orderBy: { order: 'asc' },
+          include: { theoryModule: { select: { id: true } } },
+        },
+        examBank: {
+          select: { id: true, numQuestions: true, timeLimit: true, onlyOnce: true },
+        },
+      },
+    });
+    if (!plan) throw new NotFoundException('Plan de estudio no encontrado');
+    if (plan.userId !== userId) throw new ForbiddenException('No tienes acceso a este plan');
+    return plan;
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,8 @@ const TeacherPortalPage = lazy(() => import('./pages/TeacherPortalPage'));
 const ExamPage = lazy(() => import('./pages/ExamPage'));
 const StudyPage = lazy(() => import('./pages/StudyPage'));
 const StudyUnitPage = lazy(() => import('./pages/StudyUnitPage'));
+const StudyPlanCreatePage = lazy(() => import('./pages/StudyPlanCreatePage'));
+const StudyPlanPage = lazy(() => import('./pages/StudyPlanPage'));
 const AdminDashboardPage = lazy(() => import('./pages/admin/AdminDashboardPage'));
 const AdminUsersPage = lazy(() => import('./pages/admin/AdminUsersPage'));
 const AdminCoursesPage = lazy(() => import('./pages/admin/AdminCoursesPage'));
@@ -161,6 +163,8 @@ export default function App() {
 
         {/* Estudiar — curso generado por IA (teoría + ejercicios + examen) */}
         <Route path="study" element={<StudyPage />} />
+        <Route path="study/plan/new" element={<StudyPlanCreatePage />} />
+        <Route path="study/plan/:id" element={<StudyPlanPage />} />
         <Route path="study/:id" element={<StudyUnitPage />} />
 
         {/* Fase 9 — Certificados */}

--- a/apps/web/src/api/study-plans.api.ts
+++ b/apps/web/src/api/study-plans.api.ts
@@ -1,0 +1,28 @@
+import api from '../lib/axios';
+import type {
+  StudyPlanSummary,
+  StudyPlanDetail,
+  CreateStudyPlanRequest,
+  RegenerateExercisesRequest,
+  RegenerateExamRequest,
+} from '@vkbacademy/shared';
+
+export const studyPlansApi = {
+  create: (payload: CreateStudyPlanRequest) =>
+    api.post<StudyPlanDetail>('/study-plans', payload).then((r) => r.data),
+
+  listMine: () => api.get<StudyPlanSummary[]>('/study-plans/mine').then((r) => r.data),
+
+  getById: (id: string) => api.get<StudyPlanDetail>(`/study-plans/${id}`).then((r) => r.data),
+
+  delete: (id: string) => api.delete<void>(`/study-plans/${id}`).then((r) => r.data),
+
+  regenerateTopicTheory: (id: string, topicId: string) =>
+    api.post<StudyPlanDetail>(`/study-plans/${id}/topics/${topicId}/theory`).then((r) => r.data),
+
+  regenerateExercises: (id: string, payload: RegenerateExercisesRequest) =>
+    api.post<StudyPlanDetail>(`/study-plans/${id}/exercises`, payload).then((r) => r.data),
+
+  regenerateExam: (id: string, payload: RegenerateExamRequest) =>
+    api.post<StudyPlanDetail>(`/study-plans/${id}/exam`, payload).then((r) => r.data),
+};

--- a/apps/web/src/hooks/useStudyPlans.ts
+++ b/apps/web/src/hooks/useStudyPlans.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { studyPlansApi } from '../api/study-plans.api';
+import type { CreateStudyPlanRequest } from '@vkbacademy/shared';
+
+export function useMyStudyPlans() {
+  return useQuery({ queryKey: ['study-plans', 'mine'], queryFn: () => studyPlansApi.listMine() });
+}
+
+export function useStudyPlan(id: string) {
+  return useQuery({
+    queryKey: ['study-plans', id],
+    queryFn: () => studyPlansApi.getById(id),
+    enabled: !!id,
+  });
+}
+
+export function useCreateStudyPlan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateStudyPlanRequest) => studyPlansApi.create(payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['study-plans', 'mine'] }),
+  });
+}
+
+export function useDeleteStudyPlan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => studyPlansApi.delete(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['study-plans', 'mine'] }),
+  });
+}
+
+export function useRegenerateTopicTheory(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (topicId: string) => studyPlansApi.regenerateTopicTheory(id, topicId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['study-plans', id] }),
+  });
+}
+
+export function useRegeneratePlanExercises(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (count?: number) => studyPlansApi.regenerateExercises(id, { count }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['study-plans', id] }),
+  });
+}
+
+export function useRegeneratePlanExam(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => studyPlansApi.regenerateExam(id, {}),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['study-plans', id] }),
+  });
+}

--- a/apps/web/src/pages/CoursePage.tsx
+++ b/apps/web/src/pages/CoursePage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useCourse, useCourseProgress } from '../hooks/useCourses';
 import { useExamBankInfo } from '../hooks/useExams';
 import { useMyCertificates } from '../hooks/useCertificates';
@@ -335,6 +335,14 @@ export default function CoursePage() {
             </button>
           </div>
         )}
+
+        {/* CTA: generar plan de estudio multi-tema a partir de este temario */}
+        <div style={S.examCourseBtn}>
+          <Link to={`/study/plan/new?courseId=${courseId}`} className="btn btn-ghost">
+            <Icon name="shapes" size={16} />
+            Generar curso de estudio de este temario
+          </Link>
+        </div>
 
         {/* Módulos */}
         {course.modules?.length ? (

--- a/apps/web/src/pages/StudyPage.tsx
+++ b/apps/web/src/pages/StudyPage.tsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import type { StudyDifficulty } from '@vkbacademy/shared';
 import { useCourses } from '../hooks/useCourses';
 import { useMyStudyUnits, useCreateStudyUnit, useDeleteStudyUnit } from '../hooks/useStudy';
+import { useMyStudyPlans, useDeleteStudyPlan } from '../hooks/useStudyPlans';
+import { getApiErrorMessage } from '../utils/errorMessage';
 import PageHeader from '../components/ui/PageHeader';
 import Icon from '../components/ui/Icon';
 import EmptyState from '../components/ui/EmptyState';
@@ -21,6 +23,9 @@ export default function StudyPage() {
   const { data: units, isLoading: unitsLoading } = useMyStudyUnits();
   const create = useCreateStudyUnit();
   const remove = useDeleteStudyUnit();
+
+  const { data: plans, isLoading: plansLoading } = useMyStudyPlans();
+  const removePlan = useDeleteStudyPlan();
 
   const [courseId, setCourseId] = useState('');
   const [topic, setTopic] = useState('');
@@ -65,6 +70,19 @@ export default function StudyPage() {
         title="Estudiar"
         subtitle="Escribe un tema de una de tus asignaturas y se creará un curso con teoría, ejercicios y un examen, todo generado para ti."
       />
+
+      <Link to="/study/plan/new" className="vkb-card" style={s.planCta}>
+        <span style={s.planCtaIcon}>
+          <Icon name="shapes" size={26} />
+        </span>
+        <span style={s.planCtaBody}>
+          <strong style={s.planCtaTitle}>Simulacro multi-tema</strong>
+          <span style={s.planCtaSubtitle}>
+            Combina varios temas como en un examen real
+          </span>
+        </span>
+        <Icon name="chevron-right" size={18} color="var(--brand-deep)" />
+      </Link>
 
       <form onSubmit={handleSubmit} className="vkb-card" style={s.form}>
         {/* Asignatura + tema */}
@@ -267,6 +285,68 @@ export default function StudyPage() {
           </div>
         )}
       </section>
+
+      <section style={s.results}>
+        <h2 className="section-label">Mis simulacros multi-tema</h2>
+        {removePlan.isError && (
+          <div className="alert alert-error" style={{ marginTop: 14 }}>
+            {getApiErrorMessage(removePlan.error, 'No se pudo borrar el plan. Inténtalo de nuevo.')}
+          </div>
+        )}
+        {plansLoading && <p style={s.muted}>Cargando…</p>}
+        {!plansLoading && (plans?.length ?? 0) === 0 && (
+          <EmptyState
+            icon="shapes"
+            title="Aún no has creado ningún simulacro multi-tema"
+            message="Pulsa arriba en «Simulacro multi-tema» para combinar varios temas."
+          />
+        )}
+        {!plansLoading && (plans?.length ?? 0) > 0 && (
+          <div className="numbered-grid" style={s.list}>
+            {(plans ?? []).map((p, i) => (
+              <article
+                key={p.id}
+                className="vkb-card numbered-card"
+                style={{
+                  ...s.item,
+                  animation: `riseIn 0.5s cubic-bezier(0.18, 0.72, 0.24, 1.12) ${i * 60}ms both`,
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (window.confirm(`¿Borrar "${p.title}"?`)) removePlan.mutate(p.id);
+                  }}
+                  style={s.deleteBtn}
+                  aria-label="Borrar plan"
+                >
+                  <Icon name="close" size={16} />
+                </button>
+                <Link to={`/study/plan/${p.id}`} style={s.itemLink}>
+                  <strong style={s.itemTitle}>{p.title}</strong>
+                  <span style={s.itemMeta}>
+                    {p.course.title} · {p.topics.length} temas
+                  </span>
+                  <span style={s.planSections}>
+                    <span style={p.sections.theory ? s.sectionOk : s.sectionMissing}>Apuntes</span>
+                    <span style={p.sections.exercises ? s.sectionOk : s.sectionMissing}>
+                      Ejercicios
+                    </span>
+                    <span style={p.sections.exam ? s.sectionOk : s.sectionMissing}>Examen</span>
+                  </span>
+                  <span style={s.itemDate}>
+                    {new Date(p.createdAt).toLocaleDateString('es-ES', {
+                      day: '2-digit',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </span>
+                </Link>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   );
 }
@@ -280,6 +360,27 @@ const s: Record<string, React.CSSProperties> = {
     flexDirection: 'column',
     gap: 32,
   },
+  planCta: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    padding: '18px 22px',
+    textDecoration: 'none',
+    cursor: 'pointer',
+  },
+  planCtaIcon: {
+    flex: 'none',
+    width: 52,
+    height: 52,
+    borderRadius: 14,
+    display: 'grid',
+    placeItems: 'center',
+    color: 'var(--brand-deep)',
+    background: 'var(--brand-soft)',
+  },
+  planCtaBody: { flex: 1, display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0 },
+  planCtaTitle: { fontSize: '1.05rem', fontWeight: 800, color: 'var(--color-text)' },
+  planCtaSubtitle: { fontSize: '0.875rem', color: 'var(--color-text-muted)' },
   form: {
     display: 'flex',
     flexDirection: 'column',
@@ -352,6 +453,23 @@ const s: Record<string, React.CSSProperties> = {
   itemTitle: { fontSize: '1.05rem', fontWeight: 700, color: 'var(--color-text)', lineHeight: 1.3 },
   itemMeta: { fontSize: '0.875rem', color: 'var(--color-text-muted)', lineHeight: 1.4 },
   itemDate: { fontSize: '0.75rem', color: 'var(--color-text-muted)', marginTop: 2 },
+  planSections: { display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 },
+  sectionOk: {
+    fontSize: '0.68rem',
+    fontWeight: 700,
+    color: 'var(--brand-deep)',
+    background: 'var(--brand-soft)',
+    padding: '2px 8px',
+    borderRadius: 999,
+  },
+  sectionMissing: {
+    fontSize: '0.68rem',
+    fontWeight: 700,
+    color: 'var(--color-error)',
+    background: 'rgba(220,38,38,0.08)',
+    padding: '2px 8px',
+    borderRadius: 999,
+  },
   deleteBtn: {
     position: 'absolute',
     top: 16,

--- a/apps/web/src/pages/StudyPlanCreatePage.tsx
+++ b/apps/web/src/pages/StudyPlanCreatePage.tsx
@@ -1,0 +1,518 @@
+import { useMemo, useState, type FormEvent } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import type { StudyDifficulty, StudyPlanTopicInput } from '@vkbacademy/shared';
+import { useCourses, useCourse, useSubjects } from '../hooks/useCourses';
+import { useCreateStudyPlan } from '../hooks/useStudyPlans';
+import { getApiErrorMessage } from '../utils/errorMessage';
+import PageHeader from '../components/ui/PageHeader';
+import Icon from '../components/ui/Icon';
+
+const DIFFICULTIES: { value: StudyDifficulty; label: string }[] = [
+  { value: 'EASY', label: 'Fácil' },
+  { value: 'MEDIUM', label: 'Media' },
+  { value: 'HARD', label: 'Difícil' },
+];
+
+const MAX_TOPICS = 6;
+
+// Tema ya elegido para el plan (oficial u propio), con etiqueta lista para mostrar en el chip.
+interface SelectedTopic {
+  key: string;
+  kind: 'OFFICIAL' | 'CUSTOM';
+  moduleId?: string;
+  title: string;
+  subject?: string;
+  label: string;
+}
+
+export default function StudyPlanCreatePage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const { data: coursesData } = useCourses(1);
+  const courses = coursesData?.data ?? [];
+
+  const [courseId, setCourseId] = useState(searchParams.get('courseId') ?? '');
+  const { data: courseDetail } = useCourse(courseId);
+  const { data: subjects } = useSubjects();
+
+  const [selectedTopics, setSelectedTopics] = useState<SelectedTopic[]>([]);
+  const [customTitle, setCustomTitle] = useState('');
+  const [customSubject, setCustomSubject] = useState(''); // '' = asignatura base
+
+  const [numExercises, setNumExercises] = useState(5);
+  const [difficulty, setDifficulty] = useState<StudyDifficulty>('MEDIUM');
+  const [numQuestions, setNumQuestions] = useState<5 | 10>(5);
+  const [useTimer, setUseTimer] = useState(false);
+  const [timerMins, setTimerMins] = useState(15);
+  const [onlyOnce, setOnlyOnce] = useState(false);
+
+  const create = useCreateStudyPlan();
+
+  function handleCourseChange(id: string) {
+    setCourseId(id);
+    // El temario y los temas propios "de otra asignatura" dependen de la base: se limpian al cambiarla.
+    setSelectedTopics([]);
+    setCustomSubject('');
+  }
+
+  // Materias de otras asignaturas matriculadas (con subject propio, distintas de la base),
+  // deduplicadas por nombre de materia normalizado.
+  const otherSubjectOptions = useMemo(() => {
+    if (!subjects) return [];
+    const seen = new Map<string, string>();
+    for (const c of subjects) {
+      if (!c.isEnrolled || !c.subject || c.id === courseId) continue;
+      const key = c.subject.trim().toLowerCase();
+      if (!seen.has(key)) seen.set(key, c.subject.trim());
+    }
+    return [...seen.values()];
+  }, [subjects, courseId]);
+
+  const atMax = selectedTopics.length >= MAX_TOPICS;
+
+  function toggleModule(module: { id: string; title: string; order: number }) {
+    setSelectedTopics((prev) => {
+      const exists = prev.some((t) => t.kind === 'OFFICIAL' && t.moduleId === module.id);
+      if (exists) return prev.filter((t) => !(t.kind === 'OFFICIAL' && t.moduleId === module.id));
+      if (prev.length >= MAX_TOPICS) return prev;
+      return [
+        ...prev,
+        {
+          key: `official-${module.id}`,
+          kind: 'OFFICIAL',
+          moduleId: module.id,
+          title: module.title,
+          label: `Tema ${module.order + 1} — ${module.title}`,
+        },
+      ];
+    });
+  }
+
+  function addCustomTopic() {
+    const title = customTitle.trim();
+    if (title.length < 3 || atMax) return;
+    const subject = customSubject || undefined;
+    setSelectedTopics((prev) => [
+      ...prev,
+      {
+        key: `custom-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        kind: 'CUSTOM',
+        title,
+        subject,
+        label: subject ? `${title} (${subject})` : title,
+      },
+    ]);
+    setCustomTitle('');
+    setCustomSubject('');
+  }
+
+  function removeTopic(key: string) {
+    setSelectedTopics((prev) => prev.filter((t) => t.key !== key));
+  }
+
+  const needsMoreQuestions = numQuestions < selectedTopics.length;
+  const canSubmit =
+    !!courseId && selectedTopics.length > 0 && !needsMoreQuestions && !create.isPending;
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    const topics: StudyPlanTopicInput[] = selectedTopics.map((t) =>
+      t.kind === 'OFFICIAL'
+        ? { moduleId: t.moduleId! }
+        : t.subject
+          ? { title: t.title, subject: t.subject }
+          : { title: t.title },
+    );
+    create.mutate(
+      {
+        courseId,
+        topics,
+        numExercises,
+        difficulty,
+        numQuestions,
+        timeLimit: useTimer ? Math.round(timerMins * 60) : undefined,
+        onlyOnce,
+      },
+      { onSuccess: (plan) => navigate(`/study/plan/${plan.id}`) },
+    );
+  }
+
+  const modules = courseDetail?.modules ?? [];
+
+  return (
+    <div style={s.page}>
+      <PageHeader
+        variant="light"
+        title="Simulacro multi-tema"
+        subtitle="Combina varios temas de tu temario (o temas propios) en un único examen, como en un examen real."
+      />
+
+      <form onSubmit={handleSubmit} className="dash-grid">
+        {/* Columna principal: elección de temas */}
+        <div style={s.col}>
+          <div className="vkb-card" style={s.section}>
+            <h3 style={s.sectionTitle}>
+              <Icon name="shapes" size={16} color="var(--brand-deep)" />
+              Asignatura base
+            </h3>
+            <div className="field">
+              <label htmlFor="courseId">Asignatura</label>
+              <select
+                id="courseId"
+                value={courseId}
+                onChange={(e) => handleCourseChange(e.target.value)}
+                required
+              >
+                <option value="">Selecciona una asignatura</option>
+                {courses.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {courseId && (
+            <div className="vkb-card" style={s.section}>
+              <h3 style={s.sectionTitle}>
+                <Icon name="book" size={16} color="var(--brand-deep)" />
+                Temario oficial
+              </h3>
+              {!courseDetail && <p style={s.muted}>Cargando temario…</p>}
+              {courseDetail && modules.length === 0 && (
+                <p style={s.muted}>Esta asignatura aún no tiene módulos publicados.</p>
+              )}
+              {modules.length > 0 && (
+                <ul style={s.checklist}>
+                  {modules.map((m) => {
+                    const isSelected = selectedTopics.some(
+                      (t) => t.kind === 'OFFICIAL' && t.moduleId === m.id,
+                    );
+                    const disabled = !isSelected && atMax;
+                    return (
+                      <li key={m.id}>
+                        <label style={{ ...s.checkboxRow, opacity: disabled ? 0.5 : 1 }}>
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            disabled={disabled}
+                            onChange={() => toggleModule(m)}
+                          />
+                          Tema {m.order + 1} — {m.title}
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {courseId && (
+            <div className="vkb-card" style={s.section}>
+              <h3 style={s.sectionTitle}>
+                <Icon name="zap" size={16} color="var(--brand-deep)" />
+                Añadir tema propio
+              </h3>
+              <div className="field">
+                <label htmlFor="customTitle">Tema</label>
+                <input
+                  id="customTitle"
+                  type="text"
+                  value={customTitle}
+                  onChange={(e) => setCustomTitle(e.target.value)}
+                  placeholder="Ej: verbos irregulares, la célula, ecuaciones de segundo grado..."
+                  disabled={atMax}
+                />
+              </div>
+              {otherSubjectOptions.length > 0 && (
+                <div className="field">
+                  <label htmlFor="customSubject">¿De qué asignatura es?</label>
+                  <select
+                    id="customSubject"
+                    value={customSubject}
+                    onChange={(e) => setCustomSubject(e.target.value)}
+                    disabled={atMax}
+                  >
+                    <option value="">Esta asignatura (base)</option>
+                    {otherSubjectOptions.map((subj) => (
+                      <option key={subj} value={subj}>
+                        {subj}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              <button
+                type="button"
+                className="btn btn-ghost"
+                onClick={addCustomTopic}
+                disabled={atMax || customTitle.trim().length < 3}
+                style={{ alignSelf: 'flex-start' }}
+              >
+                <Icon name="zap" size={14} />
+                Añadir
+              </button>
+              {atMax && <p style={s.warn}>Máximo {MAX_TOPICS} temas por plan.</p>}
+            </div>
+          )}
+
+          {selectedTopics.length > 0 && (
+            <div className="vkb-card" style={s.section}>
+              <h3 style={s.sectionTitle}>
+                Temas del plan
+                <span style={s.counter}>
+                  {selectedTopics.length} / {MAX_TOPICS}
+                </span>
+              </h3>
+              <ul style={s.chipList}>
+                {selectedTopics.map((t, i) => (
+                  <li key={t.key} className="chip" style={s.topicChip}>
+                    <span style={s.topicChipNum}>{i + 1}</span>
+                    <span style={s.topicChipLabel}>{t.label}</span>
+                    <span style={s.topicChipTag}>
+                      {t.kind === 'OFFICIAL' ? 'Oficial' : 'Propio'}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeTopic(t.key)}
+                      style={s.chipRemove}
+                      aria-label={`Quitar ${t.label}`}
+                    >
+                      <Icon name="close" size={13} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <p style={s.muted}>El examen tendrá al menos 1 pregunta de cada uno.</p>
+            </div>
+          )}
+        </div>
+
+        {/* Rail lateral: configuración de ejercicios/examen + envío */}
+        <div style={s.col}>
+          <div className="vkb-card" style={s.section}>
+            <h3 style={s.sectionTitle}>
+              <Icon name="target" size={16} color="var(--brand-deep)" />
+              Ejercicios
+            </h3>
+            <div className="field">
+              <label htmlFor="numExercises">Nº de ejercicios</label>
+              <input
+                id="numExercises"
+                type="number"
+                min={1}
+                max={20}
+                value={numExercises}
+                onChange={(e) =>
+                  setNumExercises(Math.max(1, Math.min(20, Number(e.target.value) || 1)))
+                }
+              />
+            </div>
+            <div className="field">
+              <label>Dificultad</label>
+              <div style={{ display: 'flex', gap: 10 }}>
+                {DIFFICULTIES.map((d) => (
+                  <button
+                    key={d.value}
+                    type="button"
+                    onClick={() => setDifficulty(d.value)}
+                    className={`chip${difficulty === d.value ? ' active' : ''}`}
+                    style={s.chipFlex}
+                  >
+                    {d.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="vkb-card" style={s.section}>
+            <h3 style={s.sectionTitle}>
+              <Icon name="graduation" size={16} color="var(--brand-deep)" />
+              Examen
+            </h3>
+            <div className="field">
+              <label>Preguntas del examen</label>
+              <div style={{ display: 'flex', gap: 10 }}>
+                {([5, 10] as const).map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setNumQuestions(n)}
+                    className={`chip${numQuestions === n ? ' active' : ''}`}
+                    style={s.chipFlex}
+                  >
+                    {n} preguntas
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <label style={s.toggle}>
+              <input
+                type="checkbox"
+                checked={useTimer}
+                onChange={(e) => setUseTimer(e.target.checked)}
+              />
+              <Icon name="clock" size={15} color="var(--color-text-muted)" />
+              <span>Límite de tiempo</span>
+              {useTimer && (
+                <input
+                  type="number"
+                  min={1}
+                  max={180}
+                  value={timerMins}
+                  onChange={(e) =>
+                    setTimerMins(Math.min(180, Math.max(1, Number(e.target.value) || 1)))
+                  }
+                  style={s.timerInput}
+                />
+              )}
+              {useTimer && <span style={s.muted}>minutos</span>}
+            </label>
+
+            <label style={s.toggle}>
+              <input
+                type="checkbox"
+                checked={onlyOnce}
+                onChange={(e) => setOnlyOnce(e.target.checked)}
+              />
+              <Icon name="lock" size={15} color="var(--color-text-muted)" />
+              <span>Examen de un solo intento</span>
+            </label>
+
+            {needsMoreQuestions && (
+              <p style={s.warn}>
+                Con {selectedTopics.length} temas necesitas al menos {selectedTopics.length}{' '}
+                preguntas (1 por tema): elige 10 preguntas o quita algún tema.
+              </p>
+            )}
+            {selectedTopics.length === 0 && (
+              <p style={s.warn}>Añade al menos 1 tema para poder crear el plan.</p>
+            )}
+          </div>
+
+          {create.isError && (
+            <div className="alert alert-error">
+              {getApiErrorMessage(create.error, 'No se pudo crear el plan. Inténtalo de nuevo.')}
+            </div>
+          )}
+
+          <button type="submit" className="btn btn-primary" disabled={!canSubmit} style={s.submitBtn}>
+            {create.isPending ? (
+              <span className="spinner" />
+            ) : (
+              <>
+                <Icon name="zap" size={16} />
+                Crear plan de estudio
+              </>
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+const s: Record<string, React.CSSProperties> = {
+  page: {
+    maxWidth: 1200,
+    margin: '0 auto',
+    padding: '32px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 24,
+  },
+  col: { display: 'flex', flexDirection: 'column', gap: 20 },
+  section: { display: 'flex', flexDirection: 'column', gap: 12 },
+  sectionTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    margin: 0,
+    fontSize: '0.95rem',
+    fontWeight: 700,
+    color: 'var(--color-text)',
+  },
+  counter: {
+    marginLeft: 'auto',
+    fontSize: '0.75rem',
+    fontWeight: 700,
+    color: 'var(--brand-deep)',
+    background: 'var(--brand-soft)',
+    padding: '2px 10px',
+    borderRadius: 999,
+  },
+  muted: { color: 'var(--color-text-muted)', fontSize: '0.875rem', margin: 0 },
+  warn: { color: 'var(--color-error)', fontSize: '0.8125rem', margin: 0, lineHeight: 1.4 },
+  checklist: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+  },
+  checkboxRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    fontSize: '0.9rem',
+    color: 'var(--color-text)',
+    cursor: 'pointer',
+    padding: '4px 0',
+  },
+  chipFlex: { flex: 1 },
+  toggle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    fontSize: '0.9rem',
+    color: 'var(--color-text)',
+  },
+  timerInput: {
+    width: 80,
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 8,
+    color: 'var(--color-text)',
+    padding: '6px 10px',
+  },
+  chipList: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+  },
+  topicChip: { width: '100%', justifyContent: 'flex-start', cursor: 'default', padding: '8px 14px' },
+  topicChipNum: {
+    fontFamily: 'var(--font-display)',
+    color: 'var(--brand-deep)',
+    fontWeight: 700,
+    flexShrink: 0,
+  },
+  topicChipLabel: { flex: 1, color: 'var(--color-text)', fontWeight: 600, textAlign: 'left' },
+  topicChipTag: {
+    fontSize: '0.7rem',
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+  },
+  chipRemove: {
+    display: 'inline-flex',
+    background: 'transparent',
+    border: 'none',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    padding: 2,
+    flexShrink: 0,
+  },
+  submitBtn: { padding: '12px 24px', justifyContent: 'center' },
+};

--- a/apps/web/src/pages/StudyPlanCreatePage.tsx
+++ b/apps/web/src/pages/StudyPlanCreatePage.tsx
@@ -39,6 +39,7 @@ export default function StudyPlanCreatePage() {
   const [selectedTopics, setSelectedTopics] = useState<SelectedTopic[]>([]);
   const [customTitle, setCustomTitle] = useState('');
   const [customSubject, setCustomSubject] = useState(''); // '' = asignatura base
+  const [customError, setCustomError] = useState('');
 
   const [numExercises, setNumExercises] = useState(5);
   const [difficulty, setDifficulty] = useState<StudyDifficulty>('MEDIUM');
@@ -92,6 +93,12 @@ export default function StudyPlanCreatePage() {
   function addCustomTopic() {
     const title = customTitle.trim();
     if (title.length < 3 || atMax) return;
+    // Guardia de duplicados en cliente (el 422 del backend queda como red de seguridad)
+    const normalized = title.toLowerCase();
+    if (selectedTopics.some((t) => t.title.trim().toLowerCase() === normalized)) {
+      setCustomError('Ese tema ya está en el plan.');
+      return;
+    }
     const subject = customSubject || undefined;
     setSelectedTopics((prev) => [
       ...prev,
@@ -105,6 +112,7 @@ export default function StudyPlanCreatePage() {
     ]);
     setCustomTitle('');
     setCustomSubject('');
+    setCustomError('');
   }
 
   function removeTopic(key: string) {
@@ -112,8 +120,13 @@ export default function StudyPlanCreatePage() {
   }
 
   const needsMoreQuestions = numQuestions < selectedTopics.length;
+  const needsMoreExercises = numExercises < selectedTopics.length;
   const canSubmit =
-    !!courseId && selectedTopics.length > 0 && !needsMoreQuestions && !create.isPending;
+    !!courseId &&
+    selectedTopics.length > 0 &&
+    !needsMoreQuestions &&
+    !needsMoreExercises &&
+    !create.isPending;
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -223,7 +236,10 @@ export default function StudyPlanCreatePage() {
                   id="customTitle"
                   type="text"
                   value={customTitle}
-                  onChange={(e) => setCustomTitle(e.target.value)}
+                  onChange={(e) => {
+                    setCustomTitle(e.target.value);
+                    setCustomError('');
+                  }}
                   placeholder="Ej: verbos irregulares, la célula, ecuaciones de segundo grado..."
                   disabled={atMax}
                 />
@@ -256,6 +272,7 @@ export default function StudyPlanCreatePage() {
                 <Icon name="zap" size={14} />
                 Añadir
               </button>
+              {customError && <p style={s.warn}>{customError}</p>}
               {atMax && <p style={s.warn}>Máximo {MAX_TOPICS} temas por plan.</p>}
             </div>
           )}
@@ -389,6 +406,12 @@ export default function StudyPlanCreatePage() {
               <p style={s.warn}>
                 Con {selectedTopics.length} temas necesitas al menos {selectedTopics.length}{' '}
                 preguntas (1 por tema): elige 10 preguntas o quita algún tema.
+              </p>
+            )}
+            {needsMoreExercises && (
+              <p style={s.warn}>
+                Con {selectedTopics.length} temas necesitas al menos {selectedTopics.length}{' '}
+                ejercicios (1 por tema): sube el número de ejercicios o quita algún tema.
               </p>
             )}
             {selectedTopics.length === 0 && (

--- a/apps/web/src/pages/StudyPlanPage.tsx
+++ b/apps/web/src/pages/StudyPlanPage.tsx
@@ -314,7 +314,7 @@ function TopicTheoryDeck({
             <TheoryView module={topic.theory} courseTitle={courseTitle} />
           ) : (
             <MissingSection
-              label={`los apuntes de "${topic.title}"`}
+              label={`la teoría de "${topic.title}"`}
               icon="book"
               onRetry={() => regen.mutate(topic.id)}
               retrying={regen.isPending}

--- a/apps/web/src/pages/StudyPlanPage.tsx
+++ b/apps/web/src/pages/StudyPlanPage.tsx
@@ -1,0 +1,533 @@
+import { Fragment, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import type { StudyPlanDetail, StudyPlanExercise, StudyPlanTopicDetail } from '@vkbacademy/shared';
+import {
+  useStudyPlan,
+  useDeleteStudyPlan,
+  useRegenerateTopicTheory,
+  useRegeneratePlanExercises,
+  useRegeneratePlanExam,
+} from '../hooks/useStudyPlans';
+import TheoryView from '../components/theory/TheoryView';
+import ExercisePractice from '../components/exercises/ExercisePractice';
+import { getApiErrorMessage } from '../utils/errorMessage';
+import PageHeader from '../components/ui/PageHeader';
+import Icon from '../components/ui/Icon';
+import EmptyState from '../components/ui/EmptyState';
+
+type Tab = 'theory' | 'exercises' | 'exam';
+
+const STEPS: { key: Tab; label: string; icon: string; desc: string }[] = [
+  { key: 'theory', label: 'Apuntes', icon: 'book', desc: 'Estudia cada tema del simulacro' },
+  { key: 'exercises', label: 'Ejercicios', icon: 'target', desc: 'Practica todos los temas combinados' },
+  { key: 'exam', label: 'Examen', icon: 'graduation', desc: 'Un examen con preguntas de cada tema' },
+];
+
+// Mismo look&feel de itinerario que StudyUnitPage (no se toca ese fichero: copia local).
+const STEPPER_CSS = `
+  .unit-steps { display: flex; align-items: stretch; gap: 6px; margin-top: 10px; }
+  .unit-step {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 18px;
+    background: var(--color-surface);
+    border: 1.5px solid var(--color-border);
+    border-radius: 14px;
+    cursor: pointer;
+    text-align: left;
+    color: var(--color-text);
+    font-family: inherit;
+    transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+  }
+  .unit-step:hover { border-color: var(--brand); transform: translateY(-2px); }
+  .unit-step.is-active {
+    border-color: var(--brand);
+    background: var(--brand-soft);
+    box-shadow: 0 0 0 3px var(--brand-soft);
+  }
+  .unit-step-num {
+    flex: none;
+    width: 46px;
+    height: 46px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    line-height: 1;
+    color: var(--brand-deep);
+    background: var(--brand-soft);
+    border: 1px solid var(--brand);
+    transition: background 0.15s, color 0.15s;
+  }
+  .unit-step.is-active .unit-step-num { background: var(--brand); color: #fff; }
+  .unit-step-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+  .unit-step-title { display: inline-flex; align-items: center; gap: 6px; font-weight: 800; font-size: 1rem; }
+  .unit-step-desc { font-size: 0.8rem; color: var(--color-text-muted); line-height: 1.35; }
+  .unit-step-arrow { align-self: center; color: var(--color-text-muted); flex: none; display: grid; place-items: center; }
+  @media (max-width: 720px) {
+    .unit-steps { flex-direction: column; }
+    .unit-step-arrow { transform: rotate(90deg); }
+  }
+  .topic-deck-toggle {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    color: var(--color-text);
+    font-family: inherit;
+  }
+`;
+
+export default function StudyPlanPage() {
+  const { id = '' } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, error } = useStudyPlan(id);
+  const remove = useDeleteStudyPlan();
+  const [tab, setTab] = useState<Tab>('theory');
+
+  if (isLoading) {
+    return (
+      <div style={s.page}>
+        <p style={s.muted}>Cargando plan de estudio…</p>
+      </div>
+    );
+  }
+  if (error || !data) {
+    return (
+      <div style={s.page}>
+        <EmptyState
+          icon="brain"
+          title="No se encontró el plan de estudio"
+          action={
+            <Link to="/study" className="btn btn-ghost">
+              <Icon name="chevron-left" size={14} />
+              Volver a Estudiar
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div style={s.page}>
+      <Link to="/study" style={s.backLink}>
+        <Icon name="chevron-left" size={14} color="var(--brand-deep)" />
+        Volver a Estudiar
+      </Link>
+
+      <span style={s.eyebrow}>
+        {data.course.title} · {data.topics.length} temas
+      </span>
+
+      <PageHeader variant="light" title={data.title} subtitle={data.summary} />
+
+      <style>{STEPPER_CSS}</style>
+      <nav className="unit-steps" aria-label="Itinerario del plan de estudio">
+        {STEPS.map((t, i) => (
+          <Fragment key={t.key}>
+            {i > 0 && (
+              <span className="unit-step-arrow" aria-hidden="true">
+                <Icon name="chevron-right" size={20} />
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => setTab(t.key)}
+              className={`unit-step${tab === t.key ? ' is-active' : ''}`}
+              aria-current={tab === t.key ? 'step' : undefined}
+            >
+              <span className="unit-step-num" aria-hidden="true">
+                {i + 1}
+              </span>
+              <span className="unit-step-body">
+                <span className="unit-step-title">
+                  <Icon name={t.icon} size={16} />
+                  {t.label}
+                  {!data.sections[t.key] && (
+                    <span style={s.tabWarn} title="Sección no generada">
+                      !
+                    </span>
+                  )}
+                </span>
+                <span className="unit-step-desc">{t.desc}</span>
+              </span>
+            </button>
+          </Fragment>
+        ))}
+      </nav>
+
+      <div style={s.content}>
+        {tab === 'theory' && <TheoryTab plan={data} />}
+        {tab === 'exercises' && <ExercisesTab plan={data} />}
+        {tab === 'exam' && (
+          <ExamTab
+            plan={data}
+            onStart={(bankId) => navigate(`/exam?aiBankId=${bankId}&returnTo=/study/plan/${id}`)}
+          />
+        )}
+      </div>
+
+      <footer style={s.footer}>
+        <button
+          type="button"
+          onClick={() => {
+            if (window.confirm('¿Borrar este plan de estudio?')) {
+              remove.mutate(id, { onSuccess: () => navigate('/study') });
+            }
+          }}
+          disabled={remove.isPending}
+          style={s.deleteBtn}
+        >
+          {remove.isPending ? (
+            <span className="spinner" />
+          ) : (
+            <>
+              <Icon name="close" size={14} />
+              Borrar plan
+            </>
+          )}
+        </button>
+      </footer>
+      {remove.isError && (
+        <div className="alert alert-error">
+          {getApiErrorMessage(remove.error, 'No se pudo borrar el plan. Inténtalo de nuevo.')}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Estado vacío + reintento de una sección, idéntico al de StudyUnitPage (no exportado desde allí: copia local).
+function MissingSection({
+  label,
+  icon,
+  onRetry,
+  retrying,
+  isError,
+  error,
+}: {
+  label: string;
+  icon: string;
+  onRetry: () => void;
+  retrying: boolean;
+  isError?: boolean;
+  error?: unknown;
+}) {
+  return (
+    <div className="vkb-card">
+      <EmptyState
+        icon={icon}
+        title={`No se pudo generar ${label}`}
+        message={
+          isError
+            ? getApiErrorMessage(error, 'Error al regenerar. Inténtalo de nuevo.')
+            : 'Puedes reintentarlo.'
+        }
+        action={
+          <button type="button" className="btn btn-primary" onClick={onRetry} disabled={retrying}>
+            {retrying ? (
+              <span className="spinner" />
+            ) : (
+              <>
+                <Icon name="zap" size={16} />
+                Reintentar generación
+              </>
+            )}
+          </button>
+        }
+      />
+    </div>
+  );
+}
+
+// ─── Apuntes: una tarjeta-deck por tema, colapsable ───────────────────────────
+
+function TheoryTab({ plan }: { plan: StudyPlanDetail }) {
+  const [expandedId, setExpandedId] = useState<string | null>(plan.topics[0]?.id ?? null);
+  return (
+    <div style={s.deckList}>
+      {plan.topics.map((topic, i) => (
+        <TopicTheoryDeck
+          key={topic.id}
+          planId={plan.id}
+          topic={topic}
+          courseTitle={plan.course.title}
+          index={i}
+          isOpen={expandedId === topic.id}
+          onToggle={() => setExpandedId((cur) => (cur === topic.id ? null : topic.id))}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TopicTheoryDeck({
+  planId,
+  topic,
+  courseTitle,
+  index,
+  isOpen,
+  onToggle,
+}: {
+  planId: string;
+  topic: StudyPlanTopicDetail;
+  courseTitle: string;
+  index: number;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const regen = useRegenerateTopicTheory(planId);
+  return (
+    <div className="vkb-card" style={s.deckCard}>
+      <button
+        type="button"
+        className="topic-deck-toggle"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+      >
+        <span style={s.deckNum}>{index + 1}</span>
+        <span style={s.deckBody}>
+          <span style={s.deckTitle}>{topic.title}</span>
+          <span style={s.deckTag}>
+            {topic.source === 'OFFICIAL' ? 'Oficial' : 'Propio'}
+            {topic.subject ? ` · ${topic.subject}` : ''}
+          </span>
+        </span>
+        <Icon
+          name="chevron-right"
+          size={18}
+          style={{ transform: isOpen ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s' }}
+        />
+      </button>
+      {isOpen && (
+        <div style={s.deckContent}>
+          {topic.hasTheory && topic.theory ? (
+            <TheoryView module={topic.theory} courseTitle={courseTitle} />
+          ) : (
+            <MissingSection
+              label={`los apuntes de "${topic.title}"`}
+              icon="book"
+              onRetry={() => regen.mutate(topic.id)}
+              retrying={regen.isPending}
+              isError={regen.isError}
+              error={regen.error}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Ejercicios: agrupados por tema, misma UX de resolución que StudyUnitPage ──
+
+function groupExercisesByTopic(
+  exercises: StudyPlanExercise[],
+): { topicLabel: string; items: StudyPlanExercise[] }[] {
+  const order: string[] = [];
+  const map = new Map<string, StudyPlanExercise[]>();
+  for (const ex of exercises) {
+    if (!map.has(ex.topicLabel)) {
+      map.set(ex.topicLabel, []);
+      order.push(ex.topicLabel);
+    }
+    map.get(ex.topicLabel)!.push(ex);
+  }
+  return order.map((topicLabel) => ({ topicLabel, items: map.get(topicLabel)! }));
+}
+
+function ExercisesTab({ plan }: { plan: StudyPlanDetail }) {
+  const regen = useRegeneratePlanExercises(plan.id);
+  if (!plan.exercises || plan.exercises.length === 0) {
+    return (
+      <MissingSection
+        label="los ejercicios"
+        icon="target"
+        onRetry={() => regen.mutate(undefined)}
+        retrying={regen.isPending}
+        isError={regen.isError}
+        error={regen.error}
+      />
+    );
+  }
+  const groups = groupExercisesByTopic(plan.exercises);
+  return (
+    <div style={s.exerciseGroups}>
+      {groups.map((g) => (
+        <div key={g.topicLabel} style={s.exerciseGroup}>
+          <h3 style={s.exerciseGroupTitle}>{g.topicLabel}</h3>
+          <ExercisePractice exercises={g.items} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Examen: mismo flujo AiExamBank que StudyUnitPage (sin código nuevo de examen) ──
+
+function ExamTab({ plan, onStart }: { plan: StudyPlanDetail; onStart: (bankId: string) => void }) {
+  const regen = useRegeneratePlanExam(plan.id);
+  if (!plan.exam) {
+    return (
+      <MissingSection
+        label="el examen"
+        icon="graduation"
+        onRetry={() => regen.mutate()}
+        retrying={regen.isPending}
+        isError={regen.isError}
+        error={regen.error}
+      />
+    );
+  }
+  const { exam } = plan;
+  const timeMinutes = exam.timeLimit ? Math.round(exam.timeLimit / 60) : null;
+  return (
+    <div className="vkb-card" style={s.examCard}>
+      <div>
+        <div style={s.examTitle}>{exam.title}</div>
+        <div style={s.examMeta}>
+          <span>{exam.questions.length} preguntas</span>
+          {timeMinutes !== null && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span style={s.examMetaItem}>
+                <Icon name="clock" size={12} />
+                {timeMinutes} min
+              </span>
+            </>
+          )}
+          {exam.onlyOnce && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span style={s.examMetaItem}>
+                <Icon name="lock" size={12} />1 intento
+              </span>
+            </>
+          )}
+          {exam.attemptCount > 0 && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>
+                {exam.attemptCount} {exam.attemptCount === 1 ? 'intento' : 'intentos'}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+      <button className="btn btn-primary" style={s.examStart} onClick={() => onStart(exam.id)}>
+        {exam.attemptCount > 0 ? 'Repetir' : 'Empezar'}
+      </button>
+    </div>
+  );
+}
+
+const s: Record<string, React.CSSProperties> = {
+  page: {
+    maxWidth: 1040,
+    margin: '0 auto',
+    padding: '24px 16px 64px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  backLink: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    color: 'var(--brand-deep)',
+    fontSize: '0.875rem',
+    textDecoration: 'none',
+    fontWeight: 600,
+    width: 'fit-content',
+  },
+  eyebrow: {
+    fontSize: '0.75rem',
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  tabWarn: { color: 'var(--color-error)', fontWeight: 800 },
+  content: { display: 'flex', flexDirection: 'column', gap: 16, marginTop: 8 },
+  muted: { color: 'var(--color-text-muted)', fontSize: '0.95rem', margin: 0 },
+
+  deckList: { display: 'flex', flexDirection: 'column', gap: 14 },
+  deckCard: { display: 'flex', flexDirection: 'column', gap: 0 },
+  deckNum: {
+    flex: 'none',
+    width: 34,
+    height: 34,
+    borderRadius: 10,
+    display: 'grid',
+    placeItems: 'center',
+    fontFamily: 'var(--font-display)',
+    fontSize: '1.1rem',
+    color: 'var(--brand-deep)',
+    background: 'var(--brand-soft)',
+    border: '1px solid var(--brand)',
+  },
+  deckBody: { flex: 1, display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 },
+  deckTitle: { fontWeight: 700, fontSize: '0.9375rem', color: 'var(--color-text)' },
+  deckTag: {
+    fontSize: '0.7rem',
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+  },
+  deckContent: { marginTop: 16 },
+
+  exerciseGroups: { display: 'flex', flexDirection: 'column', gap: 28 },
+  exerciseGroup: { display: 'flex', flexDirection: 'column', gap: 12 },
+  exerciseGroupTitle: {
+    margin: 0,
+    fontSize: '0.8rem',
+    fontWeight: 700,
+    color: 'var(--brand-deep)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+
+  examCard: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 16,
+    padding: '20px 24px',
+    flexWrap: 'wrap',
+  },
+  examTitle: { fontWeight: 700, color: 'var(--color-text)', marginBottom: 6, fontSize: '1rem' },
+  examMeta: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: 6,
+    fontSize: '0.8rem',
+    color: 'var(--color-text-muted)',
+  },
+  examMetaItem: { display: 'inline-flex', alignItems: 'center', gap: 4 },
+  examStart: { padding: '9px 20px', fontSize: '0.875rem', flexShrink: 0 },
+  footer: { display: 'flex', justifyContent: 'flex-end', gap: 12, flexWrap: 'wrap' },
+  deleteBtn: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 8,
+    background: 'transparent',
+    border: '1px solid rgba(220,38,38,0.4)',
+    color: 'var(--color-error)',
+    padding: '10px 18px',
+    borderRadius: 8,
+    fontSize: '0.875rem',
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+};

--- a/apps/web/src/pages/exam/ResultsStep.tsx
+++ b/apps/web/src/pages/exam/ResultsStep.tsx
@@ -190,6 +190,24 @@ export function ResultsStep({
                 </span>
               </div>
 
+              {c.topicLabel && (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    fontSize: '0.7rem',
+                    fontWeight: 700,
+                    color: 'var(--color-text-muted)',
+                    background: 'rgba(255,255,255,0.06)',
+                    border: '1px solid rgba(255,255,255,0.12)',
+                    borderRadius: 999,
+                    padding: '2px 10px',
+                    marginBottom: 6,
+                  }}
+                >
+                  Tema: {c.topicLabel}
+                </span>
+              )}
+
               {(() => {
                 // Para MULTIPLE muestra todas las seleccionadas/correctas; para
                 // SINGLE/TRUE_FALSE cae en los campos legacy con un único valor.

--- a/packages/shared/src/types/exam.types.ts
+++ b/packages/shared/src/types/exam.types.ts
@@ -23,6 +23,8 @@ export interface ExamAttemptStarted {
 export interface ExamCorrection {
   questionId: string;
   questionText: string;
+  // Tema del plan multi-tema al que pertenece la pregunta. Null/ausente en exámenes un-tema.
+  topicLabel?: string | null;
   // Compatibilidad: primera respuesta seleccionada/correcta.
   selectedAnswerId: string | null;
   selectedAnswerText: string | null;

--- a/packages/shared/src/types/study.types.ts
+++ b/packages/shared/src/types/study.types.ts
@@ -26,6 +26,8 @@ export interface StudyExamQuestion {
   text: string;
   type: 'SINGLE' | 'MULTIPLE' | 'TRUE_FALSE';
   order: number;
+  /// Tema del plan multi-tema al que pertenece la pregunta. Null/ausente en bancos un-tema.
+  topicLabel?: string | null;
   answers: StudyExamAnswer[];
 }
 
@@ -82,4 +84,65 @@ export interface RegenerateExamRequest {
   numQuestions?: 5 | 10;
   timeLimit?: number;
   onlyOnce?: boolean;
+}
+
+// ── Plan de estudio multi-tema (StudyPlan) ──
+// Combina N temas (oficiales del temario o libres) en teoría por tema +
+// ejercicios y examen combinados. Flujo adicional al un-tema (StudyUnit).
+
+export type StudyTopicSource = 'OFFICIAL' | 'CUSTOM';
+
+// Tema del payload de creación: moduleId (oficial) XOR title (libre).
+// subject solo acompaña a title cuando el tema es de otra asignatura matriculada.
+export interface StudyPlanTopicInput {
+  moduleId?: string;
+  title?: string;
+  subject?: string;
+}
+
+export interface CreateStudyPlanRequest {
+  courseId: string; // asignatura base
+  topics: StudyPlanTopicInput[]; // 1..6
+  numExercises: number; // 1..20
+  difficulty: StudyDifficulty; // aplica a ejercicios y examen
+  numQuestions: 5 | 10; // debe ser >= topics.length (≥1 pregunta por tema)
+  timeLimit?: number; // segundos
+  onlyOnce?: boolean;
+}
+
+// Ejercicio combinado: igual que StudyExercise pero etiquetado con su tema.
+export interface StudyPlanExercise extends StudyExercise {
+  topicLabel: string;
+}
+
+export interface StudyPlanTopicSummary {
+  id: string;
+  order: number;
+  source: StudyTopicSource;
+  moduleId: string | null;
+  title: string;
+  subject: string | null;
+  hasTheory: boolean; // false = deck fallido/pendiente → regenerable por tema
+}
+
+export interface StudyPlanSummary {
+  id: string;
+  title: string;
+  summary: string;
+  difficulty: StudyDifficulty;
+  createdAt: string;
+  course: { id: string; title: string };
+  topics: StudyPlanTopicSummary[];
+  // sections.theory = true solo si TODOS los temas tienen su deck generado
+  sections: StudySections;
+}
+
+export interface StudyPlanTopicDetail extends StudyPlanTopicSummary {
+  theory: TheoryModuleWithLessons | null;
+}
+
+export interface StudyPlanDetail extends Omit<StudyPlanSummary, 'topics'> {
+  topics: StudyPlanTopicDetail[];
+  exercises: StudyPlanExercise[] | null;
+  exam: StudyExam | null;
 }


### PR DESCRIPTION
## Qué hace

Al matricularse en una asignatura, el alumno ve su temario oficial y puede combinar N temas (1-6, oficiales o propios, incluso de otra asignatura matriculada) en un plan de estudio con teoría por tema + ejercicios y examen combinados, simulando exámenes reales.

- **Modelo nuevo** `StudyPlan`/`StudyPlanTopic` (migración aditiva `20260706120000_add_study_plan_multi_topic`); `StudyUnit` intacto.
- **Regla de coherencia determinista** sobre `Course.subject` (sin IA): un tema etiquetado de otra materia exige matrícula en ella (422 con las materias válidas).
- **Generación combinada**: N decks de teoría (uno por tema, con el curso de contexto correcto) + 1 tanda de ejercicios y 1 examen con reparto por tema, `topicLabel` validado y cobertura ≥1 por tema con reintento semántico.
- **Módulo NestJS `study-plans`**: 7 endpoints (throttle 5/h creación, 30/h regeneración por sección), DTOs class-validator con XOR moduleId/title.
- **Web**: `/study/plan/new` (checklist del temario + chips de temas propios) y `/study/plan/:id` (stepper Apuntes por tema / Ejercicios por tema / Examen con el flujo AiExamBank existente); CTAs en Estudiar y CoursePage; chip "Tema: X" en las correcciones.
- **Fix A-1**: los exámenes de bancos IA ya no emiten certificados oficiales.

## Verificación

- API 545/545 tests (36 suites; suite previa intacta) + typecheck api/web limpios + vitest web 91/92 (fallo preexistente email-validation).
- QA visual con mocks en Chrome (creación, detalle con sección fallida y regeneración, listado).
- Review adversarial (5 finders + 4 verificadores): 5 hallazgos corregidos; 2 diferidos a backlog (dedupe de plantillas de prompt, extracción de assertEnrolled).

⚠️ Lleva migración de BD: requiere que el job `migrate-pre` del pipeline la aplique antes de validar en PRE.