### PR TITLE
feat(content): export de cursos entre entornos e import fiel

### DIFF
--- a/.env.scripts.example
+++ b/.env.scripts.example
@@ -1,4 +1,4 @@
-# Credenciales para el script de importación automática (scripts/vkb-import.mjs)
+# Credenciales para los scripts de import/export (scripts/vkb-import.mjs, scripts/vkb-export.mjs)
 # Copia este archivo como .env.scripts y rellena tus datos reales.
 # NUNCA hagas commit de .env.scripts — está en .gitignore.
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ web-build/
 
 # Git worktrees locales (skill superpowers:using-git-worktrees)
 .worktrees/
+
+# Exports de contenido generados por scripts/vkb-export.mjs (snapshot de un entorno)
+data/exports/

--- a/apps/api/src/admin/admin-content.service.import-course.spec.ts
+++ b/apps/api/src/admin/admin-content.service.import-course.spec.ts
@@ -1,0 +1,222 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { AdminContentService } from './admin-content.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { YoutubeService } from '../youtube/youtube.service';
+import { ImportCourseDto } from './dto/import-course.dto';
+
+/**
+ * Tests de importCourse. Cubren la fidelidad del viaje export → import entre
+ * entornos: los metadatos del curso y el tipo real de cada pregunta deben
+ * sobrevivir, y un JSON antiguo sin esos campos debe comportarse como siempre.
+ */
+describe('AdminContentService.importCourse', () => {
+  let service: AdminContentService;
+
+  // Cliente transaccional: cada método devuelve algo con id para poder encadenar
+  let tx: {
+    course: { create: jest.Mock; findUnique: jest.Mock };
+    module: { create: jest.Mock };
+    lesson: { create: jest.Mock };
+    quiz: { create: jest.Mock };
+    question: { createMany: jest.Mock; findMany: jest.Mock };
+    answer: { createMany: jest.Mock };
+    examQuestion: { createMany: jest.Mock; findMany: jest.Mock };
+    examAnswer: { createMany: jest.Mock };
+  };
+
+  let mockPrisma: {
+    schoolYear: { findFirst: jest.Mock };
+    $transaction: jest.Mock;
+  };
+
+  const schoolYear = { id: 'sy-1', name: '1eso', label: '1º ESO' };
+
+  let lastExamQuestionCount = 0;
+
+  // Curso mínimo válido: un módulo con una lección VIDEO
+  const minimalDto = (): ImportCourseDto =>
+    ({
+      name: 'Matemáticas 1º ESO',
+      schoolYear: '1eso',
+      modules: [
+        {
+          title: 'Números naturales',
+          order: 1,
+          lessons: [{ title: 'Intro', type: 'VIDEO', order: 1, youtubeId: 'abc123' }],
+        },
+      ],
+    }) as ImportCourseDto;
+
+  beforeEach(async () => {
+    lastExamQuestionCount = 0;
+
+    tx = {
+      course: {
+        create: jest.fn().mockResolvedValue({ id: 'course-1' }),
+        findUnique: jest.fn().mockResolvedValue({ id: 'course-1', title: 'Matemáticas 1º ESO' }),
+      },
+      module: { create: jest.fn().mockResolvedValue({ id: 'module-1' }) },
+      lesson: { create: jest.fn().mockResolvedValue({ id: 'lesson-1' }) },
+      quiz: { create: jest.fn().mockResolvedValue({ id: 'quiz-1' }) },
+      question: {
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+        findMany: jest.fn().mockResolvedValue([{ id: 'question-1' }]),
+      },
+      answer: { createMany: jest.fn().mockResolvedValue({ count: 0 }) },
+      // findMany devuelve tantas filas como creó el createMany previo: el
+      // servicio las relee para colgarles las respuestas por posición
+      examQuestion: {
+        createMany: jest.fn((args: { data: unknown[] }) => {
+          lastExamQuestionCount = args.data.length;
+          return Promise.resolve({ count: lastExamQuestionCount });
+        }),
+        findMany: jest.fn(() =>
+          Promise.resolve(
+            Array.from({ length: lastExamQuestionCount }, (_, i) => ({ id: `exam-q-${i + 1}` })),
+          ),
+        ),
+      },
+      examAnswer: { createMany: jest.fn().mockResolvedValue({ count: 0 }) },
+    };
+
+    mockPrisma = {
+      schoolYear: { findFirst: jest.fn().mockResolvedValue(schoolYear) },
+      $transaction: jest.fn((cb: (client: typeof tx) => unknown) => cb(tx)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminContentService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: YoutubeService, useValue: { findCandidates: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<AdminContentService>(AdminContentService);
+  });
+
+  it('rechaza un nivel educativo inexistente', async () => {
+    mockPrisma.schoolYear.findFirst.mockResolvedValue(null);
+
+    await expect(service.importCourse(minimalDto())).rejects.toThrow(BadRequestException);
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  describe('metadatos del curso', () => {
+    it('persiste description, coverUrl, subject y published cuando vienen en el JSON', async () => {
+      const dto = {
+        ...minimalDto(),
+        description: 'Curso completo de matemáticas',
+        coverUrl: 'https://cdn.example.com/portada.jpg',
+        subject: 'Matemáticas',
+        published: true,
+      } as ImportCourseDto;
+
+      await service.importCourse(dto);
+
+      expect(tx.course.create).toHaveBeenCalledWith({
+        data: {
+          title: 'Matemáticas 1º ESO',
+          schoolYearId: 'sy-1',
+          description: 'Curso completo de matemáticas',
+          coverUrl: 'https://cdn.example.com/portada.jpg',
+          subject: 'Matemáticas',
+          published: true,
+        },
+      });
+    });
+
+    it('crea el curso despublicado y sin metadatos con un JSON legacy', async () => {
+      await service.importCourse(minimalDto());
+
+      expect(tx.course.create).toHaveBeenCalledWith({
+        data: {
+          title: 'Matemáticas 1º ESO',
+          schoolYearId: 'sy-1',
+          description: null,
+          coverUrl: null,
+          subject: null,
+          published: false,
+        },
+      });
+    });
+  });
+
+  describe('tipo de las preguntas', () => {
+    it('respeta el type de las preguntas de examen del curso', async () => {
+      const dto = {
+        ...minimalDto(),
+        examQuestions: [
+          {
+            text: '¿El cero es natural?',
+            type: 'TRUE_FALSE',
+            answers: [{ text: 'Sí', isCorrect: true }],
+          },
+          { text: 'Marca los primos', type: 'MULTIPLE', answers: [{ text: '7', isCorrect: true }] },
+        ],
+      } as ImportCourseDto;
+
+      await service.importCourse(dto);
+
+      expect(tx.examQuestion.createMany).toHaveBeenCalledWith({
+        data: [
+          expect.objectContaining({ type: 'TRUE_FALSE', order: 1 }),
+          expect.objectContaining({ type: 'MULTIPLE', order: 2 }),
+        ],
+      });
+    });
+
+    it('respeta el type de las preguntas de examen del módulo', async () => {
+      const dto = minimalDto();
+      dto.modules[0].examQuestions = [
+        { text: '¿7 es primo?', type: 'TRUE_FALSE', answers: [{ text: 'Sí', isCorrect: true }] },
+      ] as ImportCourseDto['modules'][0]['examQuestions'];
+
+      await service.importCourse(dto);
+
+      expect(tx.examQuestion.createMany).toHaveBeenCalledWith({
+        data: [expect.objectContaining({ moduleId: 'module-1', type: 'TRUE_FALSE' })],
+      });
+    });
+
+    it('respeta el type de las preguntas de un quiz', async () => {
+      const dto = minimalDto();
+      dto.modules[0].lessons = [
+        {
+          title: 'Test de repaso',
+          type: 'QUIZ',
+          order: 1,
+          quiz: {
+            questions: [
+              {
+                text: 'Marca los pares',
+                type: 'MULTIPLE',
+                answers: [{ text: '2', isCorrect: true }],
+              },
+            ],
+          },
+        },
+      ] as ImportCourseDto['modules'][0]['lessons'];
+
+      await service.importCourse(dto);
+
+      expect(tx.question.createMany).toHaveBeenCalledWith({
+        data: [expect.objectContaining({ type: 'MULTIPLE', order: 1, quizId: 'quiz-1' })],
+      });
+    });
+
+    it('cae a SINGLE cuando la pregunta no trae type', async () => {
+      const dto = {
+        ...minimalDto(),
+        examQuestions: [{ text: '¿Cuánto es 2+2?', answers: [{ text: '4', isCorrect: true }] }],
+      } as ImportCourseDto;
+
+      await service.importCourse(dto);
+
+      expect(tx.examQuestion.createMany).toHaveBeenCalledWith({
+        data: [expect.objectContaining({ type: 'SINGLE' })],
+      });
+    });
+  });
+});

--- a/apps/api/src/admin/admin-content.service.ts
+++ b/apps/api/src/admin/admin-content.service.ts
@@ -352,6 +352,10 @@ export class AdminContentService {
         data: {
           title: dto.name,
           schoolYearId: schoolYear.id,
+          description: dto.description ?? null,
+          coverUrl: dto.coverUrl ?? null,
+          subject: dto.subject ?? null,
+          published: dto.published ?? false,
         },
       });
 
@@ -361,7 +365,7 @@ export class AdminContentService {
           data: dto.examQuestions.map((q, i) => ({
             courseId: newCourse.id,
             text: q.text,
-            type: QuestionType.SINGLE,
+            type: q.type ?? QuestionType.SINGLE,
             order: i + 1,
           })),
         });
@@ -401,7 +405,7 @@ export class AdminContentService {
             data: modDto.examQuestions.map((q, i) => ({
               moduleId: newModule.id,
               text: q.text,
-              type: QuestionType.SINGLE,
+              type: q.type ?? QuestionType.SINGLE,
               order: i + 1,
             })),
           });
@@ -447,7 +451,7 @@ export class AdminContentService {
             await tx.question.createMany({
               data: lesDto.quiz.questions.map((qDto, qi) => ({
                 text: qDto.text,
-                type: QuestionType.SINGLE,
+                type: qDto.type ?? QuestionType.SINGLE,
                 order: qi + 1,
                 quizId: newQuiz.id,
               })),

--- a/apps/api/src/admin/dto/import-course.dto.ts
+++ b/apps/api/src/admin/dto/import-course.dto.ts
@@ -11,12 +11,13 @@ import {
   IsObject,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { LessonType } from '@prisma/client';
+import { LessonType, QuestionType } from '@prisma/client';
 
 // ── Respuestas de quiz / examen ──────────────────────────────────────────────
 
 export class ImportAnswerDto {
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   text: string;
 
   @IsBoolean()
@@ -26,8 +27,14 @@ export class ImportAnswerDto {
 // ── Preguntas de quiz (dentro de una lección QUIZ) ───────────────────────────
 
 export class ImportQuizQuestionDto {
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   text: string;
+
+  // Si no viene, se asume SINGLE (comportamiento histórico del import)
+  @IsOptional()
+  @IsEnum(QuestionType)
+  type?: QuestionType;
 
   @IsArray()
   @ValidateNested({ each: true })
@@ -45,8 +52,14 @@ export class ImportQuizDto {
 // ── Preguntas del banco de examen (por módulo) ───────────────────────────────
 
 export class ImportExamQuestionDto {
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   text: string;
+
+  // Si no viene, se asume SINGLE (comportamiento histórico del import)
+  @IsOptional()
+  @IsEnum(QuestionType)
+  type?: QuestionType;
 
   @IsArray()
   @ValidateNested({ each: true })
@@ -57,20 +70,24 @@ export class ImportExamQuestionDto {
 // ── Lección ──────────────────────────────────────────────────────────────────
 
 export class ImportLessonDto {
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   title: string;
 
   @IsEnum(LessonType)
   type: LessonType;
 
-  @IsInt() @Min(1)
+  @IsInt()
+  @Min(1)
   order: number;
 
-  @IsOptional() @IsString()
+  @IsOptional()
+  @IsString()
   youtubeId?: string;
 
   // Contenido para MATCH, SORT, FILL_BLANK (objeto libre)
-  @IsOptional() @IsObject()
+  @IsOptional()
+  @IsObject()
   content?: Record<string, unknown>;
 
   // Solo si type === QUIZ
@@ -83,10 +100,12 @@ export class ImportLessonDto {
 // ── Módulo ───────────────────────────────────────────────────────────────────
 
 export class ImportModuleDto {
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   title: string;
 
-  @IsInt() @Min(1)
+  @IsInt()
+  @Min(1)
   order: number;
 
   @IsArray()
@@ -105,12 +124,32 @@ export class ImportModuleDto {
 // ── Curso raíz ───────────────────────────────────────────────────────────────
 
 export class ImportCourseDto {
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   name: string;
 
   // Nombre del nivel: "1eso", "2eso", etc.
-  @IsString() @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   schoolYear: string;
+
+  // Metadatos del curso. Opcionales: un JSON antiguo sin ellos se importa igual que antes.
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  coverUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  subject?: string;
+
+  // Si no viene, el curso se crea despublicado
+  @IsOptional()
+  @IsBoolean()
+  published?: boolean;
 
   @IsArray()
   @ValidateNested({ each: true })

--- a/docs/superpowers/specs/2026-08-09-course-export-import-design.md
+++ b/docs/superpowers/specs/2026-08-09-course-export-import-design.md
@@ -1,0 +1,201 @@
+# Export de cursos PRE → JSON → import en PROD
+
+**Fecha:** 2026-08-09
+**Estado:** aprobado, pendiente de implementar
+
+---
+
+## 1. Problema
+
+PRE y PROD tienen bases de datos Neon separadas. El pipeline (`.github/workflows/deploy-pipeline.yml`)
+promociona **código** (Render/Vercel) y **esquema** (`prisma migrate deploy`, líneas 116 y 282), pero
+nunca datos. Los cursos son filas de `Course`/`Module`/`Lesson`/`Quiz`/`ExamQuestion`, así que un curso
+creado en PRE —desde el panel admin, el generador IA o `scripts/vkb-import.mjs`— vive solo en PRE.
+
+En `data/imports/courses/` solo hay 2 JSON versionados, mucho menos que los cursos existentes en PRE:
+para el resto no hay fichero de origen del que tirar.
+
+Hace falta un camino explícito PRE → JSON → PROD.
+
+## 2. Objetivo y alcance
+
+**Dentro:**
+
+- Exportar todos los cursos de un entorno a un único JSON.
+- Reimportar ese JSON en otro entorno preservando el contenido educativo íntegro.
+- Evitar duplicados accidentales al importar en producción.
+
+**Fuera (no objetivo):**
+
+- Sincronización automática o continua entre entornos. La promoción es manual y deliberada.
+- Migrar progreso de alumnos, matrículas, intentos de examen o certificados. Solo contenido de curso.
+- Upsert real de cursos existentes (actualizar en sitio). Ver §8.
+
+## 3. Formato del fichero
+
+Un envoltorio con metadatos y un array de cursos. Cada elemento de `courses` es **exactamente** un
+`ImportCourseDto` (ampliado según §4), de modo que el fichero es a la vez el formato de export y el de
+import.
+
+```jsonc
+{
+  "version": 1,
+  "exportedFrom": "https://<api-pre>/api",
+  "exportedAt": "2026-08-09T10:22:31.004Z",
+  "courses": [
+    {
+      "name": "Matemáticas 1º ESO",
+      "schoolYear": "1eso",
+      "description": "...",
+      "coverUrl": "...",
+      "subject": "Matemáticas",
+      "published": true,
+      "modules": [
+        {
+          "title": "Números naturales y operaciones",
+          "order": 1,
+          "lessons": [
+            { "title": "...", "type": "VIDEO", "order": 1, "youtubeId": "..." },
+            { "title": "...", "type": "QUIZ", "order": 2,
+              "quiz": { "questions": [ { "text": "...", "type": "SINGLE",
+                                         "answers": [ { "text": "...", "isCorrect": true } ] } ] } },
+            { "title": "...", "type": "MATCH", "order": 3, "content": { "pairs": [] } }
+          ],
+          "examQuestions": [ { "text": "...", "type": "SINGLE", "answers": [] } ]
+        }
+      ],
+      "examQuestions": [ { "text": "...", "type": "TRUE_FALSE", "answers": [] } ]
+    }
+  ]
+}
+```
+
+El import sigue aceptando **también** un curso suelto en la raíz: los dos ficheros existentes de
+`data/imports/courses/` no se tocan. El script distingue por la presencia de `courses[]`.
+
+`schoolYear` viaja como **nombre** (`"1eso"`), no como id, porque los ids de `SchoolYear` difieren entre
+bases de datos. `importCourse` ya lo resuelve por nombre (`admin-content.service.ts`).
+
+## 4. Cambios en la API
+
+Aditivos y retrocompatibles: todos los campos nuevos son opcionales y su ausencia reproduce el
+comportamiento actual.
+
+### 4.1 `apps/api/src/admin/dto/import-course.dto.ts`
+
+| Clase | Campos nuevos |
+| --- | --- |
+| `ImportCourseDto` | `description?: string`, `coverUrl?: string`, `subject?: string` (`@IsOptional() @IsString()`), `published?: boolean` (`@IsOptional() @IsBoolean()`) |
+| `ImportQuizQuestionDto` | `type?: QuestionType` (`@IsOptional() @IsEnum(QuestionType)`) |
+| `ImportExamQuestionDto` | `type?: QuestionType` (`@IsOptional() @IsEnum(QuestionType)`) |
+
+### 4.2 `apps/api/src/admin/admin-content.service.ts` → `importCourse`
+
+- El `course.create` pasa a incluir `description`, `coverUrl`, `subject` y
+  `published: dto.published ?? false`. Hoy solo escribe `title` y `schoolYearId`, de ahí que todo curso
+  importado llegue despublicado y sin metadatos.
+- Las tres construcciones de preguntas usan `type: q.type ?? QuestionType.SINGLE` en lugar de `SINGLE`
+  fijo: preguntas de examen de curso, de módulo y de quiz. Sin esto, las preguntas `MULTIPLE` y
+  `TRUE_FALSE` se degradan silenciosamente al importar.
+
+No se añade ningún endpoint. El bulk lo resuelve el script iterando sobre
+`POST /admin/courses/import`, que ya es transaccional por curso.
+
+**Consecuencia operativa:** la API de PROD debe estar desplegada con estos cambios *antes* de importar
+allí; si no, el `ValidationPipe` rechazará los campos nuevos.
+
+## 5. Scripts
+
+### 5.1 `scripts/lib/vkb-api.mjs` (nuevo)
+
+Módulo compartido que extrae de `vkb-import.mjs` lo que ambos scripts necesitan:
+
+- `loadEnv()` — lee y parsea `.env.scripts` (sin dependencia de dotenv, como hoy).
+- `login(apiUrl, email, password)` — devuelve el `accessToken`.
+- `api(path, opts)` — fetch autenticado que lanza si la respuesta no es OK.
+
+Evita duplicar ~40 líneas entre export e import.
+
+### 5.2 `scripts/vkb-export.mjs` (nuevo)
+
+```
+node scripts/vkb-export.mjs courses [--out=ruta.json] [--only=id1,id2]
+```
+
+1. Login contra `VKB_API_URL` de `.env.scripts`.
+2. Pagina `GET /admin/courses` hasta agotar el total.
+3. Por cada curso: `GET /admin/courses/:id/detail` (devuelve módulos, lecciones, quiz, preguntas y
+   respuestas **con `isCorrect`** — es ruta admin) más `GET /admin/exam-questions?courseId=` y un
+   `?moduleId=` por módulo.
+4. Mapea el resultado a la forma de `ImportCourseDto` y escribe el fichero.
+
+Salida por defecto: `data/exports/courses-<YYYYMMDD>.json`.
+
+Solo hace lecturas: es seguro ejecutarlo contra PRE o PROD.
+
+### 5.3 `scripts/vkb-import.mjs` (modificado)
+
+- Acepta payload bulk (`{ courses: [...] }`) además del curso suelto actual.
+- **Pre-chequeo de duplicados:** por cada curso, `GET /admin/courses?search=<title>` y compara `title`
+  exacto + `schoolYear.name`. Si ya existe, lo salta con aviso y continúa con el resto. `--force` lo
+  importa igualmente.
+- **`--publish-all`:** publica en destino todos los cursos del fichero. Ver §5.4.
+- Resumen final: importados / saltados / fallidos, con el id de cada curso creado. Un curso que falle
+  no aborta los demás. Si no se importa nada porque estaba todo duplicado, sale con código 1: quien
+  invoca el script (una persona o el agente `course-creator`, que hace `grep "^IMPORT_ID="`) espera un
+  curso nuevo.
+
+### 5.4 Publicación: por qué es un flag y no un dato del JSON
+
+"Estudiar" (`StudyPage.tsx`) puebla su desplegable de asignaturas con `GET /courses`, que para un
+STUDENT filtra por `published: true` y por su nivel (`courses.service.ts:32`). El tema es texto libre
+(`StudyPage.tsx`): los módulos no intervienen. Es decir, **para que un curso exista de cara al
+alumno basta con que esté publicado y sea de su nivel** — el contenido lo genera "Estudiar" bajo
+demanda.
+
+En el origen (PRE) casi todo el catálogo está despublicado, así que un import fiel dejaría el destino
+invisible. La publicación se resuelve con `--publish-all` en el import, no reescribiendo el JSON, por
+dos motivos:
+
+- El fichero de export sigue siendo una foto fiel del origen y se puede volver a comparar contra él.
+- Publicar 100 cursos en producción es una decisión deliberada; que aparezca en el comando la deja
+  registrada en el historial de la terminal, no enterrada en un diff de datos.
+
+## 6. Flujo de uso
+
+```bash
+# 1. Exportar de PRE (.env.scripts apuntando a PRE)
+node scripts/vkb-export.mjs courses --out=data/exports/courses-pre.json
+
+# 2. Ensayo contra local
+docker compose up -d
+# .env.scripts apuntando a localhost
+node scripts/vkb-import.mjs courses data/exports/courses-pre.json
+
+# 3. Desplegar la API con los cambios de §4 a PROD
+
+# 4. Importar en PROD (.env.scripts apuntando a PROD)
+node scripts/vkb-import.mjs courses data/exports/courses-pre.json --publish-all
+```
+
+## 7. Verificación
+
+- Tests unitarios nuevos para `importCourse`, que hoy no tiene ninguno: persistencia de los campos
+  nuevos, respeto del `type` real de las preguntas y retrocompatibilidad de un DTO legacy
+  (sin campos nuevos → `published: false`, `type: SINGLE`).
+- `pnpm --filter @vkbacademy/api test` en verde.
+- Round-trip real: export de PRE (solo lectura) → import contra local, comparando módulos, lecciones y
+  número de preguntas. PROD no se toca hasta que el ensayo local pase.
+- Los scripts son Node plano sin suite propia; se validan con la ejecución real.
+
+## 8. Decisiones y descartes
+
+| Decisión | Motivo |
+| --- | --- |
+| Un único JSON con array en vez de un fichero por curso | Un solo artefacto que mover entre entornos y revisar en un PR. |
+| Bulk en el script, no endpoint nuevo | `POST /admin/courses/import` ya es transaccional por curso; un endpoint bulk añadiría superficie de API sin ganancia real. |
+| Anti-duplicados en el script, no upsert en el endpoint | El upsert obliga a decidir qué pasa con módulos y lecciones huérfanos y con el progreso de los alumnos que ya cursan el curso. Fuera de alcance. |
+| `schoolYear` por nombre, no por id | Los ids de `SchoolYear` no coinciden entre bases de datos. |
+| Publicar con `--publish-all`, no editando el JSON | El export se mantiene como foto fiel del origen y la decisión queda explícita en el comando. Ver §5.4. |
+| Exportar los módulos aunque "Estudiar" no los use | Los consume la vista clásica de curso y no cuestan nada en el fichero. |
+| No exportar matrículas ni progreso | Son datos por entorno, no contenido promocionable. |

--- a/scripts/lib/vkb-api.mjs
+++ b/scripts/lib/vkb-api.mjs
@@ -1,0 +1,130 @@
+/**
+ * Utilidades compartidas por scripts/vkb-import.mjs y scripts/vkb-export.mjs:
+ * lectura de credenciales, login y cliente HTTP autenticado.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Lee .env.scripts del directorio de trabajo y devuelve { apiUrl, email, password }.
+ * Aborta el proceso si falta el fichero o alguna credencial.
+ */
+export function loadEnv() {
+  const envPath = resolve(process.cwd(), '.env.scripts');
+  if (!existsSync(envPath)) {
+    console.error(
+      '❌  No se encontró .env.scripts. Copia .env.scripts.example y rellena tus credenciales.',
+    );
+    process.exit(1);
+  }
+
+  const envVars = Object.fromEntries(
+    readFileSync(envPath, 'utf8')
+      .split('\n')
+      .filter((l) => l.trim() && !l.startsWith('#'))
+      .map((l) => l.split('=').map((s) => s.trim()))
+      .filter(([k]) => k)
+      .map(([k, ...v]) => [k, v.join('=').replace(/^["']|["']$/g, '')]),
+  );
+
+  const apiUrl = envVars.VKB_API_URL || 'http://localhost:3001/api';
+  const email = envVars.VKB_ADMIN_EMAIL;
+  const password = envVars.VKB_ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    console.error('❌  Faltan VKB_ADMIN_EMAIL o VKB_ADMIN_PASSWORD en .env.scripts.');
+    process.exit(1);
+  }
+
+  return { apiUrl, email, password };
+}
+
+/**
+ * Inicia sesión y devuelve un cliente ligado al token.
+ * Aborta el proceso si el login falla.
+ */
+export async function login({ apiUrl, email, password }) {
+  console.log(`🔐  Iniciando sesión como ${email} en ${apiUrl} ...`);
+
+  // El endpoint acepta email o username en un único campo `identifier`
+  const res = await fetch(`${apiUrl}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier: email, password }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    console.error('❌  Login fallido:', err.message ?? res.statusText);
+    process.exit(1);
+  }
+
+  const { accessToken } = await res.json();
+  console.log('✅  Login correcto.');
+
+  return createClient(apiUrl, accessToken);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Cliente HTTP autenticado. `get` lanza si la respuesta no es OK;
+ * `post` devuelve { ok, status, body } para que quien llama decida.
+ *
+ * La API limita a 100 peticiones por minuto (ThrottlerModule), así que el
+ * cliente espacia las llamadas y reintenta con espera creciente ante un 429.
+ */
+function createClient(apiUrl, accessToken, { minIntervalMs = 700, maxRetries = 5 } = {}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  let nextSlot = 0;
+
+  /** Espacia las peticiones para no agotar la ventana del throttler. */
+  async function pace() {
+    const now = Date.now();
+    const wait = Math.max(0, nextSlot - now);
+    nextSlot = Math.max(now, nextSlot) + minIntervalMs;
+    if (wait > 0) await sleep(wait);
+  }
+
+  /** Ejecuta la petición reintentando mientras la API devuelva 429. */
+  async function request(path, init) {
+    for (let attempt = 0; ; attempt++) {
+      await pace();
+      const res = await fetch(`${apiUrl}${path}`, { ...init, headers });
+
+      if (res.status !== 429 || attempt >= maxRetries) return res;
+
+      // Respetamos Retry-After si viene; si no, esperamos la ventana entera
+      const retryAfter = Number(res.headers.get('retry-after'));
+      const waitMs = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 60_000;
+      console.warn(
+        `⏳  429 en ${path} — esperando ${Math.round(waitMs / 1000)}s (intento ${attempt + 1}/${maxRetries})`,
+      );
+      await sleep(waitMs);
+    }
+  }
+
+  return {
+    apiUrl,
+
+    async get(path) {
+      const res = await request(path, {});
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(`GET ${path} → ${res.status}: ${err.message ?? res.statusText}`);
+      }
+      return res.json();
+    },
+
+    async post(path, payload) {
+      const res = await request(path, { method: 'POST', body: JSON.stringify(payload) });
+      const body = await res.json().catch(() => ({ message: res.statusText }));
+      return { ok: res.ok, status: res.status, body };
+    },
+  };
+}

--- a/scripts/vkb-export.mjs
+++ b/scripts/vkb-export.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Exporta los cursos de un entorno de VKB Academy a un único JSON, en el mismo
+ * formato que acepta scripts/vkb-import.mjs. Sirve para promocionar contenido
+ * entre entornos (PRE → PROD), que tienen bases de datos separadas.
+ *
+ * Uso:
+ *   node scripts/vkb-export.mjs courses [--out=ruta.json] [--only=id1,id2]
+ *
+ * Solo hace lecturas: es seguro ejecutarlo contra cualquier entorno.
+ * Credenciales leídas de .env.scripts (ver .env.scripts.example).
+ */
+
+import { writeFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { loadEnv, login } from './lib/vkb-api.mjs';
+
+// ── Argumentos ────────────────────────────────────────────────────────────────
+const [, , type, ...flags] = process.argv;
+
+if (type !== 'courses') {
+  console.error('Uso: node scripts/vkb-export.mjs courses [--out=ruta.json] [--only=id1,id2]');
+  process.exit(1);
+}
+
+const outFlag = flags.find((f) => f.startsWith('--out='))?.split('=')[1];
+const onlyIds = flags
+  .find((f) => f.startsWith('--only='))
+  ?.split('=')[1]
+  ?.split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+const outPath = resolve(process.cwd(), outFlag ?? `data/exports/courses-${today}.json`);
+
+// ── Mapeadores al formato de import ───────────────────────────────────────────
+
+const mapAnswers = (answers = []) => answers.map((a) => ({ text: a.text, isCorrect: a.isCorrect }));
+
+const mapExamQuestions = (questions = []) =>
+  questions.map((q) => ({ text: q.text, type: q.type, answers: mapAnswers(q.answers) }));
+
+function mapLesson(lesson) {
+  const mapped = { title: lesson.title, type: lesson.type, order: lesson.order };
+
+  if (lesson.youtubeId) mapped.youtubeId = lesson.youtubeId;
+  if (lesson.content) mapped.content = lesson.content;
+
+  // El quiz solo viaja si tiene preguntas; el import lo ignora en otro caso
+  if (lesson.quiz?.questions?.length) {
+    mapped.quiz = {
+      questions: lesson.quiz.questions.map((q) => ({
+        text: q.text,
+        type: q.type,
+        answers: mapAnswers(q.answers),
+      })),
+    };
+  }
+
+  return mapped;
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+const env = loadEnv();
+const client = await login(env);
+
+// 1. Listado paginado de cursos
+const summaries = [];
+let page = 1;
+let totalPages = 1;
+
+do {
+  const res = await client.get(`/admin/courses?page=${page}&limit=50`);
+  summaries.push(...res.data);
+  totalPages = res.totalPages || 1;
+  page++;
+} while (page <= totalPages);
+
+const selected = onlyIds ? summaries.filter((c) => onlyIds.includes(c.id)) : summaries;
+
+if (onlyIds) {
+  const missing = onlyIds.filter((id) => !summaries.some((c) => c.id === id));
+  if (missing.length) {
+    console.error(`❌  Ids no encontrados en este entorno: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+console.log(`📚  ${selected.length} curso(s) a exportar de ${summaries.length} disponibles.`);
+
+// 2. Banco de examen completo en una sola petición y agrupado en cliente.
+// Pedirlo por curso y por módulo dispararía ~1 petición por módulo y agotaría
+// el throttler de la API (100 req/min).
+const allExamQuestions = await client.get('/admin/exam-questions');
+
+const examByCourse = new Map();
+const examByModule = new Map();
+for (const q of allExamQuestions) {
+  const target = q.courseId ? examByCourse : q.moduleId ? examByModule : null;
+  if (!target) continue;
+  const key = q.courseId ?? q.moduleId;
+  if (!target.has(key)) target.set(key, []);
+  target.get(key).push(q);
+}
+
+// Las preguntas llegan ordenadas por `order`, pero el agrupado no lo garantiza
+const byOrder = (a, b) => (a.order ?? 0) - (b.order ?? 0);
+
+console.log(`📝  ${allExamQuestions.length} pregunta(s) de examen en el banco.`);
+
+// 3. Detalle de cada curso
+const courses = [];
+const skipped = [];
+
+for (const summary of selected) {
+  const detail = await client.get(`/admin/courses/${summary.id}/detail`);
+
+  // El import resuelve el nivel por nombre; sin él, el curso no es importable
+  if (!detail.schoolYear?.name) {
+    skipped.push(detail.title);
+    console.warn(`⚠️   "${detail.title}" no tiene nivel educativo asignado — se omite.`);
+    continue;
+  }
+
+  const courseExamQuestions = (examByCourse.get(detail.id) ?? []).sort(byOrder);
+
+  const modules = [];
+  for (const mod of detail.modules) {
+    const moduleExamQuestions = (examByModule.get(mod.id) ?? []).sort(byOrder);
+
+    const mapped = {
+      title: mod.title,
+      order: mod.order,
+      lessons: mod.lessons.map(mapLesson),
+    };
+    if (moduleExamQuestions.length) {
+      mapped.examQuestions = mapExamQuestions(moduleExamQuestions);
+    }
+
+    modules.push(mapped);
+  }
+
+  const course = {
+    name: detail.title,
+    schoolYear: detail.schoolYear.name,
+    modules,
+  };
+
+  if (detail.description) course.description = detail.description;
+  if (detail.coverUrl) course.coverUrl = detail.coverUrl;
+  if (detail.subject) course.subject = detail.subject;
+  course.published = detail.published;
+
+  if (courseExamQuestions.length) {
+    course.examQuestions = mapExamQuestions(courseExamQuestions);
+  }
+
+  courses.push(course);
+
+  const lessonCount = modules.reduce((n, m) => n + m.lessons.length, 0);
+  console.log(
+    `   ✓ ${detail.title} — ${modules.length} módulo(s), ${lessonCount} lección(es)` +
+      `${detail.published ? '' : ' (sin publicar)'}`,
+  );
+}
+
+// 4. Escribir el fichero
+const payload = {
+  version: 1,
+  exportedFrom: env.apiUrl,
+  exportedAt: new Date().toISOString(),
+  courses,
+};
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+
+console.log(`\n✅  ${courses.length} curso(s) exportados a ${outPath}`);
+if (skipped.length) {
+  console.log(`⚠️   ${skipped.length} omitido(s) por no tener nivel: ${skipped.join(', ')}`);
+}

--- a/scripts/vkb-import.mjs
+++ b/scripts/vkb-import.mjs
@@ -1,68 +1,40 @@
 #!/usr/bin/env node
 /**
- * Importa un JSON de curso o batería de examen en VKB Academy.
+ * Importa cursos o baterías de examen en VKB Academy.
  *
  * Uso:
- *   node scripts/vkb-import.mjs courses path/to/curso.json
+ *   node scripts/vkb-import.mjs courses path/to/curso.json [--force] [--publish-all]
  *   node scripts/vkb-import.mjs exam-banks path/to/bateria.json [--courseId=xxx | --moduleId=xxx]
+ *
+ * Para cursos acepta tanto un curso suelto en la raíz del JSON como un fichero
+ * de export con { courses: [...] } (ver scripts/vkb-export.mjs). Antes de crear
+ * cada curso comprueba que no exista ya uno con el mismo título y nivel en el
+ * entorno destino; --force salta esa comprobación.
+ *
+ * --publish-all publica todos los cursos del fichero en el destino, sin tocar el
+ * JSON: "Estudiar" solo ofrece al alumno cursos con published = true y de su nivel.
  *
  * Credenciales leídas de .env.scripts (ver .env.scripts.example)
  */
 
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
-
-// ── Leer .env.scripts manualmente (sin dependencia de dotenv) ─────────────────
-const envPath = resolve(process.cwd(), '.env.scripts');
-if (!existsSync(envPath)) {
-  console.error('❌  No se encontró .env.scripts. Copia .env.scripts.example y rellena tus credenciales.');
-  process.exit(1);
-}
-const envVars = Object.fromEntries(
-  readFileSync(envPath, 'utf8')
-    .split('\n')
-    .filter(l => l.trim() && !l.startsWith('#'))
-    .map(l => l.split('=').map(s => s.trim()))
-    .filter(([k]) => k)
-    .map(([k, ...v]) => [k, v.join('=').replace(/^["']|["']$/g, '')])
-);
-
-const API_URL    = envVars.VKB_API_URL    || 'http://localhost:3001/api';
-const ADMIN_EMAIL    = envVars.VKB_ADMIN_EMAIL;
-const ADMIN_PASSWORD = envVars.VKB_ADMIN_PASSWORD;
-
-if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
-  console.error('❌  Faltan VKB_ADMIN_EMAIL o VKB_ADMIN_PASSWORD en .env.scripts.');
-  process.exit(1);
-}
+import { loadEnv, login } from './lib/vkb-api.mjs';
 
 // ── Argumentos ────────────────────────────────────────────────────────────────
-const [,, type, filePath, ...flags] = process.argv;
+const [, , type, filePath, ...flags] = process.argv;
 
 if (!type || !filePath) {
-  console.error('Uso: node scripts/vkb-import.mjs <courses|exam-banks> <archivo.json> [--courseId=xxx | --moduleId=xxx]');
+  console.error(
+    'Uso: node scripts/vkb-import.mjs <courses|exam-banks> <archivo.json> [--courseId=xxx | --moduleId=xxx] [--force] [--publish-all]',
+  );
   process.exit(1);
 }
 
-const courseId = flags.find(f => f.startsWith('--courseId='))?.split('=')[1];
-const moduleId = flags.find(f => f.startsWith('--moduleId='))?.split('=')[1];
-
-// ── Login ─────────────────────────────────────────────────────────────────────
-console.log(`🔐  Iniciando sesión como ${ADMIN_EMAIL}...`);
-const loginRes = await fetch(`${API_URL}/auth/login`, {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
-});
-
-if (!loginRes.ok) {
-  const err = await loginRes.json().catch(() => ({}));
-  console.error('❌  Login fallido:', err.message ?? loginRes.statusText);
-  process.exit(1);
-}
-
-const { accessToken } = await loginRes.json();
-console.log('✅  Login correcto.');
+const courseId = flags.find((f) => f.startsWith('--courseId='))?.split('=')[1];
+const moduleId = flags.find((f) => f.startsWith('--moduleId='))?.split('=')[1];
+const force = flags.includes('--force');
+const publishAll = flags.includes('--publish-all');
 
 // ── Leer JSON ─────────────────────────────────────────────────────────────────
 const absPath = resolve(process.cwd(), filePath);
@@ -71,40 +43,116 @@ if (!existsSync(absPath)) {
   process.exit(1);
 }
 
-let payload = JSON.parse(readFileSync(absPath, 'utf8'));
+const parsed = JSON.parse(readFileSync(absPath, 'utf8'));
 
-// Para baterías de examen, inyectar courseId/moduleId en el payload
+// ── Login ─────────────────────────────────────────────────────────────────────
+const env = loadEnv();
+const client = await login(env);
+
+// ── Baterías de examen: un único POST, como siempre ──────────────────────────
 if (type === 'exam-banks') {
   if (!courseId && !moduleId) {
-    console.error('❌  Para importar una batería de examen necesitas pasar --courseId=xxx o --moduleId=xxx.');
+    console.error(
+      '❌  Para importar una batería de examen necesitas pasar --courseId=xxx o --moduleId=xxx.',
+    );
     process.exit(1);
   }
-  payload = { ...payload, ...(courseId ? { courseId } : { moduleId }) };
+
+  const payload = { ...parsed, ...(courseId ? { courseId } : { moduleId }) };
+
+  console.log(`📤  Importando ${filePath} → ${env.apiUrl}/admin/exam-questions/import ...`);
+  const { ok, status, body } = await client.post('/admin/exam-questions/import', payload);
+
+  if (!ok) {
+    console.error(`❌  Error ${status}:`, body.message ?? body);
+    process.exit(1);
+  }
+
+  console.log('✅  Importación completada:');
+  console.log(JSON.stringify(body, null, 2));
+  if (body.count != null) console.log(`IMPORT_COUNT=${body.count}`);
+  process.exit(0);
 }
 
-// ── Importar ──────────────────────────────────────────────────────────────────
-const endpoint = type === 'courses' ? '/admin/courses/import' : '/admin/exam-questions/import';
-console.log(`📤  Importando ${filePath} → ${API_URL}${endpoint} ...`);
-
-const importRes = await fetch(`${API_URL}${endpoint}`, {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${accessToken}`,
-  },
-  body: JSON.stringify(payload),
-});
-
-const result = await importRes.json().catch(() => ({ message: importRes.statusText }));
-
-if (!importRes.ok) {
-  console.error(`❌  Error ${importRes.status}:`, result.message ?? result);
+if (type !== 'courses') {
+  console.error(`❌  Tipo desconocido "${type}". Valores válidos: courses, exam-banks.`);
   process.exit(1);
 }
 
-console.log('✅  Importación completada:');
-console.log(JSON.stringify(result, null, 2));
+// ── Cursos: un curso suelto o un fichero de export con courses[] ─────────────
+const courses = Array.isArray(parsed.courses) ? parsed.courses : [parsed];
 
-// Línea machine-readable para que los agentes puedan extraer el ID fácilmente
-if (result.course?.id)  console.log(`IMPORT_ID=${result.course.id}`);
-if (result.count != null) console.log(`IMPORT_COUNT=${result.count}`);
+if (!courses.length) {
+  console.error('❌  El fichero no contiene ningún curso.');
+  process.exit(1);
+}
+
+if (parsed.exportedFrom) {
+  console.log(`📦  Export de ${parsed.exportedFrom} (${parsed.exportedAt ?? 'sin fecha'})`);
+}
+console.log(`📚  ${courses.length} curso(s) a importar en ${env.apiUrl}`);
+
+if (publishAll) {
+  const yaPublicados = courses.filter((c) => c.published).length;
+  console.log(
+    `📢  --publish-all: se publicarán los ${courses.length} (${yaPublicados} ya venían publicados del origen).`,
+  );
+}
+console.log();
+
+/** Busca un curso ya existente con el mismo título y nivel en el destino. */
+async function findExisting(course) {
+  const res = await client.get(`/admin/courses?search=${encodeURIComponent(course.name)}&limit=50`);
+  return res.data.find((c) => c.title === course.name && c.schoolYear?.name === course.schoolYear);
+}
+
+const imported = [];
+const skippedCourses = [];
+const failed = [];
+
+for (const course of courses) {
+  if (!force) {
+    const existing = await findExisting(course);
+    if (existing) {
+      skippedCourses.push(course.name);
+      console.log(
+        `⏭️   "${course.name}" ya existe (${existing.id}) — omitido. Usa --force para importarlo igualmente.`,
+      );
+      continue;
+    }
+  }
+
+  // El export refleja el `published` del origen; --publish-all lo fuerza en destino
+  const payload = publishAll ? { ...course, published: true } : course;
+
+  const { ok, status, body } = await client.post('/admin/courses/import', payload);
+
+  if (!ok) {
+    failed.push({ name: course.name, status, message: body.message ?? body });
+    console.error(`❌  "${course.name}" → error ${status}:`, body.message ?? body);
+    continue;
+  }
+
+  imported.push({ name: course.name, id: body.course?.id });
+  console.log(`✅  "${course.name}" importado (${body.course?.id}).`);
+  // Línea machine-readable para que los agentes puedan extraer el ID fácilmente
+  if (body.course?.id) console.log(`IMPORT_ID=${body.course.id}`);
+}
+
+// ── Resumen ───────────────────────────────────────────────────────────────────
+console.log(
+  `\n📊  Importados: ${imported.length} | Omitidos: ${skippedCourses.length} | Fallidos: ${failed.length}`,
+);
+
+if (failed.length) {
+  console.error('\n❌  Cursos que fallaron:');
+  for (const f of failed) console.error(`   · ${f.name} (${f.status}): ${f.message}`);
+  process.exit(1);
+}
+
+// Si no se importó nada porque estaba todo duplicado, es un fallo: quien invoca
+// el script (una persona o el agente course-creator) espera un curso nuevo.
+if (!imported.length && skippedCourses.length) {
+  console.error('\n❌  No se importó ningún curso: ya existían todos en el destino.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Por qué

PRE y PROD tienen bases de datos Neon separadas. El pipeline promociona **código** y **esquema** (`prisma migrate deploy`), nunca datos. Los cursos son filas, así que todo lo creado en PRE se queda en PRE y no había camino para llevarlo a producción.

Investigándolo aparecieron tres cosas rotas de forma independiente:

1. El login de los scripts enviaba `email`, pero el endpoint pasó a `identifier` en el rediseño de credenciales. `vkb-import.mjs` llevaba roto desde entonces.
2. `importCourse` creaba **todo** con `published: false`, sin forma de cambiarlo. Un curso importado no podía aparecerle nunca a un alumno.
3. Pedir el banco de examen módulo a módulo dispara ~1.470 peticiones y agota el throttler (100 req/min).

## Qué incluye

**`scripts/vkb-export.mjs`** (nuevo) — vuelca los cursos de un entorno a un JSON con el mismo formato que acepta el import. Solo lecturas, seguro contra cualquier entorno. Pide el banco de examen entero en una llamada y agrupa en cliente.

**`scripts/lib/vkb-api.mjs`** (nuevo) — `.env.scripts`, login y cliente HTTP compartidos por export e import. Espacia las peticiones y reintenta ante un 429.

**`scripts/vkb-import.mjs`** — acepta ficheros con `courses[]`; comprueba título + nivel en destino antes de crear (`--force` lo salta); `--publish-all` publica en destino sin falsear el JSON de origen.

**Fidelidad del import** — `ImportCourseDto` acepta `description`, `coverUrl`, `subject`, `published` y el `type` real de cada pregunta. Todo opcional: un JSON antiguo se comporta exactamente igual que antes.

## Verificación

- **548/548 tests** en verde, incluidos **7 nuevos** para `importCourse`, que no tenía ninguno.
- `tsc --noEmit` limpio.
- Round-trip completo contra un servidor simulado: se preservan `MULTIPLE`/`TRUE_FALSE`, el `content` de MATCH, metadatos y bancos de examen de curso y módulo; los duplicados se saltan; `--force` y `--publish-all` hacen lo que dicen.
- **Ejecutado de verdad contra PRE**: 105 cursos exportados, y los 105 validan contra el `ImportCourseDto` real con `whitelist: true, forbidNonWhitelisted: true` — la misma config del `ValidationPipe` de `main.ts`. Los dos JSON antiguos de `data/imports/courses/` también validan, así que la retrocompatibilidad está probada.

## Notas para quien lo revise

- **Rebasado sobre main**, que se había movido bastante: `importCourse` migró de `admin.service.ts` a `admin-content.service.ts` en #52, y los tests están adaptados a la versión con `createMany` por lotes.
- `data/exports/` va a `.gitignore`: es un snapshot de un entorno concreto, reproducible con un comando, y queda obsoleto en cuanto cambia el origen.
- **Este PR debe desplegarse a PROD antes de importar nada allí**, o el `ValidationPipe` rechazará los campos nuevos.

## Contexto del catálogo

De los 105 cursos de PRE, 104 son esqueletos: 1.242 módulos y 9 lecciones en total. No es un fallo — con "Estudiar" el contenido se genera bajo demanda y el índice es el producto. Lo que sí bloquea es que solo 4 están publicados, y `GET /courses` filtra por `published: true` para el alumno. De ahí `--publish-all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)