### PR TITLE
feat: ejercicios por dificultad, examenes por nivel, rename y temario 3 ESO (parte 2)

### DIFF
--- a/apps/api/prisma/data/mates-3eso-modules.ts
+++ b/apps/api/prisma/data/mates-3eso-modules.ts
@@ -1,0 +1,18 @@
+// Temario oficial de Matemáticas 3º ESO — 14 unidades en orden curricular.
+// Compartido entre seed.ts (BDs nuevas) y seed-modules-mates-3eso.ts (BDs existentes).
+export const MATES_3ESO_MODULES: string[] = [
+  'Números racionales y reales',
+  'Potencias y raíces',
+  'Sucesiones y progresiones',
+  'Proporcionalidad',
+  'Educación financiera',
+  'Polinomios',
+  'Ecuaciones de primer y segundo grado',
+  'Sistemas de ecuaciones',
+  'Funciones lineales y cuadráticas',
+  'Geometría plana: Tales y Pitágoras',
+  'Movimientos en el plano',
+  'Cuerpos geométricos',
+  'Estadística',
+  'Probabilidad',
+];

--- a/apps/api/prisma/migrations/20260706170000_study_plan_exam_levels/migration.sql
+++ b/apps/api/prisma/migrations/20260706170000_study_plan_exam_levels/migration.sql
@@ -1,0 +1,19 @@
+-- Exámenes por nivel del plan multi-tema: AiExamBank.studyPlanId pasa de 1:1 a
+-- 1:N (un banco por nivel BASIC/MEDIUM/HARD, combinado o por tema) y StudyPlan
+-- persiste el reparto de ejercicios elegido. Aditiva salvo el drop del unique.
+
+-- DropIndex
+DROP INDEX "AiExamBank_studyPlanId_key";
+
+-- AlterTable
+ALTER TABLE "AiExamBank" ADD COLUMN     "level" TEXT,
+ADD COLUMN     "studyPlanTopicId" TEXT;
+
+-- AlterTable
+ALTER TABLE "StudyPlan" ADD COLUMN     "exercisesConfig" JSONB;
+
+-- CreateIndex
+CREATE INDEX "AiExamBank_studyPlanId_idx" ON "AiExamBank"("studyPlanId");
+
+-- AddForeignKey
+ALTER TABLE "AiExamBank" ADD CONSTRAINT "AiExamBank_studyPlanTopicId_fkey" FOREIGN KEY ("studyPlanTopicId") REFERENCES "StudyPlanTopic"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -647,12 +647,21 @@ model AiExamBank {
   studyUnitId String?    @unique
   studyUnit   StudyUnit? @relation(fields: [studyUnitId], references: [id], onDelete: Cascade)
 
-  // Examen combinado de un plan de estudio multi-tema (1:1 con el plan)
-  studyPlanId String?    @unique
+  // Exámenes de un plan multi-tema: uno por nivel (BASIC/MEDIUM/HARD), combinado
+  // (studyPlanTopicId null) o por tema. Generación lazy desde la pestaña Examen.
+  studyPlanId String?
   studyPlan   StudyPlan? @relation(fields: [studyPlanId], references: [id], onDelete: Cascade)
+
+  /// Tema del plan cuando el examen es por tema (modo PER_TOPIC).
+  studyPlanTopicId String?
+  studyPlanTopic   StudyPlanTopic? @relation(fields: [studyPlanTopicId], references: [id], onDelete: Cascade)
+
+  /// Nivel del examen del plan (BASIC | MEDIUM | HARD); null en bancos un-tema y legacy.
+  level String?
 
   @@index([userId, createdAt])
   @@index([userId, courseId])
+  @@index([studyPlanId])
 }
 
 model AiExamQuestion {
@@ -735,14 +744,16 @@ model StudyPlan {
   summary  String @db.Text @default("")
   /// Dificultad elegida por el alumno (EASY | MEDIUM | HARD).
   difficulty String @default("MEDIUM")
-  /// Ejercicios combinados generados por IA; cada item lleva topicLabel para agrupar en UI.
+  /// Ejercicios por tema generados por IA; cada item lleva topicLabel y difficulty.
   exercises Json?
+  /// Reparto de ejercicios por tema elegido al crear: { easy, medium, hard }.
+  exercisesConfig Json?
   createdAt DateTime @default(now())
 
-  user     User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-  course   Course           @relation("CourseStudyPlans", fields: [courseId], references: [id], onDelete: Cascade)
-  topics   StudyPlanTopic[]
-  examBank AiExamBank? // vía AiExamBank.studyPlanId
+  user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  course    Course           @relation("CourseStudyPlans", fields: [courseId], references: [id], onDelete: Cascade)
+  topics    StudyPlanTopic[]
+  examBanks AiExamBank[] // vía AiExamBank.studyPlanId (uno por nivel/tema, lazy)
 
   @@index([userId, createdAt])
   @@index([userId, courseId])
@@ -762,6 +773,7 @@ model StudyPlanTopic {
   plan         StudyPlan     @relation(fields: [planId], references: [id], onDelete: Cascade)
   module       Module?       @relation("ModuleStudyPlanTopics", fields: [moduleId], references: [id], onDelete: SetNull)
   theoryModule TheoryModule? // vía TheoryModule.studyPlanTopicId
+  examBanks    AiExamBank[] // exámenes por tema (modo PER_TOPIC), vía AiExamBank.studyPlanTopicId
 
   @@index([planId, order])
 }

--- a/apps/api/prisma/seed-modules-mates-3eso.ts
+++ b/apps/api/prisma/seed-modules-mates-3eso.ts
@@ -1,0 +1,74 @@
+// Script idempotente: amplía el temario oficial de "Matemáticas 3º ESO" con las 14 unidades
+// de MATES_3ESO_MODULES. No borra ni modifica módulos existentes.
+//
+// Uso:
+//   DATABASE_URL="postgresql://..." npx ts-node prisma/seed-modules-mates-3eso.ts [courseId]
+//
+// Si se pasa courseId como argumento, tiene prioridad sobre la búsqueda por título.
+import { PrismaClient } from '@prisma/client';
+import { MATES_3ESO_MODULES } from './data/mates-3eso-modules';
+
+const prisma = new PrismaClient();
+
+// Normaliza un título para comparación: trim + minúsculas + sin acentos.
+function normalizeTitle(title: string): string {
+  return title
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    // Marca de diacríticos: U+0300 a U+036F (tildes, virgulillas, etc.)
+    .replace(/[̀-ͯ]/g, '');
+}
+
+async function main() {
+  const courseIdArg = process.argv[2];
+
+  const course = courseIdArg
+    ? await prisma.course.findUnique({ where: { id: courseIdArg } })
+    : await prisma.course.findFirst({
+        where: { title: { equals: 'Matemáticas 3º ESO', mode: 'insensitive' } },
+      });
+
+  if (!course) {
+    console.error(
+      courseIdArg
+        ? `❌ No se ha encontrado ningún curso con id "${courseIdArg}".`
+        : '❌ No se ha encontrado el curso "Matemáticas 3º ESO". Pasa un courseId como argumento si el título difiere.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`📚 Curso: ${course.title} (${course.id})`);
+
+  const existingModules = await prisma.module.findMany({
+    where: { courseId: course.id },
+    orderBy: { order: 'asc' },
+  });
+
+  const existingNormalizedTitles = new Set(existingModules.map((m) => normalizeTitle(m.title)));
+  let nextOrder = existingModules.reduce((max, m) => Math.max(max, m.order), 0) + 1;
+
+  for (const title of MATES_3ESO_MODULES) {
+    if (existingNormalizedTitles.has(normalizeTitle(title))) {
+      console.log(`   ⏭️  Ya existía: ${title}`);
+      continue;
+    }
+
+    await prisma.module.create({
+      data: { title, order: nextOrder, courseId: course.id },
+    });
+    console.log(`   ✅ Creada: ${title} (order ${nextOrder})`);
+    nextOrder += 1;
+  }
+
+  console.log('✅ Temario de Matemáticas 3º ESO actualizado.');
+}
+
+main()
+  .catch((e) => {
+    console.error('❌ Error:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, Role, ChallengeType } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
+import { MATES_3ESO_MODULES } from './data/mates-3eso-modules';
 
 const prisma = new PrismaClient();
 
@@ -227,12 +228,19 @@ async function main() {
   });
 
   // Curso: Matemáticas de 3º ESO — visible para el student de ejemplo
+  // Temario oficial: las 14 unidades de MATES_3ESO_MODULES, en orden
   const courseMath = await prisma.course.create({
     data: {
       title: 'Matemáticas 3º ESO',
       description: 'Repaso de álgebra, geometría y estadística para 3º de ESO.',
       published: true,
       schoolYearId: sy3eso.id,
+      modules: {
+        create: MATES_3ESO_MODULES.map((title, index) => ({
+          title,
+          order: index + 1,
+        })),
+      },
     },
   });
 

--- a/apps/api/src/exercises/exercises.service.spec.ts
+++ b/apps/api/src/exercises/exercises.service.spec.ts
@@ -127,6 +127,130 @@ describe('ExercisesService', () => {
     });
   });
 
+  describe('generateForTopics', () => {
+    function easyExerciseJson(): string {
+      return JSON.stringify({
+        exercises: [
+          {
+            difficulty: 'EASY',
+            statement: 'x',
+            type: 'SINGLE',
+            options: ['a', 'b'],
+            solution: 'a',
+            explanation: 'porque sí',
+          },
+        ],
+      });
+    }
+
+    it('hace una llamada IA por tema (no una combinada)', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      ai.generate.mockResolvedValue(easyExerciseJson());
+
+      const result = await service.generateForTopics('user-1', {
+        courseId: 'course-1',
+        topics: ['Tema A', 'Tema B'],
+        perTopic: { easy: 1, medium: 0, hard: 0 },
+      });
+
+      expect(ai.generate).toHaveBeenCalledTimes(2);
+      expect(result.exercises).toHaveLength(2);
+      // El topicLabel lo asigna el servicio localmente, no la IA
+      expect(result.exercises.map((e) => e.topicLabel)).toEqual(['Tema A', 'Tema B']);
+      expect(result.exercises.every((e) => e.difficulty === 'EASY')).toBe(true);
+    });
+
+    it('lanza ForbiddenException si el alumno no está matriculado', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.generateForTopics('user-1', {
+          courseId: 'course-1',
+          topics: ['Tema A'],
+          perTopic: { easy: 1, medium: 0, hard: 0 },
+        }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(ai.generate).not.toHaveBeenCalled();
+    });
+
+    it('lanza NotFoundException si el curso no existe', async () => {
+      prisma.course.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.generateForTopics('user-1', {
+          courseId: 'missing',
+          topics: ['Tema A'],
+          perTopic: { easy: 1, medium: 0, hard: 0 },
+        }),
+      ).rejects.toThrow(NotFoundException);
+      expect(ai.generate).not.toHaveBeenCalled();
+    });
+
+    it('reintenta (2x) un tema cuyo conteo por dificultad no cuadra, y acepta si el 2º intento es correcto', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      // 1er intento: la IA devuelve MEDIUM cuando se pidió EASY (conteo incumplido)
+      ai.generate
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            exercises: [
+              {
+                difficulty: 'MEDIUM',
+                statement: 'x',
+                type: 'SINGLE',
+                options: ['a', 'b'],
+                solution: 'a',
+                explanation: 'z',
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(easyExerciseJson());
+
+      const result = await service.generateForTopics('user-1', {
+        courseId: 'course-1',
+        topics: ['Fracciones'],
+        perTopic: { easy: 1, medium: 0, hard: 0 },
+      });
+
+      expect(ai.generate).toHaveBeenCalledTimes(2);
+      expect(result.exercises).toHaveLength(1);
+      expect(result.exercises[0].difficulty).toBe('EASY');
+      expect(result.exercises[0].topicLabel).toBe('Fracciones');
+    });
+
+    it('lanza error tras agotar los 2 intentos si el conteo por dificultad sigue sin cuadrar', async () => {
+      prisma.course.findUnique.mockResolvedValue(baseCourse);
+      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
+      // Ambos intentos devuelven MEDIUM cuando se pidió EASY
+      ai.generate.mockResolvedValue(
+        JSON.stringify({
+          exercises: [
+            {
+              difficulty: 'MEDIUM',
+              statement: 'x',
+              type: 'SINGLE',
+              options: ['a', 'b'],
+              solution: 'a',
+              explanation: 'z',
+            },
+          ],
+        }),
+      );
+
+      await expect(
+        service.generateForTopics('user-1', {
+          courseId: 'course-1',
+          topics: ['Fracciones'],
+          perTopic: { easy: 1, medium: 0, hard: 0 },
+        }),
+      ).rejects.toThrow();
+      expect(ai.generate).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('evaluate', () => {
     const dto = {
       statement: '¿Cuánto vale 2+2?',

--- a/apps/api/src/exercises/exercises.service.ts
+++ b/apps/api/src/exercises/exercises.service.ts
@@ -8,7 +8,6 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { AiProviderService } from '../ai/ai-provider.service';
 import { generateAiJson } from '../ai/ai-json';
-import { splitAcrossTopics } from '../ai/topic-distribution';
 import { GenerateExercisesDto } from './dto/generate-exercises.dto';
 import { EvaluateExerciseDto } from './dto/evaluate-exercise.dto';
 
@@ -26,20 +25,29 @@ export interface GenerateExercisesResult {
   exercises: GeneratedExercise[];
 }
 
-// Ejercicio del flujo multi-tema (StudyPlan): etiquetado con su tema.
+export type ExerciseDifficulty = 'EASY' | 'MEDIUM' | 'HARD';
+
+// Ejercicio del flujo multi-tema (StudyPlan): etiquetado con su tema y dificultad.
 export interface GeneratedTopicExercise extends GeneratedExercise {
   topicLabel: string;
+  difficulty: ExerciseDifficulty;
 }
 
 export interface GenerateTopicExercisesResult {
   exercises: GeneratedTopicExercise[];
 }
 
+// Reparto de ejercicios POR TEMA: cada tema recibe easy+medium+hard.
+export interface ExerciseDifficultySplit {
+  easy: number;
+  medium: number;
+  hard: number;
+}
+
 export interface GenerateExercisesForTopicsParams {
   courseId: string;
   topics: string[];
-  count: number;
-  difficulty?: 'EASY' | 'MEDIUM' | 'HARD';
+  perTopic: ExerciseDifficultySplit;
 }
 
 export type EvaluationVerdict = 'correct' | 'partial' | 'incorrect';
@@ -124,9 +132,10 @@ export class ExercisesService {
   }
 
   /**
-   * Variante multi-tema (flujo StudyPlan): una sola llamada IA que reparte
-   * `count` ejercicios entre los temas (base floor(count/T), resto a los
-   * primeros) y etiqueta cada uno con su `topicLabel` para agrupar en UI.
+   * Variante multi-tema (flujo StudyPlan): una llamada IA POR TEMA, cada una
+   * con el reparto de dificultad pedido (easy/medium/hard). El `topicLabel` se
+   * asigna localmente (no se confía a la IA) y la validación exige el conteo
+   * exacto por dificultad; ante fallo semántico se regenera ese tema (2x).
    */
   async generateForTopics(
     userId: string,
@@ -147,45 +156,60 @@ export class ExercisesService {
       throw new ForbiddenException('No estás matriculado en este curso');
     }
 
-    const prompt = this.buildMultiTopicPrompt(
-      course.title,
-      course.schoolYear?.label ?? '',
-      params.topics,
-      params.count,
-      params.difficulty ?? 'MEDIUM',
-    );
-
+    const total = params.perTopic.easy + params.perTopic.medium + params.perTopic.hard;
     this.logger.log(
-      `Generando ${params.count} ejercicios multi-tema (${params.topics.length} temas) para curso "${course.title}"`,
+      `Generando ${total} ejercicios por tema (${params.topics.length} temas, ` +
+        `${params.perTopic.easy}F/${params.perTopic.medium}M/${params.perTopic.hard}D) para curso "${course.title}"`,
     );
 
-    const maxTokens = Math.min(8000, 200 + params.count * 250);
+    // Un tema que falle tumba la sección entera (regenerable), igual que antes.
+    const perTopicResults = await Promise.all(
+      params.topics.map((topic) =>
+        this.generateSplitForTopic(
+          course.title,
+          course.schoolYear?.label ?? '',
+          topic,
+          params.perTopic,
+        ),
+      ),
+    );
 
-    // Como en el examen multi-tema: el reparto por tema es frágil, así que la
-    // validación semántica (etiquetas + cobertura) también reintenta, no solo el parseo.
-    let result: GenerateTopicExercisesResult | null = null;
+    return { exercises: perTopicResults.flat() };
+  }
+
+  /** Genera los ejercicios de UN tema con reparto exacto de dificultad (reintento semántico 2x). */
+  private async generateSplitForTopic(
+    courseTitle: string,
+    schoolYearLabel: string,
+    topic: string,
+    split: ExerciseDifficultySplit,
+  ): Promise<GeneratedTopicExercise[]> {
+    const total = split.easy + split.medium + split.hard;
+    const prompt = this.buildSplitPrompt(courseTitle, schoolYearLabel, topic, split);
+    const maxTokens = Math.min(8000, 200 + total * 250);
+
     let lastErr: unknown;
-    for (let attempt = 1; attempt <= 2 && !result; attempt++) {
+    for (let attempt = 1; attempt <= 2; attempt++) {
       try {
         const parsed = await generateAiJson(this.ai, prompt, maxTokens, {
           attempts: 1,
           logger: this.logger,
         });
-        result = this.validateTopicExercisesResult(parsed, params.topics, params.count);
+        return this.validateSplitExercises(parsed, split).map((ex) => ({
+          ...ex,
+          topicLabel: topic,
+        }));
       } catch (err) {
         lastErr = err;
         this.logger.warn(
-          `Ejercicios multi-tema inválidos (generación ${attempt}/2): ${err instanceof Error ? err.message : 'desconocido'}`,
+          `Ejercicios de "${topic}" inválidos (generación ${attempt}/2): ${err instanceof Error ? err.message : 'desconocido'}`,
         );
       }
     }
-    if (!result) {
-      this.logger.error('Error al generar ejercicios multi-tema tras reintentos:', lastErr);
-      throw new InternalServerErrorException(
-        `El agente IA devolvió un formato inválido: ${lastErr instanceof Error ? lastErr.message : 'desconocido'}`,
-      );
-    }
-    return result;
+    this.logger.error(`Error al generar ejercicios de "${topic}" tras reintentos:`, lastErr);
+    throw new InternalServerErrorException(
+      `El agente IA devolvió un formato inválido: ${lastErr instanceof Error ? lastErr.message : 'desconocido'}`,
+    );
   }
 
   async evaluate(dto: EvaluateExerciseDto): Promise<EvaluationResult> {
@@ -213,37 +237,35 @@ export class ExercisesService {
     return parsed as GenerateExercisesResult;
   }
 
-  private validateTopicExercisesResult(
+  /** Valida el conteo exacto por dificultad del lote de UN tema y normaliza el campo. */
+  private validateSplitExercises(
     parsed: unknown,
-    topics: string[],
-    count: number,
-  ): GenerateTopicExercisesResult {
+    split: ExerciseDifficultySplit,
+  ): (GeneratedExercise & { difficulty: ExerciseDifficulty })[] {
     const result = this.validateExercisesResult(parsed);
-    const perTopicCount = new Map<string, number>(topics.map((t) => [t.trim(), 0]));
-    for (const [idx, ex] of (result.exercises as GeneratedTopicExercise[]).entries()) {
-      const label = typeof ex.topicLabel === 'string' ? ex.topicLabel.trim() : '';
-      if (!perTopicCount.has(label)) {
+    const exercises = result.exercises as (GeneratedExercise & { difficulty?: string })[];
+
+    const counts: Record<ExerciseDifficulty, number> = { EASY: 0, MEDIUM: 0, HARD: 0 };
+    for (const [idx, ex] of exercises.entries()) {
+      const difficulty = (ex.difficulty ?? '').toUpperCase() as ExerciseDifficulty;
+      if (!(difficulty in counts)) {
         throw new InternalServerErrorException(
-          `Ejercicio ${idx + 1}: topicLabel inválido "${ex.topicLabel ?? ''}" (debe ser uno de los temas pedidos)`,
+          `Ejercicio ${idx + 1}: difficulty inválida "${ex.difficulty ?? ''}" (debe ser EASY, MEDIUM o HARD)`,
         );
       }
-      ex.topicLabel = label;
-      perTopicCount.set(label, perTopicCount.get(label)! + 1);
+      ex.difficulty = difficulty;
+      counts[difficulty]++;
     }
 
-    // Cobertura: si hay ejercicios suficientes, ningún tema puede quedarse a cero
-    // (misma regla que el examen multi-tema).
-    if (count >= topics.length) {
-      const uncovered = [...perTopicCount.entries()]
-        .filter(([, n]) => n === 0)
-        .map(([topic]) => topic);
-      if (uncovered.length > 0) {
+    const expected = { EASY: split.easy, MEDIUM: split.medium, HARD: split.hard };
+    for (const level of Object.keys(expected) as ExerciseDifficulty[]) {
+      if (counts[level] !== expected[level]) {
         throw new InternalServerErrorException(
-          `Los ejercicios no cubren todos los temas: faltan ejercicios de ${uncovered.join(', ')}`,
+          `Reparto de dificultad incumplido: se pidieron ${expected[level]} ejercicios ${level} y llegaron ${counts[level]}`,
         );
       }
     }
-    return result as GenerateTopicExercisesResult;
+    return exercises as (GeneratedExercise & { difficulty: ExerciseDifficulty })[];
   }
 
   private validateEvaluationResult(parsed: unknown): EvaluationResult {
@@ -329,34 +351,42 @@ Reglas:
 - Solo devuelve JSON puro, sin markdown ni texto adicional`;
   }
 
-  private buildMultiTopicPrompt(
+  private buildSplitPrompt(
     courseTitle: string,
     schoolYearLabel: string,
-    topics: string[],
-    count: number,
-    difficulty: 'EASY' | 'MEDIUM' | 'HARD',
+    topic: string,
+    split: ExerciseDifficultySplit,
   ): string {
-    const perTopic = splitAcrossTopics(count, topics.length);
-    const repartoLines = topics
-      .map((t, i) => `- "${t}": ${perTopic[i]} ejercicio${perTopic[i] === 1 ? '' : 's'}`)
+    const total = split.easy + split.medium + split.hard;
+    const repartoLines = (
+      [
+        ['EASY', split.easy],
+        ['MEDIUM', split.medium],
+        ['HARD', split.hard],
+      ] as const
+    )
+      .filter(([, n]) => n > 0)
+      .map(
+        ([level, n]) =>
+          `- ${n} ejercicio${n === 1 ? '' : 's'} con "difficulty": "${level}" — ${DIFFICULTY_GUIDANCE[level]}`,
+      )
       .join('\n');
 
-    return `Genera ${count} ejercicios de práctica en español que combinen VARIOS temas, como en un examen real.
+    return `Genera ${total} ejercicios de práctica en español sobre el tema "${topic}".
 
 Curso: "${courseTitle}"
 ${schoolYearLabel ? `Nivel educativo: "${schoolYearLabel}" (sistema educativo español)` : ''}
-Dificultad: ${DIFFICULTY_GUIDANCE[difficulty]}
 
-⚠️ REPARTO POR TEMA — OBLIGATORIO, NO NEGOCIABLE:
+⚠️ REPARTO POR DIFICULTAD — OBLIGATORIO, NO NEGOCIABLE:
 ${repartoLines}
 
-Cada ejercicio lleva un campo "topicLabel" con el tema al que pertenece, copiado EXACTAMENTE de la lista anterior (mismas mayúsculas, tildes y espacios). Si un topicLabel no coincide con un tema de la lista, la respuesta será RECHAZADA.
+Cada ejercicio lleva un campo "difficulty" con su nivel exacto ("EASY", "MEDIUM" o "HARD"). Si el conteo por dificultad no coincide con el reparto anterior, la respuesta será RECHAZADA.
 
 Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, sin explicaciones adicionales fuera del JSON):
 {
   "exercises": [
     {
-      "topicLabel": "${topics[0]}",
+      "difficulty": "EASY",
       "statement": "enunciado del ejercicio",
       "type": "SINGLE",
       "options": ["opción A", "opción B", "opción C"],
@@ -364,7 +394,7 @@ Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, si
       "explanation": "por qué la opción A es correcta"
     },
     {
-      "topicLabel": "${topics[0]}",
+      "difficulty": "MEDIUM",
       "statement": "enunciado",
       "type": "TRUE_FALSE",
       "options": ["Verdadero", "Falso"],
@@ -372,7 +402,7 @@ Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, si
       "explanation": "explicación de por qué es verdadero"
     },
     {
-      "topicLabel": "${topics[topics.length - 1]}",
+      "difficulty": "HARD",
       "statement": "enunciado de un ejercicio abierto",
       "type": "OPEN",
       "options": [],
@@ -383,14 +413,13 @@ Devuelve ÚNICAMENTE un objeto JSON con esta estructura exacta (sin markdown, si
 }
 
 Reglas:
-- Respeta el reparto exacto de ejercicios por tema indicado arriba
-- Agrupa los ejercicios por tema en el orden de la lista
-- Mezcla los 3 tipos (SINGLE, TRUE_FALSE, OPEN) cuando sea apropiado para cada tema
+- Respeta el reparto exacto por dificultad indicado arriba y ordena de fácil a difícil
+- Mezcla los 3 tipos (SINGLE, TRUE_FALSE, OPEN) cuando sea apropiado para el tema
 - SINGLE: 3-4 opciones, exactamente 1 correcta (la propiedad "solution" debe coincidir con una de las opciones)
 - TRUE_FALSE: opciones siempre ["Verdadero", "Falso"], solución coincide
 - OPEN: campo "options" vacío []; "solution" contiene la respuesta o pasos resueltos
 - Los enunciados deben ser claros, precisos y adecuados al nivel ${schoolYearLabel || 'del curso'}
-- Contenido curricular real relacionado con cada tema
+- Contenido curricular real relacionado con "${topic}"
 - "explanation" debe ayudar al alumno a entender por qué la respuesta es correcta
 - Solo devuelve JSON puro, sin markdown ni texto adicional`;
   }

--- a/apps/api/src/study-plans/dto/create-study-plan.dto.spec.ts
+++ b/apps/api/src/study-plans/dto/create-study-plan.dto.spec.ts
@@ -12,9 +12,7 @@ async function validateDto(payload: Record<string, unknown>) {
 const validPayload = {
   courseId: 'course-1',
   topics: [{ title: 'Fracciones' }],
-  numExercises: 5,
-  difficulty: 'MEDIUM',
-  numQuestions: 5,
+  exercisesPerTopic: { easy: 2, medium: 2, hard: 1 },
 };
 
 describe('CreateStudyPlanDto', () => {
@@ -54,23 +52,39 @@ describe('CreateStudyPlanDto', () => {
     expect(errors.some((e) => e.property === 'topics')).toBe(true);
   });
 
-  it('rechaza numQuestions fuera de {5, 10}', async () => {
-    const errors = await validateDto({ ...validPayload, numQuestions: 7 });
-    expect(errors.some((e) => e.property === 'numQuestions')).toBe(true);
+  // BUG conocido (reportado, no corregido aquí): `exercisesPerTopic` solo lleva
+  // @ValidateNested + @Type, sin @IsDefined/@IsNotEmptyObject. class-validator
+  // no valida NESTED_VALIDATION cuando el valor es undefined, así que un
+  // payload sin este campo pasa la validación (y luego el service explota con
+  // un TypeError al leer `.easy` de undefined, en vez de un 422 limpio).
+  it('NO rechaza (bug conocido) un payload sin exercisesPerTopic', async () => {
+    const payload = { ...validPayload } as Record<string, unknown>;
+    delete payload.exercisesPerTopic;
+    const errors = await validateDto(payload);
+    expect(errors).toHaveLength(0);
   });
 
-  it('rechaza numExercises fuera de rango (0 y 21)', async () => {
-    expect((await validateDto({ ...validPayload, numExercises: 0 })).length).toBeGreaterThan(0);
-    expect((await validateDto({ ...validPayload, numExercises: 21 })).length).toBeGreaterThan(0);
+  it('rechaza exercisesPerTopic con easy negativo', async () => {
+    const errors = await validateDto({
+      ...validPayload,
+      exercisesPerTopic: { easy: -1, medium: 2, hard: 1 },
+    });
+    expect(errors.some((e) => e.property === 'exercisesPerTopic')).toBe(true);
   });
 
-  it('rechaza difficulty desconocida', async () => {
-    const errors = await validateDto({ ...validPayload, difficulty: 'EXTREME' });
-    expect(errors.some((e) => e.property === 'difficulty')).toBe(true);
+  it('rechaza exercisesPerTopic con hard > 10', async () => {
+    const errors = await validateDto({
+      ...validPayload,
+      exercisesPerTopic: { easy: 2, medium: 2, hard: 11 },
+    });
+    expect(errors.some((e) => e.property === 'exercisesPerTopic')).toBe(true);
   });
 
-  it('rechaza timeLimit fuera de rango', async () => {
-    expect((await validateDto({ ...validPayload, timeLimit: 30 })).length).toBeGreaterThan(0);
-    expect((await validateDto({ ...validPayload, timeLimit: 20000 })).length).toBeGreaterThan(0);
+  it('acepta {easy:2, medium:2, hard:1} como reparto válido', async () => {
+    const errors = await validateDto({
+      ...validPayload,
+      exercisesPerTopic: { easy: 2, medium: 2, hard: 1 },
+    });
+    expect(errors).toHaveLength(0);
   });
 });

--- a/apps/api/src/study-plans/dto/create-study-plan.dto.ts
+++ b/apps/api/src/study-plans/dto/create-study-plan.dto.ts
@@ -3,8 +3,6 @@ import {
   ArrayMaxSize,
   ArrayMinSize,
   IsArray,
-  IsBoolean,
-  IsIn,
   IsInt,
   IsOptional,
   IsString,
@@ -39,6 +37,27 @@ export class StudyPlanTopicInputDto {
   subject?: string;
 }
 
+/**
+ * Reparto de ejercicios POR TEMA: cada tema del plan recibe easy+medium+hard
+ * ejercicios. La suma (1..10) se valida en el service.
+ */
+export class ExercisesPerTopicDto {
+  @IsInt()
+  @Min(0)
+  @Max(10, { message: 'Máximo 10 ejercicios fáciles por tema' })
+  easy: number;
+
+  @IsInt()
+  @Min(0)
+  @Max(10, { message: 'Máximo 10 ejercicios medios por tema' })
+  medium: number;
+
+  @IsInt()
+  @Min(0)
+  @Max(10, { message: 'Máximo 10 ejercicios difíciles por tema' })
+  hard: number;
+}
+
 export class CreateStudyPlanDto {
   @IsString()
   courseId: string;
@@ -50,25 +69,9 @@ export class CreateStudyPlanDto {
   @Type(() => StudyPlanTopicInputDto)
   topics: StudyPlanTopicInputDto[];
 
-  @IsInt()
-  @Min(1, { message: 'Mínimo 1 ejercicio' })
-  @Max(20, { message: 'Máximo 20 ejercicios' })
-  numExercises: number;
-
-  @IsIn(['EASY', 'MEDIUM', 'HARD'], { message: 'difficulty debe ser EASY, MEDIUM o HARD' })
-  difficulty: 'EASY' | 'MEDIUM' | 'HARD';
-
-  @IsInt()
-  @IsIn([5, 10], { message: 'numQuestions debe ser 5 o 10' })
-  numQuestions: 5 | 10;
-
-  @IsInt()
-  @Min(60, { message: 'El tiempo mínimo es 60 segundos' })
-  @Max(10800, { message: 'El tiempo máximo es 10800 segundos (3 h)' })
-  @IsOptional()
-  timeLimit?: number;
-
-  @IsBoolean()
-  @IsOptional()
-  onlyOnce?: boolean;
+  // Los exámenes ya no se generan al crear: se generan por nivel (lazy) desde
+  // la pestaña Examen (POST /study-plans/:id/exams).
+  @ValidateNested()
+  @Type(() => ExercisesPerTopicDto)
+  exercisesPerTopic: ExercisesPerTopicDto;
 }

--- a/apps/api/src/study-plans/dto/generate-plan-exam.dto.ts
+++ b/apps/api/src/study-plans/dto/generate-plan-exam.dto.ts
@@ -1,0 +1,27 @@
+import { IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export type StudyPlanExamLevel = 'BASIC' | 'MEDIUM' | 'HARD';
+
+/**
+ * Genera (lazy) el examen de un nivel del plan: combinado de todos los temas
+ * (sin topicId) o de un tema concreto. numQuestions/difficulty son overrides
+ * opcionales del preset del nivel.
+ */
+export class GeneratePlanExamDto {
+  @IsIn(['BASIC', 'MEDIUM', 'HARD'], { message: 'level debe ser BASIC, MEDIUM o HARD' })
+  level: StudyPlanExamLevel;
+
+  @IsOptional()
+  @IsString()
+  topicId?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(3, { message: 'Mínimo 3 preguntas' })
+  @Max(20, { message: 'Máximo 20 preguntas' })
+  numQuestions?: number;
+
+  @IsOptional()
+  @IsIn(['EASY', 'MEDIUM', 'HARD'], { message: 'difficulty debe ser EASY, MEDIUM o HARD' })
+  difficulty?: 'EASY' | 'MEDIUM' | 'HARD';
+}

--- a/apps/api/src/study-plans/dto/regenerate-plan-exercises.dto.ts
+++ b/apps/api/src/study-plans/dto/regenerate-plan-exercises.dto.ts
@@ -1,0 +1,25 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Regenera los ejercicios del plan. Sin campos, reutiliza el reparto guardado
+ * (exercisesConfig); con campos, sobreescribe el reparto por tema.
+ */
+export class RegeneratePlanExercisesDto {
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(10, { message: 'Máximo 10 ejercicios fáciles por tema' })
+  easy?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(10, { message: 'Máximo 10 ejercicios medios por tema' })
+  medium?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(10, { message: 'Máximo 10 ejercicios difíciles por tema' })
+  hard?: number;
+}

--- a/apps/api/src/study-plans/dto/rename-study-plan.dto.ts
+++ b/apps/api/src/study-plans/dto/rename-study-plan.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+/** El alumno renombra su curso multi-tema. */
+export class RenameStudyPlanDto {
+  @IsString()
+  @MinLength(3, { message: 'El título debe tener al menos 3 caracteres' })
+  @MaxLength(200, { message: 'El título es demasiado largo (máx. 200 caracteres)' })
+  title: string;
+}

--- a/apps/api/src/study-plans/study-plans.controller.ts
+++ b/apps/api/src/study-plans/study-plans.controller.ts
@@ -1,25 +1,42 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { User } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { StudyPlansService } from './study-plans.service';
 import { CreateStudyPlanDto } from './dto/create-study-plan.dto';
-import { RegenerateExercisesDto } from '../study/dto/regenerate-exercises.dto';
-import { RegenerateExamDto } from '../study/dto/regenerate-exam.dto';
+import { GeneratePlanExamDto } from './dto/generate-plan-exam.dto';
+import { RenameStudyPlanDto } from './dto/rename-study-plan.dto';
+import { RegeneratePlanExercisesDto } from './dto/regenerate-plan-exercises.dto';
 
 @Controller('study-plans')
 @UseGuards(JwtAuthGuard)
 export class StudyPlansController {
   constructor(private readonly studyPlans: StudyPlansService) {}
 
-  // Creación completa = N teorías + ejercicios + examen (hasta 8 llamadas IA),
+  // Creación completa = N teorías + N lotes de ejercicios (hasta 12 llamadas IA),
   // lo más caro de toda la app: límite estricto de 5/hora por usuario.
-  /** Crea un plan multi-tema generando teoría por tema + ejercicios y examen combinados. */
+  /** Crea un curso multi-tema generando teoría y ejercicios por tema (examen: lazy). */
   @Post()
   @Throttle({ default: { ttl: 3600000, limit: 5 } })
   create(@CurrentUser() user: User, @Body() dto: CreateStudyPlanDto) {
     return this.studyPlans.create(user.id, dto);
+  }
+
+  /** Renombra el curso multi-tema (solo el dueño). */
+  @Patch(':id')
+  rename(@CurrentUser() user: User, @Param('id') id: string, @Body() dto: RenameStudyPlanDto) {
+    return this.studyPlans.rename(user.id, id, dto);
   }
 
   /** Lista los planes multi-tema del alumno. */
@@ -53,21 +70,25 @@ export class StudyPlansController {
     return this.studyPlans.regenerateTopicTheory(user.id, id, topicId);
   }
 
-  /** Regenera los ejercicios combinados (acepta count opcional). */
+  /** Regenera los ejercicios por tema (acepta reparto easy/medium/hard opcional). */
   @Post(':id/exercises')
   @Throttle({ default: { ttl: 3600000, limit: 30 } })
   regenExercises(
     @CurrentUser() user: User,
     @Param('id') id: string,
-    @Body() dto: RegenerateExercisesDto,
+    @Body() dto: RegeneratePlanExercisesDto,
   ) {
     return this.studyPlans.regenerateExercises(user.id, id, dto);
   }
 
-  /** Regenera el examen combinado (acepta numQuestions/timeLimit/onlyOnce opcionales). */
-  @Post(':id/exam')
+  /** Genera (lazy) el examen de un nivel: combinado o de un tema concreto. */
+  @Post(':id/exams')
   @Throttle({ default: { ttl: 3600000, limit: 30 } })
-  regenExam(@CurrentUser() user: User, @Param('id') id: string, @Body() dto: RegenerateExamDto) {
-    return this.studyPlans.regenerateExam(user.id, id, dto);
+  generateExam(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() dto: GeneratePlanExamDto,
+  ) {
+    return this.studyPlans.generateExam(user.id, id, dto);
   }
 }

--- a/apps/api/src/study-plans/study-plans.service.spec.ts
+++ b/apps/api/src/study-plans/study-plans.service.spec.ts
@@ -21,28 +21,20 @@ describe('StudyPlansService', () => {
     };
     theoryModule: { update: jest.Mock; delete: jest.Mock };
     aiExamBank: { update: jest.Mock; delete: jest.Mock };
+    examAttempt: { groupBy: jest.Mock };
     $transaction: jest.Mock;
   };
   let theory: { generate: jest.Mock; getById: jest.Mock; deleteById: jest.Mock };
   let exercises: { generateForTopics: jest.Mock };
-  let aiExams: { generateForTopics: jest.Mock; getBank: jest.Mock; deleteBank: jest.Mock };
+  let aiExams: { generateForTopics: jest.Mock };
   let service: StudyPlansService;
 
   const theoryResult = { id: 'tm-1', title: 'Fracciones', summary: 'resumen', lessons: [] };
-  const examResult = {
-    id: 'bank-1',
-    title: 'Simulacro',
-    topic: 'Fracciones · Ecuaciones',
-    numQuestions: 5,
-    timeLimit: null,
-    onlyOnce: false,
-    attemptCount: 0,
-    questions: [],
-  };
   const exercisesResult = {
     exercises: [
       {
         topicLabel: 'Fracciones',
+        difficulty: 'EASY',
         statement: 'x',
         type: 'OPEN',
         options: [],
@@ -64,14 +56,17 @@ describe('StudyPlansService', () => {
     course: { id: 'course-lengua', subject: 'Lengua' },
   };
 
+  // Sirve tanto a getById como a requireOwnedPlan: mismo mock de
+  // studyPlan.findUnique para ambos caminos (union de campos usados por los dos).
   function stubPlanForGetById(over: Record<string, unknown> = {}) {
     prisma.studyPlan.findUnique.mockResolvedValue({
       id: 'plan-1',
       userId: 'user-1',
       courseId: 'course-mates',
-      title: 'Simulacro: Fracciones',
+      title: 'Fracciones',
       summary: 'resumen',
       difficulty: 'MEDIUM',
+      exercisesConfig: null,
       createdAt: new Date(),
       exercises: exercisesResult.exercises,
       course: { id: 'course-mates', title: 'Matemáticas 3º ESO' },
@@ -87,7 +82,7 @@ describe('StudyPlansService', () => {
           theoryModule: { id: 'tm-1' },
         },
       ],
-      examBank: { id: 'bank-1' },
+      examBanks: [],
       ...over,
     });
   }
@@ -127,6 +122,7 @@ describe('StudyPlansService', () => {
         update: jest.fn().mockResolvedValue({}),
         delete: jest.fn().mockResolvedValue({}),
       },
+      examAttempt: { groupBy: jest.fn().mockResolvedValue([]) },
       $transaction: jest.fn((ops: unknown[]) => Promise.all(ops)),
     };
     theory = {
@@ -135,11 +131,7 @@ describe('StudyPlansService', () => {
       deleteById: jest.fn().mockResolvedValue(undefined),
     };
     exercises = { generateForTopics: jest.fn().mockResolvedValue(exercisesResult) };
-    aiExams = {
-      generateForTopics: jest.fn().mockResolvedValue(examResult),
-      getBank: jest.fn().mockResolvedValue(examResult),
-      deleteBank: jest.fn().mockResolvedValue({ ok: true }),
-    };
+    aiExams = { generateForTopics: jest.fn().mockResolvedValue({ id: 'bank-1' }) };
     service = new StudyPlansService(
       prisma as never,
       theory as never,
@@ -286,30 +278,22 @@ describe('StudyPlansService', () => {
     const dto = {
       courseId: 'course-mates',
       topics: [{ title: 'Fracciones' }],
-      numExercises: 5,
-      difficulty: 'MEDIUM' as const,
-      numQuestions: 5 as const,
+      exercisesPerTopic: { easy: 2, medium: 2, hard: 1 },
     };
 
-    it('rechaza con 422 si numQuestions < número de temas', async () => {
+    it('rechaza con 422 si el reparto de ejercicios por tema no suma entre 1 y 10', async () => {
       await expect(
-        service.create('user-1', {
-          ...dto,
-          numQuestions: 5,
-          topics: [
-            { title: 'tema uno' },
-            { title: 'tema dos' },
-            { title: 'tema tres' },
-            { title: 'tema cuatro' },
-            { title: 'tema cinco' },
-            { title: 'tema seis' },
-          ],
-        }),
+        service.create('user-1', { ...dto, exercisesPerTopic: { easy: 0, medium: 0, hard: 0 } }),
+      ).rejects.toThrow(UnprocessableEntityException);
+      expect(prisma.studyPlan.create).not.toHaveBeenCalled();
+
+      await expect(
+        service.create('user-1', { ...dto, exercisesPerTopic: { easy: 10, medium: 10, hard: 10 } }),
       ).rejects.toThrow(UnprocessableEntityException);
       expect(prisma.studyPlan.create).not.toHaveBeenCalled();
     });
 
-    it('crea el plan, genera teoría con el contexto de cada tema y enlaza las secciones', async () => {
+    it('crea el plan, genera teoría y ejercicios por tema, y enlaza las secciones (sin examen)', async () => {
       stubPlanForGetById();
       const result = await service.create('user-1', dto);
 
@@ -317,7 +301,7 @@ describe('StudyPlansService', () => {
         expect.objectContaining({
           data: expect.objectContaining({
             title: 'Fracciones',
-            difficulty: 'MEDIUM',
+            exercisesConfig: { easy: 2, medium: 2, hard: 1 },
           }),
         }),
       );
@@ -325,23 +309,18 @@ describe('StudyPlansService', () => {
         courseId: 'course-mates',
         topic: 'Fracciones',
       });
-      expect(exercises.generateForTopics).toHaveBeenCalledWith(
-        'user-1',
-        expect.objectContaining({ topics: ['Fracciones'], count: 5, difficulty: 'MEDIUM' }),
-      );
-      expect(aiExams.generateForTopics).toHaveBeenCalledWith(
-        'user-1',
-        expect.objectContaining({ topics: ['Fracciones'], numQuestions: 5 }),
-      );
+      expect(exercises.generateForTopics).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-mates',
+        topics: ['Fracciones'],
+        perTopic: { easy: 2, medium: 2, hard: 1 },
+      });
+      expect(aiExams.generateForTopics).not.toHaveBeenCalled();
       expect(prisma.theoryModule.update).toHaveBeenCalledWith({
         where: { id: 'tm-1' },
         data: { studyPlanTopicId: 'topic-0' },
       });
-      expect(prisma.aiExamBank.update).toHaveBeenCalledWith({
-        where: { id: 'bank-1' },
-        data: { studyPlanId: 'plan-1' },
-      });
-      expect(result.sections).toEqual({ theory: true, exercises: true, exam: true });
+      expect(prisma.aiExamBank.update).not.toHaveBeenCalled();
+      expect(result.sections).toEqual({ theory: true, exercises: true, exam: false });
     });
 
     it('la teoría de cada tema usa su contextCourseId (tema de otra asignatura)', async () => {
@@ -396,7 +375,6 @@ describe('StudyPlansService', () => {
 
       expect(prisma.studyPlan.delete).not.toHaveBeenCalled();
       expect(prisma.theoryModule.update).not.toHaveBeenCalled();
-      expect(prisma.aiExamBank.update).toHaveBeenCalled(); // el examen sí se enlaza
       expect(result.sections.theory).toBe(false);
       expect(result.topics[0].hasTheory).toBe(false);
     });
@@ -404,7 +382,6 @@ describe('StudyPlansService', () => {
     it('fallo total: si TODO falla, borra la cáscara y lanza 500 (sin plan huérfano)', async () => {
       theory.generate.mockRejectedValue(new Error('IA caída'));
       exercises.generateForTopics.mockRejectedValue(new Error('IA caída'));
-      aiExams.generateForTopics.mockRejectedValue(new Error('IA caída'));
 
       await expect(service.create('user-1', dto)).rejects.toThrow(InternalServerErrorException);
       expect(prisma.studyPlan.delete).toHaveBeenCalledWith({ where: { id: 'plan-1' } });
@@ -417,30 +394,10 @@ describe('StudyPlansService', () => {
       expect(prisma.studyPlan.delete).toHaveBeenCalledWith({ where: { id: 'plan-1' } });
       // Los artefactos generados pero sin enlazar tampoco quedan huérfanos
       expect(prisma.theoryModule.delete).toHaveBeenCalledWith({ where: { id: 'tm-1' } });
-      expect(prisma.aiExamBank.delete).toHaveBeenCalledWith({ where: { id: 'bank-1' } });
-    });
-
-    it('rechaza con 422 si numExercises < número de temas', async () => {
-      await expect(
-        service.create('user-1', {
-          ...dto,
-          numQuestions: 10,
-          numExercises: 5,
-          topics: [
-            { title: 'tema uno' },
-            { title: 'tema dos' },
-            { title: 'tema tres' },
-            { title: 'tema cuatro' },
-            { title: 'tema cinco' },
-            { title: 'tema seis' },
-          ],
-        }),
-      ).rejects.toThrow(UnprocessableEntityException);
-      expect(prisma.studyPlan.create).not.toHaveBeenCalled();
     });
   });
 
-  // ─── getById / deleteById: ownership ────────────────────────────────────────
+  // ─── getById / deleteById: ownership y exámenes lazy ────────────────────────
 
   describe('getById', () => {
     it('lanza 404 si el plan no existe', async () => {
@@ -453,13 +410,54 @@ describe('StudyPlansService', () => {
       await expect(service.getById('user-1', 'plan-1')).rejects.toThrow(ForbiddenException);
     });
 
-    it('devuelve el examen vía aiExams.getBank (serialización sin isCorrect)', async () => {
-      stubPlanForGetById();
+    it('no llama a examAttempt.groupBy si el plan no tiene examBanks', async () => {
+      stubPlanForGetById(); // examBanks: []
       const result = await service.getById('user-1', 'plan-1');
-      // getBank es el único camino al examen: su serialización ya oculta isCorrect
-      expect(aiExams.getBank).toHaveBeenCalledWith('user-1', 'bank-1');
-      expect(result.exam).toBe(examResult);
-      expect(JSON.stringify(result.exam)).not.toContain('isCorrect');
+      expect(prisma.examAttempt.groupBy).not.toHaveBeenCalled();
+      expect(result.exams).toEqual([]);
+      expect(result.sections.exam).toBe(false);
+    });
+
+    it('devuelve exams desde examBanks con attemptCount y bestScore vía examAttempt.groupBy', async () => {
+      stubPlanForGetById({
+        examBanks: [
+          {
+            id: 'bank-1',
+            title: 'Básico',
+            level: 'BASIC',
+            studyPlanTopicId: null,
+            numQuestions: 5,
+            timeLimit: null,
+            onlyOnce: false,
+          },
+        ],
+      });
+      prisma.examAttempt.groupBy.mockResolvedValue([
+        { aiExamBankId: 'bank-1', _count: { _all: 3 }, _max: { score: 80 } },
+      ]);
+
+      const result = await service.getById('user-1', 'plan-1');
+
+      expect(prisma.examAttempt.groupBy).toHaveBeenCalledWith({
+        by: ['aiExamBankId'],
+        where: { aiExamBankId: { in: ['bank-1'] }, userId: 'user-1' },
+        _count: { _all: true },
+        _max: { score: true },
+      });
+      expect(result.exams).toEqual([
+        {
+          id: 'bank-1',
+          title: 'Básico',
+          level: 'BASIC',
+          topicId: null,
+          numQuestions: 5,
+          timeLimit: null,
+          onlyOnce: false,
+          attemptCount: 3,
+          bestScore: 80,
+        },
+      ]);
+      expect(result.sections.exam).toBe(true);
     });
   });
 
@@ -498,6 +496,198 @@ describe('StudyPlansService', () => {
       await expect(
         service.regenerateTopicTheory('user-1', 'plan-1', 'topic-ajeno'),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('regenerateExercises', () => {
+    it('usa el exercisesConfig guardado como fallback cuando el dto va vacío', async () => {
+      stubPlanForGetById({
+        exercisesConfig: { easy: 3, medium: 1, hard: 0 },
+        topics: [
+          {
+            id: 'topic-0',
+            order: 0,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'Fracciones',
+            subject: null,
+            contextCourseId: 'course-mates',
+            theoryModule: { id: 'tm-1' },
+          },
+        ],
+      });
+
+      await service.regenerateExercises('user-1', 'plan-1', {});
+
+      expect(exercises.generateForTopics).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-mates',
+        topics: ['Fracciones'],
+        perTopic: { easy: 3, medium: 1, hard: 0 },
+      });
+      expect(prisma.studyPlan.update).toHaveBeenCalledWith({
+        where: { id: 'plan-1' },
+        data: {
+          exercises: exercisesResult.exercises,
+          exercisesConfig: { easy: 3, medium: 1, hard: 0 },
+        },
+      });
+    });
+
+    it('el dto sobreescribe el reparto guardado campo a campo', async () => {
+      stubPlanForGetById({ exercisesConfig: { easy: 3, medium: 1, hard: 0 } });
+
+      await service.regenerateExercises('user-1', 'plan-1', { hard: 2 });
+
+      expect(exercises.generateForTopics).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ perTopic: { easy: 3, medium: 1, hard: 2 } }),
+      );
+    });
+  });
+
+  describe('generateExam', () => {
+    it('preset BASIC: numQuestions 5, difficulty EASY, enlaza el banco con level BASIC', async () => {
+      stubPlanForGetById();
+      aiExams.generateForTopics.mockResolvedValue({ id: 'bank-1' });
+
+      await service.generateExam('user-1', 'plan-1', { level: 'BASIC' });
+
+      expect(aiExams.generateForTopics).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-mates',
+        topics: ['Fracciones'],
+        numQuestions: 5,
+        difficulty: 'EASY',
+      });
+      expect(prisma.aiExamBank.update).toHaveBeenCalledWith({
+        where: { id: 'bank-1' },
+        data: { studyPlanId: 'plan-1', studyPlanTopicId: null, level: 'BASIC' },
+      });
+    });
+
+    it('con topicId usa el contextCourseId del tema y genera solo su título', async () => {
+      stubPlanForGetById({
+        topics: [
+          {
+            id: 'topic-0',
+            order: 0,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'Fracciones',
+            subject: null,
+            contextCourseId: 'course-mates',
+            theoryModule: { id: 'tm-1' },
+          },
+          {
+            id: 'topic-1',
+            order: 1,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'análisis morfológico',
+            subject: null,
+            contextCourseId: 'course-lengua',
+            theoryModule: null,
+          },
+        ],
+      });
+      aiExams.generateForTopics.mockResolvedValue({ id: 'bank-2' });
+
+      await service.generateExam('user-1', 'plan-1', { level: 'MEDIUM', topicId: 'topic-1' });
+
+      expect(aiExams.generateForTopics).toHaveBeenCalledWith('user-1', {
+        courseId: 'course-lengua',
+        topics: ['análisis morfológico'],
+        numQuestions: 8,
+        difficulty: 'MEDIUM',
+      });
+      expect(prisma.aiExamBank.update).toHaveBeenCalledWith({
+        where: { id: 'bank-2' },
+        data: { studyPlanId: 'plan-1', studyPlanTopicId: 'topic-1', level: 'MEDIUM' },
+      });
+    });
+
+    it('idempotente: si ya existe un banco con el mismo (level, topicId), no llama a la IA', async () => {
+      stubPlanForGetById({
+        examBanks: [
+          {
+            id: 'bank-1',
+            title: 'Básico',
+            level: 'BASIC',
+            studyPlanTopicId: null,
+            numQuestions: 5,
+            timeLimit: null,
+            onlyOnce: false,
+          },
+        ],
+      });
+
+      await service.generateExam('user-1', 'plan-1', { level: 'BASIC' });
+
+      expect(aiExams.generateForTopics).not.toHaveBeenCalled();
+      expect(prisma.aiExamBank.update).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 422 si numQuestions es menor que el número de temas', async () => {
+      stubPlanForGetById({
+        topics: [
+          {
+            id: 'topic-0',
+            order: 0,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'Tema 1',
+            subject: null,
+            contextCourseId: 'course-mates',
+            theoryModule: null,
+          },
+          {
+            id: 'topic-1',
+            order: 1,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'Tema 2',
+            subject: null,
+            contextCourseId: 'course-mates',
+            theoryModule: null,
+          },
+          {
+            id: 'topic-2',
+            order: 2,
+            source: 'CUSTOM',
+            moduleId: null,
+            title: 'Tema 3',
+            subject: null,
+            contextCourseId: 'course-mates',
+            theoryModule: null,
+          },
+        ],
+      });
+
+      await expect(
+        service.generateExam('user-1', 'plan-1', { level: 'BASIC', numQuestions: 2 }),
+      ).rejects.toThrow(UnprocessableEntityException);
+      expect(aiExams.generateForTopics).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rename', () => {
+    it('actualiza el título recortando espacios', async () => {
+      stubPlanForGetById();
+
+      await service.rename('user-1', 'plan-1', { title: '  Nuevo título  ' });
+
+      expect(prisma.studyPlan.update).toHaveBeenCalledWith({
+        where: { id: 'plan-1' },
+        data: { title: 'Nuevo título' },
+      });
+    });
+
+    it('lanza 403 si el plan pertenece a otro usuario', async () => {
+      stubPlanForGetById({ userId: 'user-2' });
+
+      await expect(service.rename('user-1', 'plan-1', { title: 'Nuevo título' })).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(prisma.studyPlan.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/study-plans/study-plans.service.ts
+++ b/apps/api/src/study-plans/study-plans.service.ts
@@ -12,9 +12,25 @@ import { PrismaService } from '../prisma/prisma.service';
 import { TheoryService } from '../theory/theory.service';
 import { ExercisesService, GeneratedTopicExercise } from '../exercises/exercises.service';
 import { AiExamsService } from '../exams/ai-exams.service';
-import { CreateStudyPlanDto, StudyPlanTopicInputDto } from './dto/create-study-plan.dto';
-import { RegenerateExercisesDto } from '../study/dto/regenerate-exercises.dto';
-import { RegenerateExamDto } from '../study/dto/regenerate-exam.dto';
+import {
+  CreateStudyPlanDto,
+  ExercisesPerTopicDto,
+  StudyPlanTopicInputDto,
+} from './dto/create-study-plan.dto';
+import { GeneratePlanExamDto, StudyPlanExamLevel } from './dto/generate-plan-exam.dto';
+import { RenameStudyPlanDto } from './dto/rename-study-plan.dto';
+import { RegeneratePlanExercisesDto } from './dto/regenerate-plan-exercises.dto';
+
+// Presets de los niveles de examen del plan; numQuestions/difficulty son
+// overridables por el alumno al generar.
+const EXAM_LEVEL_PRESETS: Record<
+  StudyPlanExamLevel,
+  { numQuestions: number; difficulty: 'EASY' | 'MEDIUM' | 'HARD' }
+> = {
+  BASIC: { numQuestions: 5, difficulty: 'EASY' },
+  MEDIUM: { numQuestions: 8, difficulty: 'MEDIUM' },
+  HARD: { numQuestions: 10, difficulty: 'HARD' },
+};
 
 // Tema del payload ya resuelto contra matrículas y temario (regla de coherencia).
 export interface ResolvedTopic {
@@ -26,9 +42,10 @@ export interface ResolvedTopic {
 }
 
 /**
- * Plan de estudio multi-tema: combina N temas (oficiales del temario o libres)
- * en teoría POR TEMA (N decks) + ejercicios y examen COMBINADOS (1 llamada
- * cada uno), simulando exámenes reales. Flujo adicional al un-tema
+ * Curso multi-tema (StudyPlan): combina N temas (oficiales del temario o
+ * libres) en teoría POR TEMA (N decks) + ejercicios POR TEMA con reparto de
+ * dificultad. Los exámenes se generan LAZY por nivel (básico/medio/difícil),
+ * combinados o por tema, desde la pestaña Examen. Flujo adicional al un-tema
  * (StudyService/StudyUnit), que no se toca. Personal (scoped por userId).
  */
 @Injectable()
@@ -177,21 +194,19 @@ export class StudyPlansService {
     return resolved;
   }
 
+  /** Suma del reparto por tema, validada fuera del DTO para mensaje claro. */
+  private assertPerTopicTotal(perTopic: ExercisesPerTopicDto): void {
+    const total = perTopic.easy + perTopic.medium + perTopic.hard;
+    if (total < 1 || total > 10) {
+      throw new UnprocessableEntityException(
+        'El reparto de ejercicios por tema debe sumar entre 1 y 10',
+      );
+    }
+  }
+
   async create(userId: string, dto: CreateStudyPlanDto) {
     await this.assertEnrolled(userId, dto.courseId);
-
-    if (dto.numQuestions < dto.topics.length) {
-      throw new UnprocessableEntityException(
-        `El examen debe tener al menos 1 pregunta por tema: con ${dto.topics.length} temas ` +
-          `necesitas numQuestions ≥ ${dto.topics.length}`,
-      );
-    }
-    if (dto.numExercises < dto.topics.length) {
-      throw new UnprocessableEntityException(
-        `Debe haber al menos 1 ejercicio por tema: con ${dto.topics.length} temas ` +
-          `necesitas numExercises ≥ ${dto.topics.length}`,
-      );
-    }
+    this.assertPerTopicTotal(dto.exercisesPerTopic);
 
     const resolvedTopics = await this.resolveAndAssertTopics(userId, dto.courseId, dto.topics);
 
@@ -202,7 +217,11 @@ export class StudyPlansService {
         courseId: dto.courseId,
         title: this.buildTitle(resolvedTopics),
         summary: '',
-        difficulty: dto.difficulty,
+        exercisesConfig: {
+          easy: dto.exercisesPerTopic.easy,
+          medium: dto.exercisesPerTopic.medium,
+          hard: dto.exercisesPerTopic.hard,
+        },
         topics: {
           create: resolvedTopics.map((t, i) => ({
             order: i,
@@ -217,10 +236,11 @@ export class StudyPlansService {
       include: { topics: { orderBy: { order: 'asc' } } },
     });
 
-    // N teorías (una por tema, con su curso de contexto) + ejercicios y examen
-    // combinados. allSettled: una sección que falle no tumba las demás.
+    // N teorías (una por tema, con su curso de contexto) + ejercicios por tema.
+    // Los exámenes NO se generan aquí: son lazy por nivel (generateExam).
+    // allSettled: una sección que falle no tumba las demás.
     const topicTitles = plan.topics.map((t) => t.title);
-    const [theoryResults, [exercisesRes], [examRes]] = await Promise.all([
+    const [theoryResults, [exercisesRes]] = await Promise.all([
       Promise.allSettled(
         plan.topics.map((t) =>
           this.theory.generate(userId, { courseId: t.contextCourseId, topic: t.title }),
@@ -230,26 +250,13 @@ export class StudyPlansService {
         this.exercises.generateForTopics(userId, {
           courseId: dto.courseId,
           topics: topicTitles,
-          count: dto.numExercises,
-          difficulty: dto.difficulty,
-        }),
-      ]),
-      Promise.allSettled([
-        this.aiExams.generateForTopics(userId, {
-          courseId: dto.courseId,
-          topics: topicTitles,
-          numQuestions: dto.numQuestions,
-          timeLimit: dto.timeLimit,
-          onlyOnce: dto.onlyOnce,
-          difficulty: dto.difficulty,
+          perTopic: dto.exercisesPerTopic,
         }),
       ]),
     ]);
 
     const allFailed =
-      theoryResults.every((r) => r.status === 'rejected') &&
-      exercisesRes.status === 'rejected' &&
-      examRes.status === 'rejected';
+      theoryResults.every((r) => r.status === 'rejected') && exercisesRes.status === 'rejected';
     if (allFailed) {
       this.logger.error('Todas las secciones fallaron al generar el plan de estudio');
       await this.prisma.studyPlan.delete({ where: { id: plan.id } });
@@ -276,14 +283,6 @@ export class StudyPlansService {
     if (exercisesRes.status === 'fulfilled') {
       data.exercises = exercisesRes.value.exercises as unknown as Prisma.InputJsonValue;
     }
-    if (examRes.status === 'fulfilled') {
-      ops.push(
-        this.prisma.aiExamBank.update({
-          where: { id: examRes.value.id },
-          data: { studyPlanId: plan.id },
-        }) as unknown as Prisma.PrismaPromise<unknown>,
-      );
-    }
     data.summary = summaries.join(' · ').slice(0, 600);
     ops.push(
       this.prisma.studyPlan.update({
@@ -295,7 +294,7 @@ export class StudyPlansService {
       await this.prisma.$transaction(ops);
     } catch (err) {
       // Si el enlace transaccional falla, no dejar huérfanos: ni el plan cáscara
-      // ni los decks/banco ya generados pero sin enlazar (quedarían sueltos en la
+      // ni los decks ya generados pero sin enlazar (quedarían sueltos en la
       // biblioteca del alumno, indistinguibles de los creados a mano).
       const generatedTheoryIds = theoryResults.flatMap((r) =>
         r.status === 'fulfilled' ? [r.value.id] : [],
@@ -304,9 +303,6 @@ export class StudyPlansService {
         ...generatedTheoryIds.map((theoryId) =>
           this.prisma.theoryModule.delete({ where: { id: theoryId } }),
         ),
-        ...(examRes.status === 'fulfilled'
-          ? [this.prisma.aiExamBank.delete({ where: { id: examRes.value.id } })]
-          : []),
         this.prisma.studyPlan.delete({ where: { id: plan.id } }),
       ]);
       throw err;
@@ -330,7 +326,7 @@ export class StudyPlansService {
           orderBy: { order: 'asc' },
           include: { theoryModule: { select: { id: true } } },
         },
-        examBank: { select: { id: true } },
+        examBanks: { select: { id: true } },
       },
     });
     return plans.map((p) => ({
@@ -344,7 +340,7 @@ export class StudyPlansService {
       sections: {
         theory: p.topics.length > 0 && p.topics.every((t) => !!t.theoryModule),
         exercises: Array.isArray(p.exercises) && (p.exercises as unknown[]).length > 0,
-        exam: !!p.examBank,
+        exam: p.examBanks.length > 0,
       },
     }));
   }
@@ -358,7 +354,18 @@ export class StudyPlansService {
           orderBy: { order: 'asc' },
           include: { theoryModule: { select: { id: true } } },
         },
-        examBank: { select: { id: true } },
+        examBanks: {
+          orderBy: { createdAt: 'asc' },
+          select: {
+            id: true,
+            title: true,
+            level: true,
+            studyPlanTopicId: true,
+            numQuestions: true,
+            timeLimit: true,
+            onlyOnce: true,
+          },
+        },
       },
     });
     if (!plan) throw new NotFoundException('Plan de estudio no encontrado');
@@ -370,8 +377,31 @@ export class StudyPlansService {
         theory: t.theoryModule ? await this.theory.getById(userId, t.theoryModule.id) : null,
       })),
     );
-    // getBank serializa SIN isCorrect (mismo camino que StudyService.getById)
-    const exam = plan.examBank ? await this.aiExams.getBank(userId, plan.examBank.id) : null;
+
+    // Info de cada examen (sin preguntas: se cargan al hacerlo, vía /exam) con
+    // intentos y mejor nota del alumno para pintar "aprobado" por nivel.
+    const bankIds = plan.examBanks.map((b) => b.id);
+    const attemptStats = bankIds.length
+      ? await this.prisma.examAttempt.groupBy({
+          by: ['aiExamBankId'],
+          where: { aiExamBankId: { in: bankIds }, userId },
+          _count: { _all: true },
+          _max: { score: true },
+        })
+      : [];
+    const statsByBank = new Map(attemptStats.map((s) => [s.aiExamBankId, s]));
+    const exams = plan.examBanks.map((b) => ({
+      id: b.id,
+      title: b.title,
+      level: (b.level as StudyPlanExamLevel | null) ?? null,
+      topicId: b.studyPlanTopicId,
+      numQuestions: b.numQuestions,
+      timeLimit: b.timeLimit,
+      onlyOnce: b.onlyOnce,
+      attemptCount: statsByBank.get(b.id)?._count._all ?? 0,
+      bestScore: statsByBank.get(b.id)?._max.score ?? null,
+    }));
+
     const exercises = Array.isArray(plan.exercises)
       ? (plan.exercises as unknown as GeneratedTopicExercise[])
       : null;
@@ -387,10 +417,12 @@ export class StudyPlansService {
       sections: {
         theory: topics.length > 0 && topics.every((t) => t.hasTheory),
         exercises: !!exercises && exercises.length > 0,
-        exam: !!exam,
+        exam: exams.length > 0,
       },
       exercises,
-      exam,
+      exercisesConfig:
+        (plan.exercisesConfig as { easy: number; medium: number; hard: number } | null) ?? null,
+      exams,
     };
   }
 
@@ -426,53 +458,88 @@ export class StudyPlansService {
     return this.getById(userId, planId);
   }
 
-  /** Regenera los ejercicios combinados del plan. */
-  async regenerateExercises(userId: string, planId: string, dto: RegenerateExercisesDto) {
+  /** Regenera los ejercicios del plan (reparto por tema; override opcional). */
+  async regenerateExercises(userId: string, planId: string, dto: RegeneratePlanExercisesDto) {
     const plan = await this.requireOwnedPlan(userId, planId);
-    const prevCount = Array.isArray(plan.exercises) ? (plan.exercises as unknown[]).length : 0;
-    const count = dto.count ?? (prevCount > 0 ? prevCount : Math.max(5, plan.topics.length));
-    if (count < plan.topics.length) {
-      throw new UnprocessableEntityException(
-        `Debe haber al menos 1 ejercicio por tema: con ${plan.topics.length} temas ` +
-          `necesitas count ≥ ${plan.topics.length}`,
-      );
-    }
+    const stored =
+      (plan.exercisesConfig as { easy?: number; medium?: number; hard?: number } | null) ?? null;
+    const perTopic = {
+      easy: dto.easy ?? stored?.easy ?? 2,
+      medium: dto.medium ?? stored?.medium ?? 2,
+      hard: dto.hard ?? stored?.hard ?? 1,
+    };
+    this.assertPerTopicTotal(perTopic as ExercisesPerTopicDto);
+
+    // Generar primero: si la IA falla, los ejercicios anteriores quedan intactos.
     const res = await this.exercises.generateForTopics(userId, {
       courseId: plan.courseId,
       topics: plan.topics.map((t) => t.title),
-      count,
-      difficulty: plan.difficulty as 'EASY' | 'MEDIUM' | 'HARD',
+      perTopic,
     });
     await this.prisma.studyPlan.update({
       where: { id: plan.id },
-      data: { exercises: res.exercises as unknown as Prisma.InputJsonValue },
+      data: {
+        exercises: res.exercises as unknown as Prisma.InputJsonValue,
+        exercisesConfig: perTopic,
+      },
     });
     return this.getById(userId, planId);
   }
 
-  /** Regenera el examen combinado del plan. */
-  async regenerateExam(userId: string, planId: string, dto: RegenerateExamDto) {
+  // ── Exámenes por nivel (generación lazy) ──
+
+  /**
+   * Genera el examen de un nivel del plan: combinado de todos los temas (sin
+   * topicId) o de un tema concreto. Idempotente: si ya existe un banco para
+   * ese (tema, nivel), lo devuelve sin llamar a la IA.
+   */
+  async generateExam(userId: string, planId: string, dto: GeneratePlanExamDto) {
     const plan = await this.requireOwnedPlan(userId, planId);
-    const numQuestions = dto.numQuestions ?? plan.examBank?.numQuestions ?? 5;
-    if (numQuestions < plan.topics.length) {
+
+    let topicTitles = plan.topics.map((t) => t.title);
+    let courseId = plan.courseId;
+    let topicId: string | null = null;
+    if (dto.topicId) {
+      const topic = plan.topics.find((t) => t.id === dto.topicId);
+      if (!topic) throw new NotFoundException('Tema no encontrado en este plan');
+      topicId = topic.id;
+      courseId = topic.contextCourseId;
+      topicTitles = [topic.title];
+    }
+
+    const existing = plan.examBanks.find(
+      (b) => b.level === dto.level && (b.studyPlanTopicId ?? null) === topicId,
+    );
+    if (existing) return this.getById(userId, planId);
+
+    const preset = EXAM_LEVEL_PRESETS[dto.level];
+    const numQuestions = dto.numQuestions ?? preset.numQuestions;
+    if (numQuestions < topicTitles.length) {
       throw new UnprocessableEntityException(
-        `El examen debe tener al menos 1 pregunta por tema: con ${plan.topics.length} temas ` +
-          `necesitas numQuestions ≥ ${plan.topics.length}`,
+        `El examen debe tener al menos 1 pregunta por tema: con ${topicTitles.length} temas ` +
+          `necesitas numQuestions ≥ ${topicTitles.length}`,
       );
     }
-    // Generar primero: si la IA falla, el banco anterior (si existía) queda intacto.
+
     const bank = await this.aiExams.generateForTopics(userId, {
-      courseId: plan.courseId,
-      topics: plan.topics.map((t) => t.title),
+      courseId,
+      topics: topicTitles,
       numQuestions,
-      timeLimit: dto.timeLimit ?? plan.examBank?.timeLimit ?? undefined,
-      onlyOnce: dto.onlyOnce ?? plan.examBank?.onlyOnce,
-      difficulty: plan.difficulty as 'EASY' | 'MEDIUM' | 'HARD',
+      difficulty: dto.difficulty ?? preset.difficulty,
     });
-    if (plan.examBank) await this.aiExams.deleteBank(userId, plan.examBank.id);
     await this.prisma.aiExamBank.update({
       where: { id: bank.id },
-      data: { studyPlanId: plan.id },
+      data: { studyPlanId: plan.id, studyPlanTopicId: topicId, level: dto.level },
+    });
+    return this.getById(userId, planId);
+  }
+
+  /** Renombra el curso multi-tema del alumno. */
+  async rename(userId: string, planId: string, dto: RenameStudyPlanDto) {
+    await this.requireOwnedPlan(userId, planId);
+    await this.prisma.studyPlan.update({
+      where: { id: planId },
+      data: { title: dto.title.trim() },
     });
     return this.getById(userId, planId);
   }
@@ -507,8 +574,8 @@ export class StudyPlansService {
           orderBy: { order: 'asc' },
           include: { theoryModule: { select: { id: true } } },
         },
-        examBank: {
-          select: { id: true, numQuestions: true, timeLimit: true, onlyOnce: true },
+        examBanks: {
+          select: { id: true, level: true, studyPlanTopicId: true },
         },
       },
     });

--- a/apps/web/src/api/study-plans.api.ts
+++ b/apps/web/src/api/study-plans.api.ts
@@ -3,8 +3,9 @@ import type {
   StudyPlanSummary,
   StudyPlanDetail,
   CreateStudyPlanRequest,
-  RegenerateExercisesRequest,
-  RegenerateExamRequest,
+  GenerateStudyPlanExamRequest,
+  RenameStudyPlanRequest,
+  RegenerateStudyPlanExercisesRequest,
 } from '@vkbacademy/shared';
 
 export const studyPlansApi = {
@@ -15,14 +16,18 @@ export const studyPlansApi = {
 
   getById: (id: string) => api.get<StudyPlanDetail>(`/study-plans/${id}`).then((r) => r.data),
 
+  rename: (id: string, payload: RenameStudyPlanRequest) =>
+    api.patch<StudyPlanDetail>(`/study-plans/${id}`, payload).then((r) => r.data),
+
   delete: (id: string) => api.delete<void>(`/study-plans/${id}`).then((r) => r.data),
 
   regenerateTopicTheory: (id: string, topicId: string) =>
     api.post<StudyPlanDetail>(`/study-plans/${id}/topics/${topicId}/theory`).then((r) => r.data),
 
-  regenerateExercises: (id: string, payload: RegenerateExercisesRequest) =>
+  regenerateExercises: (id: string, payload: RegenerateStudyPlanExercisesRequest) =>
     api.post<StudyPlanDetail>(`/study-plans/${id}/exercises`, payload).then((r) => r.data),
 
-  regenerateExam: (id: string, payload: RegenerateExamRequest) =>
-    api.post<StudyPlanDetail>(`/study-plans/${id}/exam`, payload).then((r) => r.data),
+  // Genera (lazy) el examen de un nivel: combinado o de un tema concreto.
+  generateExam: (id: string, payload: GenerateStudyPlanExamRequest) =>
+    api.post<StudyPlanDetail>(`/study-plans/${id}/exams`, payload).then((r) => r.data),
 };

--- a/apps/web/src/components/exercises/ExercisePractice.tsx
+++ b/apps/web/src/components/exercises/ExercisePractice.tsx
@@ -1,7 +1,16 @@
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import type { StudyExercise } from '@vkbacademy/shared';
+import type { StudyDifficulty, StudyExercise } from '@vkbacademy/shared';
 import api from '../../lib/axios';
+
+// Los ejercicios del curso multi-tema llegan con dificultad; los del flujo un-tema, sin ella.
+type PracticeExercise = StudyExercise & { difficulty?: StudyDifficulty };
+
+const DIFFICULTY_LABEL: Record<StudyDifficulty, string> = {
+  EASY: 'Fácil',
+  MEDIUM: 'Medio',
+  HARD: 'Difícil',
+};
 
 type Verdict = 'correct' | 'partial' | 'incorrect';
 
@@ -16,7 +25,7 @@ interface EvaluatePayload {
   solution: string;
 }
 
-export default function ExercisePractice({ exercises }: { exercises: StudyExercise[] }) {
+export default function ExercisePractice({ exercises }: { exercises: PracticeExercise[] }) {
   const [revealed, setRevealed] = useState<Record<number, boolean>>({});
   const [selected, setSelected] = useState<Record<number, number | null>>({});
   const [answers, setAnswers] = useState<Record<number, string>>({});
@@ -113,7 +122,7 @@ function ExerciseCard({
   onEvaluate,
   onToggle,
 }: {
-  exercise: StudyExercise;
+  exercise: PracticeExercise;
   index: number;
   revealed: boolean;
   selected: number | null;
@@ -162,6 +171,11 @@ function ExerciseCard({
       <header style={s.cardHeader}>
         <span style={s.cardNumber}>#{index + 1}</span>
         <span style={s.cardType}>{labelForType(exercise.type)}</span>
+        {exercise.difficulty && (
+          <span style={{ ...s.cardDifficulty, ...difficultyStyle(exercise.difficulty) }}>
+            {DIFFICULTY_LABEL[exercise.difficulty]}
+          </span>
+        )}
       </header>
 
       <p style={s.statement}>{exercise.statement}</p>
@@ -240,6 +254,18 @@ function verdictLabel(verdict: Verdict): string {
   }
 }
 
+// Color del chip de dificultad (verde / ámbar / rojo suaves).
+function difficultyStyle(difficulty: StudyDifficulty): React.CSSProperties {
+  switch (difficulty) {
+    case 'EASY':
+      return { color: 'var(--color-success, #16a34a)', background: 'rgba(22,163,74,0.1)' };
+    case 'MEDIUM':
+      return { color: '#b45309', background: 'rgba(180,83,9,0.1)' };
+    case 'HARD':
+      return { color: 'var(--color-error)', background: 'rgba(220,38,38,0.08)' };
+  }
+}
+
 function labelForType(type: StudyExercise['type']): string {
   switch (type) {
     case 'SINGLE':
@@ -275,6 +301,14 @@ const s: Record<string, React.CSSProperties> = {
   },
   cardHeader: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   cardNumber: { fontSize: '0.9rem', fontWeight: 700, color: 'var(--brand-deep)' },
+  cardDifficulty: {
+    fontSize: '0.72rem',
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    padding: '2px 8px',
+    borderRadius: 999,
+  },
   cardType: {
     fontSize: '0.75rem',
     fontWeight: 600,

--- a/apps/web/src/hooks/useStudyPlans.ts
+++ b/apps/web/src/hooks/useStudyPlans.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { studyPlansApi } from '../api/study-plans.api';
-import type { CreateStudyPlanRequest } from '@vkbacademy/shared';
+import type {
+  CreateStudyPlanRequest,
+  GenerateStudyPlanExamRequest,
+  RegenerateStudyPlanExercisesRequest,
+} from '@vkbacademy/shared';
 
 export function useMyStudyPlans() {
   return useQuery({ queryKey: ['study-plans', 'mine'], queryFn: () => studyPlansApi.listMine() });
@@ -41,15 +45,32 @@ export function useRegenerateTopicTheory(id: string) {
 export function useRegeneratePlanExercises(id: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (count?: number) => studyPlansApi.regenerateExercises(id, { count }),
+    mutationFn: (payload?: RegenerateStudyPlanExercisesRequest) =>
+      studyPlansApi.regenerateExercises(id, payload ?? {}),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['study-plans', id] }),
   });
 }
 
-export function useRegeneratePlanExam(id: string) {
+/** Genera (lazy) el examen de un nivel del plan; el detalle se refresca al terminar. */
+export function useGeneratePlanExam(id: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => studyPlansApi.regenerateExam(id, {}),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['study-plans', id] }),
+    mutationFn: (payload: GenerateStudyPlanExamRequest) =>
+      studyPlansApi.generateExam(id, payload),
+    onSuccess: (detail) => {
+      qc.setQueryData(['study-plans', id], detail);
+      void qc.invalidateQueries({ queryKey: ['study-plans', 'mine'] });
+    },
+  });
+}
+
+export function useRenameStudyPlan(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (title: string) => studyPlansApi.rename(id, { title }),
+    onSuccess: (detail) => {
+      qc.setQueryData(['study-plans', id], detail);
+      void qc.invalidateQueries({ queryKey: ['study-plans', 'mine'] });
+    },
   });
 }

--- a/apps/web/src/pages/StudyPage.tsx
+++ b/apps/web/src/pages/StudyPage.tsx
@@ -332,7 +332,8 @@ export default function StudyPage() {
                     <span style={p.sections.exercises ? s.sectionOk : s.sectionMissing}>
                       Ejercicios
                     </span>
-                    <span style={p.sections.exam ? s.sectionOk : s.sectionMissing}>Examen</span>
+                    {/* El examen se genera lazy por niveles: sin generar no es un fallo */}
+                    <span style={p.sections.exam ? s.sectionOk : s.sectionPending}>Examen</span>
                   </span>
                   <span style={s.itemDate}>
                     {new Date(p.createdAt).toLocaleDateString('es-ES', {
@@ -467,6 +468,15 @@ const s: Record<string, React.CSSProperties> = {
     fontWeight: 700,
     color: 'var(--color-error)',
     background: 'rgba(220,38,38,0.08)',
+    padding: '2px 8px',
+    borderRadius: 999,
+  },
+  // Examen aún sin generar (es lazy por niveles): pendiente, no fallo.
+  sectionPending: {
+    fontSize: '0.68rem',
+    fontWeight: 700,
+    color: 'var(--color-text-muted)',
+    background: 'rgba(0,0,0,0.05)',
     padding: '2px 8px',
     borderRadius: 999,
   },

--- a/apps/web/src/pages/StudyPlanCreatePage.tsx
+++ b/apps/web/src/pages/StudyPlanCreatePage.tsx
@@ -1,19 +1,22 @@
 import { useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import type { StudyDifficulty, StudyPlanTopicInput } from '@vkbacademy/shared';
+import type { StudyExercisesPerTopic, StudyPlanTopicInput } from '@vkbacademy/shared';
 import { useCourses, useCourse, useSubjects } from '../hooks/useCourses';
 import { useCreateStudyPlan } from '../hooks/useStudyPlans';
 import { getApiErrorMessage } from '../utils/errorMessage';
 import PageHeader from '../components/ui/PageHeader';
 import Icon from '../components/ui/Icon';
 
-const DIFFICULTIES: { value: StudyDifficulty; label: string }[] = [
-  { value: 'EASY', label: 'Fácil' },
-  { value: 'MEDIUM', label: 'Media' },
-  { value: 'HARD', label: 'Difícil' },
-];
-
 const MAX_TOPICS = 6;
+
+// Reparto de ejercicios por tema (pedido del producto: 2 fáciles, 2 medios, 1 difícil).
+const DEFAULT_PER_TOPIC: StudyExercisesPerTopic = { easy: 2, medium: 2, hard: 1 };
+
+const SPLIT_FIELDS: { key: keyof StudyExercisesPerTopic; label: string }[] = [
+  { key: 'easy', label: 'Fáciles' },
+  { key: 'medium', label: 'Medios' },
+  { key: 'hard', label: 'Difíciles' },
+];
 
 // Tema ya elegido para el plan (oficial u propio), con etiqueta lista para mostrar en el chip.
 interface SelectedTopic {
@@ -41,14 +44,14 @@ export default function StudyPlanCreatePage() {
   const [customSubject, setCustomSubject] = useState(''); // '' = asignatura base
   const [customError, setCustomError] = useState('');
 
-  const [numExercises, setNumExercises] = useState(5);
-  const [difficulty, setDifficulty] = useState<StudyDifficulty>('MEDIUM');
-  const [numQuestions, setNumQuestions] = useState<5 | 10>(5);
-  const [useTimer, setUseTimer] = useState(false);
-  const [timerMins, setTimerMins] = useState(15);
-  const [onlyOnce, setOnlyOnce] = useState(false);
+  const [perTopic, setPerTopic] = useState<StudyExercisesPerTopic>(DEFAULT_PER_TOPIC);
+  const perTopicTotal = perTopic.easy + perTopic.medium + perTopic.hard;
 
   const create = useCreateStudyPlan();
+
+  function setSplit(key: keyof StudyExercisesPerTopic, value: number) {
+    setPerTopic((prev) => ({ ...prev, [key]: Math.max(0, Math.min(10, value)) }));
+  }
 
   function handleCourseChange(id: string) {
     setCourseId(id);
@@ -72,7 +75,9 @@ export default function StudyPlanCreatePage() {
 
   const atMax = selectedTopics.length >= MAX_TOPICS;
 
-  function toggleModule(module: { id: string; title: string; order: number }) {
+  // displayNum = posición en el temario ordenado (el campo `order` de BD no es
+  // fiable como numeral: hay cursos 0-based y 1-based).
+  function toggleModule(module: { id: string; title: string }, displayNum: number) {
     setSelectedTopics((prev) => {
       const exists = prev.some((t) => t.kind === 'OFFICIAL' && t.moduleId === module.id);
       if (exists) return prev.filter((t) => !(t.kind === 'OFFICIAL' && t.moduleId === module.id));
@@ -84,7 +89,7 @@ export default function StudyPlanCreatePage() {
           kind: 'OFFICIAL',
           moduleId: module.id,
           title: module.title,
-          label: `Tema ${module.order + 1} — ${module.title}`,
+          label: `Tema ${displayNum} — ${module.title}`,
         },
       ];
     });
@@ -119,14 +124,8 @@ export default function StudyPlanCreatePage() {
     setSelectedTopics((prev) => prev.filter((t) => t.key !== key));
   }
 
-  const needsMoreQuestions = numQuestions < selectedTopics.length;
-  const needsMoreExercises = numExercises < selectedTopics.length;
-  const canSubmit =
-    !!courseId &&
-    selectedTopics.length > 0 &&
-    !needsMoreQuestions &&
-    !needsMoreExercises &&
-    !create.isPending;
+  const splitInvalid = perTopicTotal < 1 || perTopicTotal > 10;
+  const canSubmit = !!courseId && selectedTopics.length > 0 && !splitInvalid && !create.isPending;
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -139,15 +138,7 @@ export default function StudyPlanCreatePage() {
           : { title: t.title },
     );
     create.mutate(
-      {
-        courseId,
-        topics,
-        numExercises,
-        difficulty,
-        numQuestions,
-        timeLimit: useTimer ? Math.round(timerMins * 60) : undefined,
-        onlyOnce,
-      },
+      { courseId, topics, exercisesPerTopic: perTopic },
       { onSuccess: (plan) => navigate(`/study/plan/${plan.id}`) },
     );
   }
@@ -200,7 +191,7 @@ export default function StudyPlanCreatePage() {
               )}
               {modules.length > 0 && (
                 <ul style={s.checklist}>
-                  {modules.map((m) => {
+                  {modules.map((m, i) => {
                     const isSelected = selectedTopics.some(
                       (t) => t.kind === 'OFFICIAL' && t.moduleId === m.id,
                     );
@@ -212,9 +203,9 @@ export default function StudyPlanCreatePage() {
                             type="checkbox"
                             checked={isSelected}
                             disabled={disabled}
-                            onChange={() => toggleModule(m)}
+                            onChange={() => toggleModule(m, i + 1)}
                           />
-                          Tema {m.order + 1} — {m.title}
+                          Tema {i + 1} — {m.title}
                         </label>
                       </li>
                     );
@@ -303,118 +294,58 @@ export default function StudyPlanCreatePage() {
                   </li>
                 ))}
               </ul>
-              <p style={s.muted}>El examen tendrá al menos 1 pregunta de cada uno.</p>
+              <p style={s.muted}>Cada tema tendrá su propio bloque de teoría y de ejercicios.</p>
             </div>
           )}
         </div>
 
-        {/* Rail lateral: configuración de ejercicios/examen + envío */}
+        {/* Rail lateral: configuración de ejercicios + envío */}
         <div style={s.col}>
           <div className="vkb-card" style={s.section}>
             <h3 style={s.sectionTitle}>
               <Icon name="target" size={16} color="var(--brand-deep)" />
-              Ejercicios
+              Ejercicios por tema
             </h3>
-            <div className="field">
-              <label htmlFor="numExercises">Nº de ejercicios</label>
-              <input
-                id="numExercises"
-                type="number"
-                min={1}
-                max={20}
-                value={numExercises}
-                onChange={(e) =>
-                  setNumExercises(Math.max(1, Math.min(20, Number(e.target.value) || 1)))
-                }
-              />
-            </div>
-            <div className="field">
-              <label>Dificultad</label>
-              <div style={{ display: 'flex', gap: 10 }}>
-                {DIFFICULTIES.map((d) => (
-                  <button
-                    key={d.value}
-                    type="button"
-                    onClick={() => setDifficulty(d.value)}
-                    className={`chip${difficulty === d.value ? ' active' : ''}`}
-                    style={s.chipFlex}
-                  >
-                    {d.label}
-                  </button>
-                ))}
+            {SPLIT_FIELDS.map((f) => (
+              <div className="field" key={f.key} style={s.splitRow}>
+                <label htmlFor={`split-${f.key}`} style={s.splitLabel}>
+                  {f.label}
+                </label>
+                <input
+                  id={`split-${f.key}`}
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={perTopic[f.key]}
+                  onChange={(e) => setSplit(f.key, Number(e.target.value) || 0)}
+                  style={s.splitInput}
+                />
               </div>
-            </div>
+            ))}
+            <p style={s.muted}>
+              {perTopicTotal} por tema
+              {selectedTopics.length > 1 &&
+                ` · ${selectedTopics.length} temas × ${perTopicTotal} = ${
+                  selectedTopics.length * perTopicTotal
+                } ejercicios`}
+            </p>
+            {splitInvalid && (
+              <p style={s.warn}>El reparto debe sumar entre 1 y 10 ejercicios por tema.</p>
+            )}
           </div>
 
           <div className="vkb-card" style={s.section}>
             <h3 style={s.sectionTitle}>
               <Icon name="graduation" size={16} color="var(--brand-deep)" />
-              Examen
+              Exámenes
             </h3>
-            <div className="field">
-              <label>Preguntas del examen</label>
-              <div style={{ display: 'flex', gap: 10 }}>
-                {([5, 10] as const).map((n) => (
-                  <button
-                    key={n}
-                    type="button"
-                    onClick={() => setNumQuestions(n)}
-                    className={`chip${numQuestions === n ? ' active' : ''}`}
-                    style={s.chipFlex}
-                  >
-                    {n} preguntas
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <label style={s.toggle}>
-              <input
-                type="checkbox"
-                checked={useTimer}
-                onChange={(e) => setUseTimer(e.target.checked)}
-              />
-              <Icon name="clock" size={15} color="var(--color-text-muted)" />
-              <span>Límite de tiempo</span>
-              {useTimer && (
-                <input
-                  type="number"
-                  min={1}
-                  max={180}
-                  value={timerMins}
-                  onChange={(e) =>
-                    setTimerMins(Math.min(180, Math.max(1, Number(e.target.value) || 1)))
-                  }
-                  style={s.timerInput}
-                />
-              )}
-              {useTimer && <span style={s.muted}>minutos</span>}
-            </label>
-
-            <label style={s.toggle}>
-              <input
-                type="checkbox"
-                checked={onlyOnce}
-                onChange={(e) => setOnlyOnce(e.target.checked)}
-              />
-              <Icon name="lock" size={15} color="var(--color-text-muted)" />
-              <span>Examen de un solo intento</span>
-            </label>
-
-            {needsMoreQuestions && (
-              <p style={s.warn}>
-                Con {selectedTopics.length} temas necesitas al menos {selectedTopics.length}{' '}
-                preguntas (1 por tema): elige 10 preguntas o quita algún tema.
-              </p>
-            )}
-            {needsMoreExercises && (
-              <p style={s.warn}>
-                Con {selectedTopics.length} temas necesitas al menos {selectedTopics.length}{' '}
-                ejercicios (1 por tema): sube el número de ejercicios o quita algún tema.
-              </p>
-            )}
+            <p style={s.muted}>
+              Los exámenes se generan después, en la pestaña Examen del curso: niveles básico,
+              medio y difícil, de todos los temas juntos o de cada tema por separado. El reto es
+              aprobar los 3 niveles.
+            </p>
             {selectedTopics.length === 0 && (
-              <p style={s.warn}>Añade al menos 1 tema para poder crear el plan.</p>
+              <p style={s.warn}>Añade al menos 1 tema para poder crear el curso.</p>
             )}
           </div>
 
@@ -430,7 +361,7 @@ export default function StudyPlanCreatePage() {
             ) : (
               <>
                 <Icon name="zap" size={16} />
-                Crear plan de estudio
+                Crear curso
               </>
             )}
           </button>
@@ -488,22 +419,9 @@ const s: Record<string, React.CSSProperties> = {
     cursor: 'pointer',
     padding: '4px 0',
   },
-  chipFlex: { flex: 1 },
-  toggle: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 10,
-    fontSize: '0.9rem',
-    color: 'var(--color-text)',
-  },
-  timerInput: {
-    width: 80,
-    background: 'var(--color-surface)',
-    border: '1px solid var(--color-border)',
-    borderRadius: 8,
-    color: 'var(--color-text)',
-    padding: '6px 10px',
-  },
+  splitRow: { display: 'flex', alignItems: 'center', gap: 12, flexDirection: 'row' },
+  splitLabel: { flex: 1, margin: 0 },
+  splitInput: { width: 90 },
   chipList: {
     listStyle: 'none',
     margin: 0,

--- a/apps/web/src/pages/StudyPlanPage.tsx
+++ b/apps/web/src/pages/StudyPlanPage.tsx
@@ -1,12 +1,19 @@
 import { Fragment, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import type { StudyPlanDetail, StudyPlanExercise, StudyPlanTopicDetail } from '@vkbacademy/shared';
+import type {
+  StudyPlanDetail,
+  StudyPlanExamInfo,
+  StudyPlanExamLevel,
+  StudyPlanExercise,
+  StudyPlanTopicDetail,
+} from '@vkbacademy/shared';
 import {
   useStudyPlan,
   useDeleteStudyPlan,
   useRegenerateTopicTheory,
   useRegeneratePlanExercises,
-  useRegeneratePlanExam,
+  useGeneratePlanExam,
+  useRenameStudyPlan,
 } from '../hooks/useStudyPlans';
 import TheoryView from '../components/theory/TheoryView';
 import ExercisePractice from '../components/exercises/ExercisePractice';
@@ -20,8 +27,17 @@ type Tab = 'theory' | 'exercises' | 'exam';
 const STEPS: { key: Tab; label: string; icon: string; desc: string }[] = [
   { key: 'theory', label: 'Apuntes', icon: 'book', desc: 'Estudia cada tema del curso' },
   { key: 'exercises', label: 'Ejercicios', icon: 'target', desc: 'Practica tema a tema lo aprendido' },
-  { key: 'exam', label: 'Examen', icon: 'graduation', desc: 'Un examen con preguntas de cada tema' },
+  { key: 'exam', label: 'Examen', icon: 'graduation', desc: 'Apruébalo en 3 niveles: básico, medio y difícil' },
 ];
+
+// Niveles del examen con su configuración por defecto (presets del backend).
+const EXAM_LEVELS: { key: StudyPlanExamLevel; label: string; preset: string }[] = [
+  { key: 'BASIC', label: 'Básico', preset: '5 preguntas · fáciles' },
+  { key: 'MEDIUM', label: 'Medio', preset: '8 preguntas · medias' },
+  { key: 'HARD', label: 'Difícil', preset: '10 preguntas · difíciles' },
+];
+
+const PASS_SCORE = 50;
 
 // Mismo look&feel de itinerario que StudyUnitPage (no se toca ese fichero: copia local).
 const STEPPER_CSS = `
@@ -91,7 +107,10 @@ export default function StudyPlanPage() {
   const navigate = useNavigate();
   const { data, isLoading, error } = useStudyPlan(id);
   const remove = useDeleteStudyPlan();
+  const rename = useRenameStudyPlan(id);
   const [tab, setTab] = useState<Tab>('theory');
+  // null = no se está editando; string = borrador del título nuevo.
+  const [titleDraft, setTitleDraft] = useState<string | null>(null);
 
   if (isLoading) {
     return (
@@ -128,7 +147,51 @@ export default function StudyPlanPage() {
         {data.course.title} · {data.topics.length} temas
       </span>
 
-      <PageHeader variant="light" title={data.title} subtitle={data.summary} />
+      {titleDraft === null ? (
+        <div style={s.titleRow}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <PageHeader variant="light" title={data.title} subtitle={data.summary} />
+          </div>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            style={s.renameBtn}
+            onClick={() => setTitleDraft(data.title)}
+          >
+            Renombrar
+          </button>
+        </div>
+      ) : (
+        <div style={s.renameRow}>
+          <input
+            type="text"
+            value={titleDraft}
+            onChange={(e) => setTitleDraft(e.target.value)}
+            maxLength={200}
+            autoFocus
+            aria-label="Nuevo nombre del curso"
+            style={s.renameInput}
+          />
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={titleDraft.trim().length < 3 || rename.isPending}
+            onClick={() =>
+              rename.mutate(titleDraft.trim(), { onSuccess: () => setTitleDraft(null) })
+            }
+          >
+            {rename.isPending ? <span className="spinner" /> : 'Guardar'}
+          </button>
+          <button type="button" className="btn btn-ghost" onClick={() => setTitleDraft(null)}>
+            Cancelar
+          </button>
+        </div>
+      )}
+      {rename.isError && (
+        <div className="alert alert-error">
+          {getApiErrorMessage(rename.error, 'No se pudo renombrar el curso. Inténtalo de nuevo.')}
+        </div>
+      )}
 
       <style>{STEPPER_CSS}</style>
       <nav className="unit-steps" aria-label="Itinerario del plan de estudio">
@@ -152,7 +215,8 @@ export default function StudyPlanPage() {
                 <span className="unit-step-title">
                   <Icon name={t.icon} size={16} />
                   {t.label}
-                  {!data.sections[t.key] && (
+                  {/* El examen se genera lazy por niveles: no generado no es un fallo */}
+                  {t.key !== 'exam' && !data.sections[t.key] && (
                     <span style={s.tabWarn} title="Sección no generada">
                       !
                     </span>
@@ -403,60 +467,224 @@ function ExercisesTab({ plan }: { plan: StudyPlanDetail }) {
   );
 }
 
-// ─── Examen: mismo flujo AiExamBank que StudyUnitPage (sin código nuevo de examen) ──
+// ─── Examen: 3 niveles (básico/medio/difícil) generados lazy, combinados o por tema ──
 
 function ExamTab({ plan, onStart }: { plan: StudyPlanDetail; onStart: (bankId: string) => void }) {
-  const regen = useRegeneratePlanExam(plan.id);
-  if (!plan.exam) {
-    return (
-      <MissingSection
-        label="el examen"
-        icon="graduation"
-        onRetry={() => regen.mutate()}
-        retrying={regen.isPending}
-        isError={regen.isError}
-        error={regen.error}
-      />
+  const gen = useGeneratePlanExam(plan.id);
+  const [mode, setMode] = useState<'COMBINED' | 'PER_TOPIC'>('COMBINED');
+  // Qué tarjeta está generando: `${topicId ?? 'all'}:${level}`.
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+  const exams = plan.exams ?? [];
+  const legacyExams = exams.filter((e) => !e.level);
+  const findExam = (topicId: string | null, level: StudyPlanExamLevel) =>
+    exams.find((e) => e.level === level && e.topicId === topicId);
+
+  function generate(topicId: string | null, level: StudyPlanExamLevel, numQuestions?: number) {
+    const key = `${topicId ?? 'all'}:${level}`;
+    setPendingKey(key);
+    gen.mutate(
+      { level, topicId: topicId ?? undefined, numQuestions },
+      { onSettled: () => setPendingKey(null) },
     );
   }
-  const { exam } = plan;
-  const timeMinutes = exam.timeLimit ? Math.round(exam.timeLimit / 60) : null;
+
+  const combinedPassed = EXAM_LEVELS.filter((l) => {
+    const exam = findExam(null, l.key);
+    return exam?.bestScore != null && exam.bestScore >= PASS_SCORE;
+  }).length;
+
   return (
-    <div className="vkb-card" style={s.examCard}>
-      <div>
-        <div style={s.examTitle}>{exam.title}</div>
-        <div style={s.examMeta}>
-          <span>{exam.questions.length} preguntas</span>
-          {timeMinutes !== null && (
-            <>
-              <span aria-hidden="true">·</span>
-              <span style={s.examMetaItem}>
-                <Icon name="clock" size={12} />
-                {timeMinutes} min
-              </span>
-            </>
-          )}
-          {exam.onlyOnce && (
-            <>
-              <span aria-hidden="true">·</span>
-              <span style={s.examMetaItem}>
-                <Icon name="lock" size={12} />1 intento
-              </span>
-            </>
-          )}
-          {exam.attemptCount > 0 && (
-            <>
-              <span aria-hidden="true">·</span>
-              <span>
-                {exam.attemptCount} {exam.attemptCount === 1 ? 'intento' : 'intentos'}
-              </span>
-            </>
-          )}
+    <div style={s.deckList}>
+      <div className="vkb-card" style={s.examIntro}>
+        <p style={s.examIntroText}>
+          No te conformes con aprobar el nivel básico: el reto es aprobar <strong>los 3 niveles</strong>.
+          {mode === 'COMBINED' && ` Llevas ${combinedPassed} de 3.`}
+        </p>
+        <div style={s.examModeRow} role="group" aria-label="Modo de examen">
+          <button
+            type="button"
+            className={`chip${mode === 'COMBINED' ? ' active' : ''}`}
+            onClick={() => setMode('COMBINED')}
+          >
+            Todos los temas juntos
+          </button>
+          <button
+            type="button"
+            className={`chip${mode === 'PER_TOPIC' ? ' active' : ''}`}
+            onClick={() => setMode('PER_TOPIC')}
+          >
+            Un examen por tema
+          </button>
         </div>
       </div>
-      <button className="btn btn-primary" style={s.examStart} onClick={() => onStart(exam.id)}>
-        {exam.attemptCount > 0 ? 'Repetir' : 'Empezar'}
-      </button>
+
+      {gen.isError && (
+        <div className="alert alert-error">
+          {getApiErrorMessage(gen.error, 'No se pudo generar el examen. Inténtalo de nuevo.')}
+        </div>
+      )}
+
+      {mode === 'COMBINED' ? (
+        <div style={s.levelGrid}>
+          {EXAM_LEVELS.map((l) => (
+            <ExamLevelCard
+              key={l.key}
+              level={l}
+              exam={findExam(null, l.key)}
+              busy={pendingKey === `all:${l.key}`}
+              anyBusy={pendingKey !== null}
+              onGenerate={(numQuestions) => generate(null, l.key, numQuestions)}
+              onStart={onStart}
+            />
+          ))}
+        </div>
+      ) : (
+        plan.topics.map((topic, i) => (
+          <div key={topic.id} style={s.examTopicBlock}>
+            <h3 style={s.examTopicTitle}>
+              <span style={s.deckNum}>{i + 1}</span>
+              {topic.title}
+            </h3>
+            <div style={s.levelGrid}>
+              {EXAM_LEVELS.map((l) => (
+                <ExamLevelCard
+                  key={l.key}
+                  level={l}
+                  exam={findExam(topic.id, l.key)}
+                  busy={pendingKey === `${topic.id}:${l.key}`}
+                  anyBusy={pendingKey !== null}
+                  onGenerate={(numQuestions) => generate(topic.id, l.key, numQuestions)}
+                  onStart={onStart}
+                />
+              ))}
+            </div>
+          </div>
+        ))
+      )}
+
+      {legacyExams.map((exam) => (
+        <div key={exam.id} className="vkb-card" style={s.examCard}>
+          <div>
+            <div style={s.examTitle}>{exam.title}</div>
+            <div style={s.examMeta}>
+              <span>{exam.numQuestions} preguntas</span>
+              {exam.attemptCount > 0 && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>
+                    {exam.attemptCount} {exam.attemptCount === 1 ? 'intento' : 'intentos'}
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+          <button className="btn btn-primary" style={s.examStart} onClick={() => onStart(exam.id)}>
+            {exam.attemptCount > 0 ? 'Repetir' : 'Empezar'}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ExamLevelCard({
+  level,
+  exam,
+  busy,
+  anyBusy,
+  onGenerate,
+  onStart,
+}: {
+  level: { key: StudyPlanExamLevel; label: string; preset: string };
+  exam: StudyPlanExamInfo | undefined;
+  busy: boolean;
+  anyBusy: boolean;
+  onGenerate: (numQuestions?: number) => void;
+  onStart: (bankId: string) => void;
+}) {
+  const [adjusting, setAdjusting] = useState(false);
+  const [numQuestions, setNumQuestions] = useState<number | undefined>(undefined);
+
+  const passed = exam?.bestScore != null && exam.bestScore >= PASS_SCORE;
+
+  return (
+    <div className="vkb-card" style={s.levelCard}>
+      <div style={s.levelHeader}>
+        <span style={s.levelName}>{level.label}</span>
+        {passed && (
+          <span style={s.levelPassed} title="Nivel aprobado">
+            ✓ Aprobado
+          </span>
+        )}
+      </div>
+
+      {exam ? (
+        <>
+          <div style={s.examMeta}>
+            <span>{exam.numQuestions} preguntas</span>
+            {exam.attemptCount > 0 && (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>
+                  {exam.attemptCount} {exam.attemptCount === 1 ? 'intento' : 'intentos'}
+                </span>
+              </>
+            )}
+            {exam.bestScore != null && (
+              <>
+                <span aria-hidden="true">·</span>
+                <span style={passed ? s.scoreOk : s.scoreKo}>
+                  Mejor nota: {Math.round(exam.bestScore)}%
+                </span>
+              </>
+            )}
+          </div>
+          <button className="btn btn-primary" onClick={() => onStart(exam.id)}>
+            {exam.attemptCount > 0 ? 'Repetir' : 'Empezar'}
+          </button>
+        </>
+      ) : (
+        <>
+          <p style={s.levelPreset}>{level.preset}</p>
+          {adjusting && (
+            <div className="field" style={{ margin: 0 }}>
+              <label htmlFor={`nq-${level.key}`}>Nº de preguntas</label>
+              <select
+                id={`nq-${level.key}`}
+                value={numQuestions ?? ''}
+                onChange={(e) =>
+                  setNumQuestions(e.target.value ? Number(e.target.value) : undefined)
+                }
+              >
+                <option value="">Por defecto</option>
+                {[5, 8, 10, 15, 20].map((n) => (
+                  <option key={n} value={n}>
+                    {n} preguntas
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div style={s.levelActions}>
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={anyBusy}
+              onClick={() => onGenerate(numQuestions)}
+            >
+              {busy ? <span className="spinner" /> : 'Generar examen'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={() => setAdjusting((v) => !v)}
+            >
+              {adjusting ? 'Ocultar ajustes' : 'Ajustar'}
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -516,6 +744,62 @@ const s: Record<string, React.CSSProperties> = {
     letterSpacing: '0.04em',
   },
   deckContent: { marginTop: 16 },
+
+  titleRow: { display: 'flex', alignItems: 'flex-start', gap: 12 },
+  renameBtn: { flexShrink: 0, marginTop: 6 },
+  renameRow: { display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' },
+  renameInput: {
+    flex: 1,
+    minWidth: 260,
+    fontSize: '1.1rem',
+    fontWeight: 700,
+    padding: '10px 14px',
+    background: 'var(--color-surface)',
+    border: '1.5px solid var(--brand)',
+    borderRadius: 10,
+    color: 'var(--color-text)',
+  },
+
+  examIntro: { display: 'flex', flexDirection: 'column', gap: 12, padding: '18px 22px' },
+  examIntroText: { margin: 0, fontSize: '0.95rem', color: 'var(--color-text)', lineHeight: 1.5 },
+  examModeRow: { display: 'flex', gap: 10, flexWrap: 'wrap' },
+  levelGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))',
+    gap: 14,
+  },
+  levelCard: { display: 'flex', flexDirection: 'column', gap: 12, padding: '18px 20px' },
+  levelHeader: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  levelName: {
+    fontFamily: 'var(--font-display)',
+    fontSize: '1.05rem',
+    fontWeight: 800,
+    color: 'var(--color-text)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+  },
+  levelPassed: {
+    fontSize: '0.75rem',
+    fontWeight: 800,
+    color: 'var(--color-success, #16a34a)',
+    background: 'rgba(22,163,74,0.12)',
+    padding: '3px 10px',
+    borderRadius: 999,
+  },
+  levelPreset: { margin: 0, fontSize: '0.85rem', color: 'var(--color-text-muted)' },
+  levelActions: { display: 'flex', gap: 8, flexWrap: 'wrap' },
+  scoreOk: { color: 'var(--color-success, #16a34a)', fontWeight: 700 },
+  scoreKo: { color: 'var(--color-text)', fontWeight: 700 },
+  examTopicBlock: { display: 'flex', flexDirection: 'column', gap: 10 },
+  examTopicTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    margin: '6px 0 0',
+    fontSize: '0.95rem',
+    fontWeight: 700,
+    color: 'var(--color-text)',
+  },
 
   examCard: {
     display: 'flex',

--- a/packages/shared/src/types/study.types.ts
+++ b/packages/shared/src/types/study.types.ts
@@ -100,19 +100,56 @@ export interface StudyPlanTopicInput {
   subject?: string;
 }
 
+// Reparto de ejercicios POR TEMA: cada tema del plan recibe easy+medium+hard.
+export interface StudyExercisesPerTopic {
+  easy: number;
+  medium: number;
+  hard: number;
+}
+
 export interface CreateStudyPlanRequest {
   courseId: string; // asignatura base
   topics: StudyPlanTopicInput[]; // 1..6
-  numExercises: number; // 1..20
-  difficulty: StudyDifficulty; // aplica a ejercicios y examen
-  numQuestions: 5 | 10; // debe ser >= topics.length (≥1 pregunta por tema)
-  timeLimit?: number; // segundos
-  onlyOnce?: boolean;
+  exercisesPerTopic: StudyExercisesPerTopic; // suma 1..10 (por tema)
 }
 
-// Ejercicio combinado: igual que StudyExercise pero etiquetado con su tema.
+// Ejercicio del plan: etiquetado con su tema y su dificultad.
 export interface StudyPlanExercise extends StudyExercise {
   topicLabel: string;
+  difficulty?: StudyDifficulty; // ausente en ejercicios generados antes del reparto
+}
+
+// ── Exámenes por nivel del plan (generación lazy desde la pestaña Examen) ──
+
+export type StudyPlanExamLevel = 'BASIC' | 'MEDIUM' | 'HARD';
+
+export interface StudyPlanExamInfo {
+  id: string;
+  title: string;
+  level: StudyPlanExamLevel | null; // null = banco anterior a los niveles
+  topicId: string | null; // null = examen combinado de todos los temas
+  numQuestions: number;
+  timeLimit: number | null;
+  onlyOnce: boolean;
+  attemptCount: number;
+  bestScore: number | null; // mejor nota del alumno (0-100); aprobado = ≥50
+}
+
+export interface GenerateStudyPlanExamRequest {
+  level: StudyPlanExamLevel;
+  topicId?: string; // presente = examen de ese tema; ausente = combinado
+  numQuestions?: number; // override del preset del nivel (3..20)
+  difficulty?: StudyDifficulty; // override del preset del nivel
+}
+
+export interface RenameStudyPlanRequest {
+  title: string; // 3..200
+}
+
+export interface RegenerateStudyPlanExercisesRequest {
+  easy?: number;
+  medium?: number;
+  hard?: number;
 }
 
 export interface StudyPlanTopicSummary {
@@ -144,5 +181,8 @@ export interface StudyPlanTopicDetail extends StudyPlanTopicSummary {
 export interface StudyPlanDetail extends Omit<StudyPlanSummary, 'topics'> {
   topics: StudyPlanTopicDetail[];
   exercises: StudyPlanExercise[] | null;
-  exam: StudyExam | null;
+  /// Reparto por tema con el que se generaron los ejercicios (null en planes antiguos).
+  exercisesConfig: StudyExercisesPerTopic | null;
+  /// Exámenes generados (por nivel, combinados o por tema). Vacío hasta que el alumno genere el primero.
+  exams: StudyPlanExamInfo[];
 }


### PR DESCRIPTION
Feedback de uso del curso multi-tema (06/07), parte 2 de 2: generación configurable. **Apilado sobre #58** (mergear ese primero; esta base es `fix/multi-tema-deck-visual`).

## Ejercicios por tema con reparto de dificultad

- La creación configura `exercisesPerTopic { easy, medium, hard }` (default 2/2/1, suma 1-10). Cada tema recibe exactamente ese reparto: con 3 temas y 2/2/1 se generan 15 ejercicios.
- Generación: una llamada IA **por tema** (antes una combinada). `topicLabel` se asigna localmente (ya no se confía a la IA) y la validación exige el conteo exacto por dificultad, con reintento semántico 2x por tema.
- Cada ejercicio persiste su dificultad y la UI muestra chip Fácil/Medio/Difícil.
- El reparto se guarda en `StudyPlan.exercisesConfig` y la regeneración lo reutiliza (u overridea).

## Exámenes por nivel (básico/medio/difícil), lazy

- Crear el curso ya no genera examen (creación más rápida y barata). La pestaña Examen ofrece 3 niveles con presets: básico 5 preguntas fáciles, medio 8 medias, difícil 10 difíciles, con override de nº de preguntas ("Ajustar").
- Modo **"Todos los temas juntos"** o **"Un examen por tema"** (3 niveles × N temas).
- Cada nivel se genera la primera vez que se pulsa "Generar examen" (`POST /study-plans/:id/exams`, idempotente por nivel+tema, throttle 30/h).
- Badge "✓ Aprobado" con la mejor nota (≥50%) y copy: "no te conformes con el básico: el reto es aprobar los 3 niveles". Contador "llevas X de 3".
- Schema: `AiExamBank.studyPlanId` pasa de 1:1 a 1:N + columnas `studyPlanTopicId` y `level` (migración aditiva salvo el drop del unique; los bancos existentes se muestran como "examen original").

## Renombrar cursos (alumno)

- `PATCH /study-plans/:id { title }` con ownership; botón "Renombrar" con edición inline en la página del curso.

## Temario oficial de Matemáticas 3º ESO

- 14 unidades consolidadas de libros reales (Anaya, SM, Santillana, Oxford, Edelvives, Marea Verde) y RD 217/2022, compartidas entre el seed (BDs nuevas) y un script idempotente para PRE/PROD:
  `DATABASE_URL=... npx ts-node prisma/seed-modules-mates-3eso.ts [courseId]`
- **Pendiente tras el merge**: ejecutar el script contra PRE y PROD (necesita el connection string de Neon).
- La numeración "Tema N" del checklist ahora usa la posición en la lista (el campo `order` de BD mezcla 0-based y 1-based).

## Verificación

- API: 559/559 (36 suites; +14 tests nuevos: presets e idempotencia de niveles, rename con ownership, reparto de dificultad, suma 1-10). `tsc --noEmit` limpio. `prisma validate` OK y migración generada con `prisma migrate diff` (paridad por construcción).
- Web: `tsc --noEmit` limpio; vitest 100/101 (fallo preexistente email-validation exento).
- Pendiente tras deploy en PRE: QA del flujo completo con el curso real (crear con 2/2/1, generar los 3 niveles, renombrar).
