### PR TITLE
fix: fullscreen del deck, PDF con progreso y curso multi-tema (parte 1)

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -731,7 +731,7 @@ model StudyPlan {
   id       String @id @default(cuid())
   userId   String
   courseId String // asignatura base (curso matriculado desde el que se crea el plan)
-  title    String // "Simulacro: Fracciones · Ecuaciones · Proporcionalidad" (generado)
+  title    String // "Fracciones · Ecuaciones · Proporcionalidad" (generado; renombrable por el alumno)
   summary  String @db.Text @default("")
   /// Dificultad elegida por el alumno (EASY | MEDIUM | HARD).
   difficulty String @default("MEDIUM")

--- a/apps/api/src/study-plans/study-plans.service.spec.ts
+++ b/apps/api/src/study-plans/study-plans.service.spec.ts
@@ -316,7 +316,7 @@ describe('StudyPlansService', () => {
       expect(prisma.studyPlan.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            title: 'Simulacro: Fracciones',
+            title: 'Fracciones',
             difficulty: 'MEDIUM',
           }),
         }),

--- a/apps/api/src/study-plans/study-plans.service.ts
+++ b/apps/api/src/study-plans/study-plans.service.ts
@@ -316,7 +316,8 @@ export class StudyPlansService {
   }
 
   private buildTitle(topics: { title: string }[]): string {
-    return `Simulacro: ${topics.map((t) => t.title).join(' · ')}`.slice(0, 200);
+    // Título por defecto del curso multi-tema; el alumno puede renombrarlo después.
+    return topics.map((t) => t.title).join(' · ').slice(0, 200);
   }
 
   async listMine(userId: string) {

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -228,13 +228,13 @@ Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, si
     { "kind": "CONTENT", "heading": "título de la sección de desarrollo", "body": "desarrollo (ver ESTRUCTURA)" },
     { "kind": "EXAMPLE", "heading": "Ejemplos paso a paso", "body": "mínimo 3 ejemplos resueltos (ver ESTRUCTURA)" },
     { "kind": "VIDEO", "heading": "Vídeo recomendado", "ytQuery": "consulta optimizada para buscar el mejor vídeo en YouTube sobre este tema" },
-    { "kind": "CONTENT", "heading": "Chuleta de repaso", "body": "resumen compacto de fórmulas y reglas clave (ver ESTRUCTURA)" },
+    { "kind": "CONTENT", "heading": "Reglas de oro", "body": "resumen compacto de fórmulas y reglas clave (ver ESTRUCTURA)" },
     { "kind": "CONTENT", "heading": "Lo que te llevas", "body": "cierre espejo de la promesa (ver ESTRUCTURA)" }
   ]
 }
 
 ESTRUCTURA — metodología Winston de enseñanza, OBLIGATORIA:
-- Entre 6 y 9 lecciones, en este orden: 1 INTRO "Qué vas a conseguir" (SIEMPRE la primera) + 1-3 CONTENT de desarrollo + 1 EXAMPLE + 1 VIDEO + 1 CONTENT "Chuleta de repaso" + 1 CONTENT "Lo que te llevas" (SIEMPRE la última).
+- Entre 6 y 9 lecciones, en este orden: 1 INTRO "Qué vas a conseguir" (SIEMPRE la primera) + 1-3 CONTENT de desarrollo + 1 EXAMPLE + 1 VIDEO + 1 CONTENT "Reglas de oro" + 1 CONTENT "Lo que te llevas" (SIEMPRE la última).
 
 - INTRO "Qué vas a conseguir" — promesa de empoderamiento: qué sabrá HACER el alumno al final que no sabe ahora, y para qué le sirve. Formato: 1 frase corta que enganche + lista de 3-4 items con el formato exacto "- **Sabrás** [habilidad concreta]: te servirá para [uso real: el examen, el deporte o la vida diaria]". Sin definiciones todavía, sin índice.
 
@@ -255,7 +255,7 @@ ESTRUCTURA — metodología Winston de enseñanza, OBLIGATORIA:
 **Resultado:** [solución final]
 **Por qué funciona:** [1-2 frases conectando el procedimiento con la teoría]
 
-- CONTENT "Chuleta de repaso" — resumen de estudio antes del cierre: TODAS las fórmulas, reglas y definiciones clave del tema en formato compacto, pensado para releerse 5 minutos antes del examen. Lista de items cortos "- **[nombre]**: [fórmula o regla en 1 línea]" (con LaTeX si aplica) + exactamente 1 callout 🧠 con lo más importante de todo el tema. Sin párrafos largos ni contenido nuevo: solo condensa lo ya explicado.
+- CONTENT "Reglas de oro" — resumen de estudio antes del cierre: TODAS las fórmulas, reglas y definiciones clave del tema en formato compacto, pensado para releerse 5 minutos antes del examen. Se renderiza como tarjetas (flashcards): CADA item DEBE seguir el formato exacto "- **[nombre corto]**: [fórmula o regla en 1 línea]" (con LaTeX si aplica), entre 4 y 8 items + exactamente 1 callout 🧠 con lo más importante de todo el tema. Sin párrafos largos ni contenido nuevo: solo condensa lo ya explicado.
 
 - CONTENT "Lo que te llevas" — cierre de contribuciones, espejo de la promesa inicial: lista de 3-4 items "- **Ya sabes** [la misma habilidad prometida al inicio]" + 1 frase final que empuje al siguiente paso (practicar con ejercicios o hacer el test). PROHIBIDO cerrar con "gracias", "espero que" o despedidas.
 

--- a/apps/web/src/components/theory/SlideView.tsx
+++ b/apps/web/src/components/theory/SlideView.tsx
@@ -73,16 +73,35 @@ function ContentSlide({
   revealed: number;
   forPdf: boolean;
 }) {
+  const cards = slide.cards ?? [];
   const blocks = slide.blocks ?? [];
   return (
     <div className={`tsl-content${slide.variant ? ` tsl-content--${slide.variant}` : ''}`}>
-      <h2 className="tsl-heading">
-        {slide.heading}
-        {slide.continued && <span className="tsl-cont">cont.</span>}
-      </h2>
+      <h2 className="tsl-heading">{slide.heading}</h2>
       <div className="tsl-body">
+        {cards.length > 0 && (
+          <div className="tsl-flashcards">
+            {cards.map((card, i) => (
+              <Frag key={`card-${i}`} shown={forPdf || i < revealed} delayIndex={i} forPdf={forPdf}>
+                <div className="tsl-flashcard">
+                  <span className="tsl-flashcard-term">{card.term}</span>
+                  {card.body && (
+                    <div className="tsl-flashcard-body">
+                      <TheoryMarkdown>{card.body}</TheoryMarkdown>
+                    </div>
+                  )}
+                </div>
+              </Frag>
+            ))}
+          </div>
+        )}
         {blocks.map((block, i) => (
-          <Frag key={i} shown={forPdf || i < revealed} delayIndex={i} forPdf={forPdf}>
+          <Frag
+            key={i}
+            shown={forPdf || cards.length + i < revealed}
+            delayIndex={cards.length + i}
+            forPdf={forPdf}
+          >
             <TheoryMarkdown>{block}</TheoryMarkdown>
           </Frag>
         ))}

--- a/apps/web/src/components/theory/TheorySlides.test.tsx
+++ b/apps/web/src/components/theory/TheorySlides.test.tsx
@@ -1,0 +1,63 @@
+// Tests de regresión del deck: el overlay debe colgar de <body> (un ancestro
+// con transform, como .vkb-card:hover, se convertiría en containing block del
+// position:fixed y encogería el deck) y debe ofrecer pantalla completa real.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { TheoryModuleWithLessons } from '@vkbacademy/shared';
+import TheorySlides from './TheorySlides';
+
+const theoryModule: TheoryModuleWithLessons = {
+  id: 'm1',
+  userId: 'u1',
+  courseId: 'c1',
+  topic: 'fracciones',
+  title: 'Fracciones',
+  summary: 'Resumen.',
+  createdAt: '2026-07-06T00:00:00.000Z',
+  lessons: [],
+};
+
+beforeEach(() => {
+  // jsdom no implementa matchMedia (auto-fit) ni la Fullscreen API.
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({ matches: false, addListener: vi.fn(), removeListener: vi.fn() }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  delete (HTMLElement.prototype as { requestFullscreen?: unknown }).requestFullscreen;
+});
+
+describe('TheorySlides', () => {
+  it('se monta como portal directo en <body>, aunque el padre tenga transform', () => {
+    render(
+      <div style={{ transform: 'translateY(-3px)' }}>
+        <TheorySlides module={theoryModule} onClose={() => undefined} />
+      </div>,
+    );
+    const dialog = screen.getByRole('dialog', { name: /Presentación: Fracciones/ });
+    expect(dialog.parentElement).toBe(document.body);
+  });
+
+  it('sin Fullscreen API no muestra el botón de pantalla completa', () => {
+    render(<TheorySlides module={theoryModule} onClose={() => undefined} />);
+    expect(screen.queryByRole('button', { name: 'Pantalla completa' })).toBeNull();
+  });
+
+  it('con Fullscreen API, el botón pide pantalla completa sobre el deck', () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(HTMLElement.prototype, 'requestFullscreen', {
+      configurable: true,
+      writable: true,
+      value: requestFullscreen,
+    });
+
+    render(<TheorySlides module={theoryModule} onClose={() => undefined} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Pantalla completa' }));
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/theory/TheorySlides.tsx
+++ b/apps/web/src/components/theory/TheorySlides.tsx
@@ -11,6 +11,7 @@ import {
   useState,
   type TouchEvent as ReactTouchEvent,
 } from 'react';
+import { createPortal } from 'react-dom';
 import type { TheoryModuleWithLessons } from '@vkbacademy/shared';
 import { buildSlides, fragmentCount } from '../../utils/theorySlides';
 import { SlideView } from './SlideView';
@@ -32,8 +33,34 @@ export default function TheorySlides({ module, onClose }: Props) {
   const slide = slides[current];
   const frags = fragmentCount(slide);
 
+  const rootRef = useRef<HTMLDivElement>(null);
   const stageRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
+
+  // Pantalla completa real (Fullscreen API). Si el navegador no la soporta
+  // (iOS Safari), el botón no se muestra.
+  const fullscreenSupported =
+    typeof document !== 'undefined' &&
+    typeof document.documentElement.requestFullscreen === 'function';
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const toggleFullscreen = useCallback(() => {
+    if (document.fullscreenElement) {
+      void document.exitFullscreen().catch(() => undefined);
+    } else if (rootRef.current) {
+      void rootRef.current.requestFullscreen().catch(() => undefined);
+    }
+  }, []);
+
+  useEffect(() => {
+    const onChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
+    document.addEventListener('fullscreenchange', onChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', onChange);
+      // Al cerrar el deck estando en pantalla completa, salir de ella.
+      if (document.fullscreenElement) void document.exitFullscreen().catch(() => undefined);
+    };
+  }, []);
 
   const goTo = useCallback(
     (idx: number, reveal: 'all' | 'none') => {
@@ -95,7 +122,15 @@ export default function TheorySlides({ module, onClose }: Props) {
           e.preventDefault();
           setGridOpen(true);
           break;
+        case 'f':
+        case 'F':
+          e.preventDefault();
+          toggleFullscreen();
+          break;
         case 'Escape':
+          // En pantalla completa, Esc la abandona (lo gestiona el navegador);
+          // no cerramos además el deck.
+          if (document.fullscreenElement) break;
           e.preventDefault();
           onClose();
           break;
@@ -103,7 +138,7 @@ export default function TheorySlides({ module, onClose }: Props) {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [next, prev, goTo, total, onClose, gridOpen]);
+  }, [next, prev, goTo, total, onClose, gridOpen, toggleFullscreen]);
 
   // Bloquear scroll del body mientras el deck está abierto.
   useEffect(() => {
@@ -115,7 +150,17 @@ export default function TheorySlides({ module, onClose }: Props) {
   }, []);
 
   // Auto-fit: escala la slide para que no desborde verticalmente en desktop.
-  // En móvil no se escala (se hace scroll vertical).
+  // En móvil no se escala (se hace scroll vertical). Se recalcula también al
+  // cambiar el tamaño del escenario (entrar/salir de pantalla completa, resize).
+  const [fitTick, setFitTick] = useState(0);
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => setFitTick((t) => t + 1));
+    observer.observe(stage);
+    return () => observer.disconnect();
+  }, []);
+
   useLayoutEffect(() => {
     const inner = innerRef.current;
     const stage = stageRef.current;
@@ -127,7 +172,7 @@ export default function TheorySlides({ module, onClose }: Props) {
     if (need > avail) {
       inner.style.transform = `scale(${Math.max(0.55, avail / need)})`;
     }
-  }, [current, revealed, slide]);
+  }, [current, revealed, slide, fitTick]);
 
   // Swipe en móvil.
   const touch = useRef<{ x: number; y: number } | null>(null);
@@ -151,8 +196,11 @@ export default function TheorySlides({ module, onClose }: Props) {
   const atStart = current === 0 && revealed === 0;
   const atEnd = current === total - 1 && revealed >= frags;
 
-  return (
+  return createPortal(
+    // Portal a <body>: un ancestro con transform (p.ej. .vkb-card:hover) se
+    // convertiría en containing block del position:fixed y encogería el deck.
     <div
+      ref={rootRef}
       className="tslides"
       role="dialog"
       aria-modal="true"
@@ -170,6 +218,16 @@ export default function TheorySlides({ module, onClose }: Props) {
       <header className="tslides-topbar">
         <div className="tslides-title">{module.title}</div>
         <div className="tslides-actions">
+          {fullscreenSupported && (
+            <button
+              type="button"
+              onClick={toggleFullscreen}
+              aria-label={isFullscreen ? 'Salir de pantalla completa' : 'Pantalla completa'}
+              title={isFullscreen ? 'Salir de pantalla completa (F)' : 'Pantalla completa (F)'}
+            >
+              ⛶
+            </button>
+          )}
           <button
             type="button"
             onClick={() => setGridOpen(true)}
@@ -253,7 +311,7 @@ export default function TheorySlides({ module, onClose }: Props) {
         </button>
       </nav>
 
-      <p className="tslides-hint">← → o toca para avanzar · G índice · Esc para salir</p>
+      <p className="tslides-hint">← → o toca para avanzar · F pantalla completa · G índice · Esc para salir</p>
 
       {gridOpen && (
         <div className="tslides-grid" onClick={() => setGridOpen(false)}>
@@ -279,7 +337,8 @@ export default function TheorySlides({ module, onClose }: Props) {
           </div>
         </div>
       )}
-    </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -489,17 +548,6 @@ export const TSLIDES_CSS = `
     gap: 12px;
     flex-wrap: wrap;
   }
-  .tsl-cont {
-    font-family: 'Inter', sans-serif;
-    font-size: 0.6em;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: rgba(255,255,255,0.5);
-    border: 1px solid rgba(255,255,255,0.2);
-    border-radius: 999px;
-    padding: 2px 10px;
-  }
   .tsl-body {
     font-size: clamp(1.05rem, 2.1vw, 1.4rem);
     line-height: 1.65;
@@ -538,38 +586,87 @@ export const TSLIDES_CSS = `
     margin: 0 0 0.8em;
     padding: 0;
     display: grid;
-    gap: 12px;
+    gap: 14px;
   }
   .tsl-content--objectives .tsl-body li,
   .tsl-content--takeaways .tsl-body li {
     position: relative;
     margin: 0;
-    padding: 14px 18px 14px 58px;
+    padding: 18px 20px 18px 64px;
     background: rgba(255,255,255,0.05);
     border: 1px solid rgba(255,255,255,0.14);
-    border-radius: 14px;
+    border-radius: 16px;
     line-height: 1.5;
+    box-shadow: 0 10px 26px rgba(0,0,0,0.25);
   }
   .tsl-content--objectives .tsl-body li::before,
   .tsl-content--takeaways .tsl-body li::before {
     content: '✓';
     position: absolute;
-    left: 15px;
+    left: 16px;
     top: 50%;
     transform: translateY(-50%);
-    width: 28px;
-    height: 28px;
+    width: 34px;
+    height: 34px;
     border-radius: 50%;
-    background: var(--brand-glow);
-    color: var(--brand-light);
+    background: var(--gradient-signature, var(--brand));
+    color: #fff;
     font-weight: 800;
-    font-size: 0.95rem;
+    font-size: 1.05rem;
     display: grid;
     place-items: center;
+    box-shadow: 0 0 18px var(--brand-glow);
   }
   .tsl-content--takeaways .tsl-body li {
     background: var(--brand-soft);
     border-color: var(--brand);
+  }
+
+  /* ── Variante summary: flashcards de reglas de oro / chuleta de repaso ── */
+  .tsl-content--summary .tsl-body { font-size: clamp(0.9rem, 1.8vw, 1.15rem); }
+  .tsl-flashcards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 12px;
+    margin: 0 0 14px;
+  }
+  .tsl-flashcards .tslides-frag { display: flex; }
+  .tsl-flashcard {
+    position: relative;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 18px 18px 16px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.14);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 10px 26px rgba(0,0,0,0.25);
+  }
+  .tsl-flashcard::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: var(--gradient-signature, linear-gradient(90deg, var(--brand), var(--brand-light)));
+  }
+  .tsl-flashcard-term {
+    font-family: 'Unbounded', 'Inter', sans-serif;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1.3;
+    color: var(--brand-light);
+  }
+  .tsl-flashcard-body { line-height: 1.5; color: rgba(255,255,255,0.92); }
+  .tsl-flashcard-body p { margin: 0; }
+  .tsl-flashcard-body .katex { font-size: 1.12em; }
+  /* El callout 🧠 de la chuleta destaca a ancho completo bajo las tarjetas */
+  .tsl-content--summary .theory-callout {
+    background: var(--brand-soft);
+    border-left-color: var(--brand);
   }
 
   /* ── Slide de ejemplo paso a paso ── */

--- a/apps/web/src/components/theory/TheoryView.tsx
+++ b/apps/web/src/components/theory/TheoryView.tsx
@@ -20,17 +20,25 @@ export default function TheoryView({ module, courseTitle }: TheoryViewProps) {
   // La presentación es la fuente; los apuntes en texto quedan colapsados por defecto.
   const [showArticle, setShowArticle] = useState(false);
   const [pdfBusy, setPdfBusy] = useState<'download' | 'share' | null>(null);
+  const [pdfProgress, setPdfProgress] = useState<{ page: number; total: number } | null>(null);
   const slideCount = useMemo(() => buildSlides(module).length, [module]);
+
+  const pdfBusyLabel = pdfProgress
+    ? `⏳ Generando… ${pdfProgress.page}/${pdfProgress.total}`
+    : '⏳ Generando…';
 
   async function handleDownload() {
     if (pdfBusy) return;
     setPdfBusy('download');
     try {
-      await downloadTheoryPdf(module, courseTitle);
+      await downloadTheoryPdf(module, courseTitle, (page, total) =>
+        setPdfProgress({ page, total }),
+      );
     } catch {
       window.alert('No se pudo generar el PDF. Inténtalo de nuevo.');
     } finally {
       setPdfBusy(null);
+      setPdfProgress(null);
     }
   }
 
@@ -38,11 +46,12 @@ export default function TheoryView({ module, courseTitle }: TheoryViewProps) {
     if (pdfBusy) return;
     setPdfBusy('share');
     try {
-      await shareTheoryPdf(module, courseTitle);
+      await shareTheoryPdf(module, courseTitle, (page, total) => setPdfProgress({ page, total }));
     } catch {
       window.alert('No se pudo compartir el PDF. Inténtalo de nuevo.');
     } finally {
       setPdfBusy(null);
+      setPdfProgress(null);
     }
   }
 
@@ -82,7 +91,7 @@ export default function TheoryView({ module, courseTitle }: TheoryViewProps) {
           disabled={pdfBusy !== null}
           style={s.secondaryBtn}
         >
-          {pdfBusy === 'download' ? '⏳ Generando…' : '⬇️ Descargar PDF'}
+          {pdfBusy === 'download' ? pdfBusyLabel : '⬇️ Descargar PDF'}
         </button>
         <button
           type="button"
@@ -90,7 +99,7 @@ export default function TheoryView({ module, courseTitle }: TheoryViewProps) {
           disabled={pdfBusy !== null}
           style={s.secondaryBtn}
         >
-          {pdfBusy === 'share' ? '⏳ Generando…' : '📲 Enviar por WhatsApp'}
+          {pdfBusy === 'share' ? pdfBusyLabel : '📲 Enviar por WhatsApp'}
         </button>
         <button
           type="button"

--- a/apps/web/src/pages/StudyPage.tsx
+++ b/apps/web/src/pages/StudyPage.tsx
@@ -76,7 +76,7 @@ export default function StudyPage() {
           <Icon name="shapes" size={26} />
         </span>
         <span style={s.planCtaBody}>
-          <strong style={s.planCtaTitle}>Simulacro multi-tema</strong>
+          <strong style={s.planCtaTitle}>Curso multi-tema</strong>
           <span style={s.planCtaSubtitle}>
             Combina varios temas como en un examen real
           </span>
@@ -287,7 +287,7 @@ export default function StudyPage() {
       </section>
 
       <section style={s.results}>
-        <h2 className="section-label">Mis simulacros multi-tema</h2>
+        <h2 className="section-label">Mis cursos multi-tema</h2>
         {removePlan.isError && (
           <div className="alert alert-error" style={{ marginTop: 14 }}>
             {getApiErrorMessage(removePlan.error, 'No se pudo borrar el plan. Inténtalo de nuevo.')}
@@ -297,8 +297,8 @@ export default function StudyPage() {
         {!plansLoading && (plans?.length ?? 0) === 0 && (
           <EmptyState
             icon="shapes"
-            title="Aún no has creado ningún simulacro multi-tema"
-            message="Pulsa arriba en «Simulacro multi-tema» para combinar varios temas."
+            title="Aún no has creado ningún curso multi-tema"
+            message="Pulsa arriba en «Curso multi-tema» para combinar varios temas."
           />
         )}
         {!plansLoading && (plans?.length ?? 0) > 0 && (

--- a/apps/web/src/pages/StudyPlanCreatePage.tsx
+++ b/apps/web/src/pages/StudyPlanCreatePage.tsx
@@ -158,8 +158,8 @@ export default function StudyPlanCreatePage() {
     <div style={s.page}>
       <PageHeader
         variant="light"
-        title="Simulacro multi-tema"
-        subtitle="Combina varios temas de tu temario (o temas propios) en un único examen, como en un examen real."
+        title="Curso multi-tema"
+        subtitle="Combina varios temas de tu temario (o temas propios) en un curso con teoría, ejercicios y examen."
       />
 
       <form onSubmit={handleSubmit} className="dash-grid">
@@ -240,7 +240,6 @@ export default function StudyPlanCreatePage() {
                     setCustomTitle(e.target.value);
                     setCustomError('');
                   }}
-                  placeholder="Ej: verbos irregulares, la célula, ecuaciones de segundo grado..."
                   disabled={atMax}
                 />
               </div>

--- a/apps/web/src/pages/StudyPlanPage.tsx
+++ b/apps/web/src/pages/StudyPlanPage.tsx
@@ -18,8 +18,8 @@ import EmptyState from '../components/ui/EmptyState';
 type Tab = 'theory' | 'exercises' | 'exam';
 
 const STEPS: { key: Tab; label: string; icon: string; desc: string }[] = [
-  { key: 'theory', label: 'Apuntes', icon: 'book', desc: 'Estudia cada tema del simulacro' },
-  { key: 'exercises', label: 'Ejercicios', icon: 'target', desc: 'Practica todos los temas combinados' },
+  { key: 'theory', label: 'Apuntes', icon: 'book', desc: 'Estudia cada tema del curso' },
+  { key: 'exercises', label: 'Ejercicios', icon: 'target', desc: 'Practica tema a tema lo aprendido' },
   { key: 'exam', label: 'Examen', icon: 'graduation', desc: 'Un examen con preguntas de cada tema' },
 ];
 
@@ -347,6 +347,11 @@ function groupExercisesByTopic(
 
 function ExercisesTab({ plan }: { plan: StudyPlanDetail }) {
   const regen = useRegeneratePlanExercises(plan.id);
+  const groups = groupExercisesByTopic(plan.exercises ?? []);
+  // Mismo patrón de bloques colapsables por tema que el tab de Apuntes.
+  const [expandedLabel, setExpandedLabel] = useState<string | null>(
+    groups[0]?.topicLabel ?? null,
+  );
   if (!plan.exercises || plan.exercises.length === 0) {
     return (
       <MissingSection
@@ -359,15 +364,41 @@ function ExercisesTab({ plan }: { plan: StudyPlanDetail }) {
       />
     );
   }
-  const groups = groupExercisesByTopic(plan.exercises);
   return (
-    <div style={s.exerciseGroups}>
-      {groups.map((g) => (
-        <div key={g.topicLabel} style={s.exerciseGroup}>
-          <h3 style={s.exerciseGroupTitle}>{g.topicLabel}</h3>
-          <ExercisePractice exercises={g.items} />
-        </div>
-      ))}
+    <div style={s.deckList}>
+      {groups.map((g, i) => {
+        const isOpen = expandedLabel === g.topicLabel;
+        return (
+          <div key={g.topicLabel} className="vkb-card" style={s.deckCard}>
+            <button
+              type="button"
+              className="topic-deck-toggle"
+              onClick={() =>
+                setExpandedLabel((cur) => (cur === g.topicLabel ? null : g.topicLabel))
+              }
+              aria-expanded={isOpen}
+            >
+              <span style={s.deckNum}>{i + 1}</span>
+              <span style={s.deckBody}>
+                <span style={s.deckTitle}>{g.topicLabel}</span>
+                <span style={s.deckTag}>
+                  {g.items.length} {g.items.length === 1 ? 'ejercicio' : 'ejercicios'}
+                </span>
+              </span>
+              <Icon
+                name="chevron-right"
+                size={18}
+                style={{ transform: isOpen ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s' }}
+              />
+            </button>
+            {isOpen && (
+              <div style={s.deckContent}>
+                <ExercisePractice exercises={g.items} />
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -485,17 +516,6 @@ const s: Record<string, React.CSSProperties> = {
     letterSpacing: '0.04em',
   },
   deckContent: { marginTop: 16 },
-
-  exerciseGroups: { display: 'flex', flexDirection: 'column', gap: 28 },
-  exerciseGroup: { display: 'flex', flexDirection: 'column', gap: 12 },
-  exerciseGroupTitle: {
-    margin: 0,
-    fontSize: '0.8rem',
-    fontWeight: 700,
-    color: 'var(--brand-deep)',
-    textTransform: 'uppercase',
-    letterSpacing: '0.05em',
-  },
 
   examCard: {
     display: 'flex',

--- a/apps/web/src/utils/theoryPdf.ts
+++ b/apps/web/src/utils/theoryPdf.ts
@@ -80,12 +80,9 @@ function drawFooter(doc: JsPdf, pageNum: number, totalPages: number): void {
   doc.setTextColor(ORANGE.r, ORANGE.g, ORANGE.b);
   doc.text('VKB ACADEMY', FOOTER_MARGIN, FOOTER_BASELINE);
 
-  const brandW = doc.getTextWidth('VKB ACADEMY');
+  // Numeración de página (derecha)
   doc.setFont('helvetica', 'normal');
   doc.setTextColor(FOOTER_MUTED.r, FOOTER_MUTED.g, FOOTER_MUTED.b);
-  doc.text('· Temario', FOOTER_MARGIN + brandW + 10, FOOTER_BASELINE);
-
-  // Numeración de página (derecha)
   doc.text(`${pageNum} / ${totalPages}`, PAGE_W - FOOTER_MARGIN, FOOTER_BASELINE, {
     align: 'right',
   });
@@ -138,7 +135,6 @@ const PDF_OVERRIDE_CSS = `
   .tslides-pdf-page .tsl-closing-title { color: #111827; }
   .tslides-pdf-page .tsl-logo { filter: none; }
   .tslides-pdf-page .tsl-heading { color: #111827; }
-  .tslides-pdf-page .tsl-cont { color: #475569; border-color: #cbd5e1; }
   .tslides-pdf-page .tsl-body { color: #111827; }
   .tslides-pdf-page .tsl-body strong { color: #000; }
   .tslides-pdf-page .tsl-body code { background: #f1f5f9; color: #111827; }
@@ -152,11 +148,25 @@ const PDF_OVERRIDE_CSS = `
   .tslides-pdf-page .tsl-content--takeaways .tsl-body li {
     background: #f8fafc;
     border-color: #cbd5e1;
+    box-shadow: none;
   }
   .tslides-pdf-page .tsl-content--objectives .tsl-body li::before,
   .tslides-pdf-page .tsl-content--takeaways .tsl-body li::before {
     background: #e2e8f0;
     color: #111827;
+    box-shadow: none;
+  }
+  .tslides-pdf-page .tsl-flashcard {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+    box-shadow: none;
+  }
+  .tslides-pdf-page .tsl-flashcard::before { background: #94a3b8; }
+  .tslides-pdf-page .tsl-flashcard-term { color: #111827; }
+  .tslides-pdf-page .tsl-flashcard-body { color: #111827; }
+  .tslides-pdf-page .tsl-content--summary .theory-callout {
+    background: #f1f5f9 !important;
+    border-left-color: #64748b !important;
   }
   .tslides-pdf-page .tsl-ex-label { color: #334155; }
   .tslides-pdf-page .tsl-ex-statement { background: #f8fafc; border-color: #cbd5e1; }
@@ -169,26 +179,43 @@ const PDF_OVERRIDE_CSS = `
   .tslides-pdf-page .tsl-video-card-play { background: #e2e8f0; color: #111827; box-shadow: none; }
 `;
 
-function PdfPages({ slides }: { slides: Slide[] }) {
+// Una sola página montada a la vez: html2canvas clona el documento entero en
+// cada captura, así que montar TODAS las slides a la vez encarece cada captura
+// con el DOM de las demás (los temarios con mucho KaTeX tardaban minutos).
+function PdfPage({ slide }: { slide: Slide }) {
   return createElement(
     'div',
     null,
     createElement('style', null, TSLIDES_CSS + THEORY_CALLOUT_CSS + PDF_OVERRIDE_CSS),
-    ...slides.map((slide) =>
+    createElement(
+      'div',
+      {
+        key: slide.id,
+        className: 'tslides-pdf-page',
+        style: slide.kind === 'cover' ? COVER_PAGE_STYLE : PAGE_STYLE,
+      },
       createElement(
         'div',
-        {
-          key: slide.id,
-          className: 'tslides-pdf-page',
-          style: slide.kind === 'cover' ? COVER_PAGE_STYLE : PAGE_STYLE,
-        },
-        createElement(
-          'div',
-          { className: 'tslides-inner', style: { width: '100%', maxWidth: 1080 } },
-          createElement(SlideView, { slide, revealed: Number.MAX_SAFE_INTEGER, forPdf: true }),
-        ),
+        { className: 'tslides-inner', style: { width: '100%', maxWidth: 1080 } },
+        createElement(SlideView, { slide, revealed: Number.MAX_SAFE_INTEGER, forPdf: true }),
       ),
     ),
+  );
+}
+
+/** Avance de la generación, para pintar "Generando… página i de N" en la UI. */
+export type PdfProgress = (page: number, total: number) => void;
+
+/** Espera a que React pinte, carguen fuentes (KaTeX) e imágenes de la página montada. */
+async function waitForPageReady(host: HTMLElement): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+  try {
+    await document.fonts.ready;
+  } catch {
+    /* fonts.ready no soportado: continuar */
+  }
+  await Promise.all(
+    Array.from(host.querySelectorAll('img')).map((img) => img.decode().catch(() => undefined)),
   );
 }
 
@@ -199,10 +226,11 @@ function buildDocTitle(module: TheoryModuleWithLessons, courseTitle: string): st
   return `${courseTitle} - ${capitalized}`;
 }
 
-/** Renderiza las slides fuera de pantalla y genera el documento PDF. */
+/** Renderiza las slides fuera de pantalla (una a una) y genera el documento PDF. */
 async function generateTheoryPdf(
   module: TheoryModuleWithLessons,
   courseTitle: string,
+  onProgress?: PdfProgress,
 ): Promise<JsPdf> {
   // Carga diferida: html2canvas/jsPDF solo se descargan al exportar (no en el bundle inicial).
   const [{ default: JsPDFCtor }, { default: html2canvas }, logo] = await Promise.all([
@@ -228,28 +256,21 @@ async function generateTheoryPdf(
   document.body.appendChild(host);
 
   const root = createRoot(host);
-  root.render(createElement(PdfPages, { slides }));
-
-  // Esperar a que carguen fuentes (incl. KaTeX), imágenes (logo) y a que React
-  // pinte el markdown.
-  try {
-    await document.fonts.ready;
-  } catch {
-    /* fonts.ready no soportado: continuar */
-  }
-  await new Promise((resolve) => setTimeout(resolve, 400));
-  await Promise.all(
-    Array.from(host.querySelectorAll('img')).map((img) => img.decode().catch(() => undefined)),
-  );
-
-  const pages = Array.from(host.querySelectorAll<HTMLElement>('.tslides-pdf-page'));
   const doc = new JsPDFCtor({ orientation: 'landscape', unit: 'px', format: [PAGE_W, PAGE_H] });
 
   try {
-    for (let i = 0; i < pages.length; i++) {
-      const isCover = slides[i]?.kind === 'cover';
+    for (let i = 0; i < slides.length; i++) {
+      onProgress?.(i + 1, slides.length);
+      const isCover = slides[i].kind === 'cover';
+
+      root.render(createElement(PdfPage, { slide: slides[i] }));
+      await waitForPageReady(host);
+
+      const page = host.querySelector<HTMLElement>('.tslides-pdf-page');
+      if (!page) continue;
+
       // Escalar el contenido para que no se recorte en la página (no hay scroll en PDF).
-      const inner = pages[i].querySelector<HTMLElement>('.tslides-inner');
+      const inner = page.querySelector<HTMLElement>('.tslides-inner');
       if (inner) {
         const availH = isCover ? PAGE_H - 112 : PAGE_H - HEADER_H - 80; // padding vertical
         const availW = PAGE_W - 160; // padding horizontal (80 × 2)
@@ -259,7 +280,7 @@ async function generateTheoryPdf(
       // scale 3 para texto nítido al imprimir (a scale 2 salía borroso). JPEG en
       // calidad alta: jsPDF incrusta los PNG como píxeles sin comprimir (~24 MB
       // por página); a 3x los artefactos JPEG son invisibles.
-      const canvas = await html2canvas(pages[i], {
+      const canvas = await html2canvas(page, {
         scale: 3,
         backgroundColor: '#ffffff',
         useCORS: true,
@@ -271,7 +292,7 @@ async function generateTheoryPdf(
       if (i > 0) doc.addPage([PAGE_W, PAGE_H], 'landscape');
       doc.addImage(img, 'JPEG', 0, 0, PAGE_W, PAGE_H);
       if (!isCover) drawHeader(doc, logo, docTitle);
-      drawFooter(doc, i + 1, pages.length);
+      drawFooter(doc, i + 1, slides.length);
     }
   } finally {
     root.unmount();
@@ -294,8 +315,9 @@ export function theoryPdfFilename(module: TheoryModuleWithLessons, courseTitle: 
 export async function downloadTheoryPdf(
   module: TheoryModuleWithLessons,
   courseTitle: string,
+  onProgress?: PdfProgress,
 ): Promise<void> {
-  const doc = await generateTheoryPdf(module, courseTitle);
+  const doc = await generateTheoryPdf(module, courseTitle, onProgress);
   doc.save(theoryPdfFilename(module, courseTitle));
 }
 
@@ -309,8 +331,9 @@ type ShareResult = 'shared' | 'downloaded';
 export async function shareTheoryPdf(
   module: TheoryModuleWithLessons,
   courseTitle: string,
+  onProgress?: PdfProgress,
 ): Promise<ShareResult> {
-  const doc = await generateTheoryPdf(module, courseTitle);
+  const doc = await generateTheoryPdf(module, courseTitle, onProgress);
   const filename = theoryPdfFilename(module, courseTitle);
   const blob = doc.output('blob');
   const file = new File([blob], filename, { type: 'application/pdf' });

--- a/apps/web/src/utils/theorySlides.test.ts
+++ b/apps/web/src/utils/theorySlides.test.ts
@@ -5,6 +5,7 @@ import {
   fragmentCount,
   paginateBlocks,
   parseExample,
+  parseSummaryCards,
   resolveVideoCandidates,
   splitExampleChunks,
   splitMarkdownBlocks,
@@ -121,7 +122,8 @@ describe('buildSlides', () => {
     const slides = buildSlides(moduleWith([lesson({ kind: 'CONTENT', body })]));
     const content = slides.filter((s) => s.kind === 'content');
     expect(content.length).toBe(2);
-    expect(content[1].continued).toBe(true);
+    // Las dos slides comparten heading, sin marcador "cont." (fuera de la UI).
+    expect(content[0].heading).toBe(content[1].heading);
   });
 
   it('numera las slides de forma correlativa', () => {
@@ -209,6 +211,39 @@ describe('buildSlides — estructura Winston', () => {
     expect(slides.find((s) => s.kind === 'content')!.variant).toBeUndefined();
   });
 
+  it('marca "Reglas de oro" y "Chuleta de repaso" como variante summary con flashcards', () => {
+    const body = `- **Fracción generatriz**: $x = a/b$\n- **Redondeo**: mira la cifra siguiente\n\n> 🧠 **Recuerda:** lo más importante.`;
+    for (const heading of ['Reglas de oro', 'Chuleta de repaso']) {
+      const slides = buildSlides(moduleWith([lesson({ kind: 'CONTENT', heading, body })]));
+      const slide = slides.find((s) => s.kind === 'content')!;
+      expect(slide.variant).toBe('summary');
+      expect(slide.cards).toEqual([
+        { term: 'Fracción generatriz', body: '$x = a/b$' },
+        { term: 'Redondeo', body: 'mira la cifra siguiente' },
+      ]);
+      expect(slide.blocks).toEqual(['> 🧠 **Recuerda:** lo más importante.']);
+    }
+  });
+
+  it('una summary sin items de lista degrada a contenido normal (sin tarjetas)', () => {
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'CONTENT', heading: 'Reglas de oro', body: 'párrafo suelto' })]),
+    );
+    const slide = slides.find((s) => s.kind === 'content')!;
+    expect(slide.cards).toEqual([]);
+    expect(slide.blocks).toEqual(['párrafo suelto']);
+  });
+
+  it('la summary no se pagina aunque supere el presupuesto de caracteres', () => {
+    const items = Array.from({ length: 8 }, (_, i) => `- **Regla ${i}**: ${'x'.repeat(90)}`);
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'CONTENT', heading: 'Reglas de oro', body: items.join('\n') })]),
+    );
+    const content = slides.filter((s) => s.kind === 'content');
+    expect(content).toHaveLength(1);
+    expect(content[0].cards).toHaveLength(8);
+  });
+
   it('convierte una lección EXAMPLE estructurada en slides example con pasos', () => {
     const body = `${EXAMPLE_MD}\n${EXAMPLE_MD.replace('Ejemplo 1', 'Ejemplo 2')}`;
     const slides = buildSlides(moduleWith([lesson({ kind: 'EXAMPLE', heading: 'Ejemplos', body })]));
@@ -230,7 +265,32 @@ describe('buildSlides — estructura Winston', () => {
   });
 });
 
+describe('parseSummaryCards', () => {
+  it('separa tarjetas y resto dentro del mismo bloque', () => {
+    const { cards, rest } = parseSummaryCards(['- **A**: uno\nlínea suelta\n- **B.** dos']);
+    expect(cards).toEqual([
+      { term: 'A', body: 'uno' },
+      { term: 'B', body: 'dos' },
+    ]);
+    expect(rest).toEqual(['línea suelta']);
+  });
+
+  it('devuelve todo como resto si nada parsea', () => {
+    const { cards, rest } = parseSummaryCards(['párrafo', '- item sin negrita']);
+    expect(cards).toEqual([]);
+    expect(rest).toEqual(['párrafo', '- item sin negrita']);
+  });
+});
+
 describe('fragmentCount', () => {
+  it('en slides summary cuenta tarjetas + bloques restantes', () => {
+    const body = `- **A**: uno\n- **B**: dos\n\n> 🧠 **Recuerda:** clave.`;
+    const slides = buildSlides(
+      moduleWith([lesson({ kind: 'CONTENT', heading: 'Reglas de oro', body })]),
+    );
+    expect(fragmentCount(slides.find((s) => s.kind === 'content')!)).toBe(3);
+  });
+
   it('en slides example cuenta enunciado + pasos + resultado + porqué', () => {
     const slides = buildSlides(
       moduleWith([lesson({ kind: 'EXAMPLE', heading: 'Ejemplos', body: EXAMPLE_MD })]),

--- a/apps/web/src/utils/theorySlides.ts
+++ b/apps/web/src/utils/theorySlides.ts
@@ -23,8 +23,14 @@ import type {
 
 export type SlideKind = 'cover' | 'content' | 'video' | 'closing' | 'example';
 
-/** Variante visual de una slide de contenido (checklist Winston). */
-export type ContentVariant = 'objectives' | 'takeaways';
+/** Variante visual de una slide de contenido (checklist Winston / flashcards). */
+export type ContentVariant = 'objectives' | 'takeaways' | 'summary';
+
+/** Tarjeta de la variante summary: término + regla/fórmula ("- **término**: regla"). */
+export interface SummaryCard {
+  term: string;
+  body: string;
+}
 
 export interface Slide {
   id: string;
@@ -41,10 +47,10 @@ export interface Slide {
   heading?: string;
   /** Bloques de markdown; cada uno se revela como un fragmento. */
   blocks?: string[];
-  /** true si es continuación de una lección dividida en varias slides. */
-  continued?: boolean;
-  /** Promesa inicial u "objetivos" / cierre "lo que te llevas". */
+  /** Promesa inicial u "objetivos" / cierre "lo que te llevas" / chuleta "reglas de oro". */
   variant?: ContentVariant;
+  /** Flashcards de la variante summary (se revelan antes que los blocks). */
+  cards?: SummaryCard[];
   // example (ejercicio resuelto paso a paso)
   statement?: string;
   steps?: string[];
@@ -105,16 +111,44 @@ export function paginateBlocks(blocks: string[], budget = MAX_SLIDE_CHARS): stri
 
 const OBJECTIVES_RE = /qu[eé] vas a conseguir/i;
 const TAKEAWAYS_RE = /lo que te llevas/i;
+const SUMMARY_RE = /chuleta de repaso|reglas de oro|resumen/i;
 
 /**
- * Detecta si una lección es la promesa inicial o el cierre Winston por su
- * heading. Los temarios antiguos ("Introducción", …) no matchean y se
- * renderizan como contenido normal.
+ * Detecta si una lección es la promesa inicial, el cierre Winston o la chuleta
+ * de reglas clave por su heading. Los temarios antiguos ("Introducción", …) no
+ * matchean y se renderizan como contenido normal.
  */
 export function contentVariant(lesson: TheoryLesson): ContentVariant | undefined {
   if (lesson.kind === 'INTRO' && OBJECTIVES_RE.test(lesson.heading)) return 'objectives';
   if (TAKEAWAYS_RE.test(lesson.heading)) return 'takeaways';
+  if (lesson.kind !== 'INTRO' && SUMMARY_RE.test(lesson.heading)) return 'summary';
   return undefined;
+}
+
+const SUMMARY_CARD_RE = /^[-*]\s+\*\*(.+?)\*\*[:.]?\s*(.*)$/;
+
+/**
+ * Extrae las flashcards de una slide summary: cada línea "- **término**: regla"
+ * se convierte en tarjeta; el resto de líneas/bloques (callouts, párrafos) se
+ * conserva como bloques normales. Si nada parsea, degrada a contenido normal.
+ */
+export function parseSummaryCards(blocks: string[]): { cards: SummaryCard[]; rest: string[] } {
+  const cards: SummaryCard[] = [];
+  const rest: string[] = [];
+
+  for (const block of blocks) {
+    const leftover: string[] = [];
+    for (const line of block.split('\n')) {
+      const match = line.trim().match(SUMMARY_CARD_RE);
+      // El separador a veces queda dentro de la negrita ("- **Regla.** texto").
+      if (match) cards.push({ term: match[1].trim().replace(/[:.]+$/, ''), body: match[2].trim() });
+      else leftover.push(line);
+    }
+    const restBlock = leftover.join('\n').trim();
+    if (restBlock) rest.push(restBlock);
+  }
+
+  return { cards, rest };
 }
 
 export interface ParsedExample {
@@ -259,7 +293,6 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
             kind: 'content',
             heading: stripLeadingEmoji(lesson.heading),
             blocks: pageBlocks,
-            continued: emitted > 0 || j > 0,
           });
           emitted++;
         });
@@ -277,17 +310,28 @@ export function buildSlides(module: TheoryModuleWithLessons): Slide[] {
 
     const variant = contentVariant(lesson);
     const blocks = splitMarkdownBlocks(lesson.body ?? '');
-    // La promesa y el cierre son checklists cortas y autocontenidas: siempre en
-    // una sola slide (paginarlas deja el callout huérfano en una slide "cont.").
+    // Las variantes (promesa, cierre, chuleta) son autocontenidas: siempre en
+    // una sola slide (paginarlas dejaría huérfanos el callout o las tarjetas).
     const pages =
       blocks.length === 0 ? [['']] : variant ? [blocks] : paginateBlocks(blocks);
     pages.forEach((pageBlocks, i) => {
+      if (variant === 'summary') {
+        const { cards, rest } = parseSummaryCards(pageBlocks);
+        slides.push({
+          id: `${lesson.id}-${i}`,
+          kind: 'content',
+          heading: stripLeadingEmoji(lesson.heading),
+          blocks: rest,
+          variant,
+          cards,
+        });
+        return;
+      }
       slides.push({
         id: `${lesson.id}-${i}`,
         kind: 'content',
         heading: stripLeadingEmoji(lesson.heading),
         blocks: pageBlocks,
-        continued: i > 0,
         variant,
       });
     });
@@ -306,15 +350,15 @@ function slideLabel(slide: Omit<Slide, 'index' | 'label'>, i: number): string {
   if (slide.kind === 'cover') return 'Portada';
   if (slide.kind === 'closing') return 'Fin';
   if (slide.kind === 'video') return slide.heading ?? 'Vídeo';
-  const base = slide.heading ?? `Slide ${i + 1}`;
-  return slide.continued ? `${base} (cont.)` : base;
+  return slide.heading ?? `Slide ${i + 1}`;
 }
 
-/** Nº de fragmentos revelables de una slide (bloques o piezas del ejemplo). */
+/** Nº de fragmentos revelables de una slide (bloques, tarjetas o piezas del ejemplo). */
 export function fragmentCount(slide: Slide): number {
   if (slide.kind === 'example') {
     // enunciado + pasos + resultado + porqué (si existe)
     return 1 + (slide.steps?.length ?? 0) + 1 + (slide.why ? 1 : 0);
   }
-  return slide.kind === 'content' ? (slide.blocks?.length ?? 0) : 0;
+  if (slide.kind !== 'content') return 0;
+  return (slide.cards?.length ?? 0) + (slide.blocks?.length ?? 0);
 }


### PR DESCRIPTION
Feedback de uso del curso multi-tema (06/07), parte 1 de 2: fixes y visual.

## Bug de pantalla completa de la presentación (causa raíz)

`.vkb-card:hover` aplica `transform: translateY(-3px)`; en `StudyPlanPage` el deck (`position: fixed; inset: 0`) se monta dentro de esa tarjeta y, por especificación CSS, un ancestro con transform pasa a ser el containing block de los `fixed`: con el ratón encima el deck se encogía a la tarjeta y al salir el ratón (otra pantalla) se expandía al viewport.

- Deck renderizado vía `createPortal(document.body)`: inmune a ancestros transformados.
- Botón de pantalla completa real (Fullscreen API, atajo `F`), oculto si el navegador no la soporta.
- El auto-ajuste de escala se recalcula con `ResizeObserver` (antes solo al cambiar de slide).
- Tests: portal bajo `<body>` con padre transformado, botón con `requestFullscreen` mockeado.

## PDF lento en módulos con muchas fórmulas

html2canvas clona el documento entero en cada captura: con todas las slides montadas el coste era ~cuadrático y los temarios densos en KaTeX (raíces, logaritmos) tardaban minutos. Ahora se monta una sola página por captura y el botón muestra `Generando… i/N`.

## Slides

- Fuera el chip "cont." y el "(cont.)" del índice.
- Fuera el "· Temario" del pie del PDF.
- La "Chuleta de repaso" pasa a "Reglas de oro" (prompt) y se renderiza como flashcards (término + regla, grid de tarjetas KPI); el callout 🧠 destaca a ancho completo. Los decks existentes matchean por regex (chuleta|reglas de oro|resumen).
- Checklists de "Qué vas a conseguir" / "Lo que te llevas" con tarjetas más vistosas.

## Curso multi-tema

- Renombrado "Simulacro multi-tema" → "Curso multi-tema" en toda la UI; el título generado pierde el prefijo "Simulacro:".
- Tab de ejercicios agrupado por tema con tarjetas colapsables numeradas (mismo patrón que los apuntes).
- Fuera el placeholder "Ej: verbos irregulares, la célula…" del tema propio.

## Verificación

- API: suites de theory y study-plans 52/52 (el resto no se toca).
- Web: `tsc --noEmit` limpio; vitest 37/37 en los ficheros tocados (fallo preexistente de email-validation exento).
- Pendiente tras deploy en PRE: QA visual con el curso real (deck + PDF de los 3 módulos).

Parte 2 (en rama aparte): ejercicios configurables por tema y dificultad, exámenes por nivel básico/medio/difícil (por tema o combinado, generación lazy), renombrado de cursos por el alumno y ampliación del temario oficial de Matemáticas 3º ESO.
