### PR TITLE
feat(study): Estudiar sin matricula y sin Asignaturas en el menu

### DIFF
--- a/apps/api/src/exams/ai-exams.service.spec.ts
+++ b/apps/api/src/exams/ai-exams.service.spec.ts
@@ -9,7 +9,6 @@ describe('AiExamsService', () => {
 
   const mockPrisma = {
     course: { findUnique: jest.fn() },
-    enrollment: { findFirst: jest.fn() },
     aiExamBank: {
       create: jest.fn(),
       findMany: jest.fn(),
@@ -48,7 +47,6 @@ describe('AiExamsService', () => {
         title: 'Mate',
         schoolYear: { label: '3º ESO' },
       });
-      mockPrisma.enrollment.findFirst.mockResolvedValue({ id: 'enr1' });
       mockAi.generate.mockResolvedValue(
         JSON.stringify({
           title: 'Examen',

--- a/apps/api/src/exams/ai-exams.service.ts
+++ b/apps/api/src/exams/ai-exams.service.ts
@@ -104,11 +104,6 @@ export class AiExamsService {
     });
     if (!course) throw new NotFoundException(`Curso "${params.courseId}" no encontrado`);
 
-    const enrollment = await this.prisma.enrollment.findFirst({
-      where: { userId, courseId: params.courseId },
-    });
-    if (!enrollment) throw new ForbiddenException('No estás matriculado en este curso');
-
     const prompt = this.buildMultiTopicPrompt(
       course.title,
       course.schoolYear?.label ?? '',

--- a/apps/api/src/exercises/exercises.service.spec.ts
+++ b/apps/api/src/exercises/exercises.service.spec.ts
@@ -1,10 +1,9 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { ExercisesService } from './exercises.service';
 
 describe('ExercisesService', () => {
   let prisma: {
     course: { findUnique: jest.Mock };
-    enrollment: { findFirst: jest.Mock };
   };
   let ai: { generate: jest.Mock };
   let service: ExercisesService;
@@ -18,7 +17,6 @@ describe('ExercisesService', () => {
   beforeEach(() => {
     prisma = {
       course: { findUnique: jest.fn() },
-      enrollment: { findFirst: jest.fn() },
     };
     ai = { generate: jest.fn() };
     service = new ExercisesService(prisma as never, ai as never);
@@ -42,10 +40,9 @@ describe('ExercisesService', () => {
 
     it('hace una llamada IA por tema (no una combinada)', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(easyExerciseJson());
 
-      const result = await service.generateForTopics('user-1', {
+      const result = await service.generateForTopics({
         courseId: 'course-1',
         topics: ['Tema A', 'Tema B'],
         perTopic: { easy: 1, medium: 0, hard: 0 },
@@ -60,10 +57,9 @@ describe('ExercisesService', () => {
 
     it('incluye la instrucción de LaTeX (con escape JSON) en el prompt de generación', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(easyExerciseJson());
 
-      await service.generateForTopics('user-1', {
+      await service.generateForTopics({
         courseId: 'course-1',
         topics: ['Fracciones'],
         perTopic: { easy: 1, medium: 0, hard: 0 },
@@ -75,25 +71,25 @@ describe('ExercisesService', () => {
       expect(prompt).toContain('$\\\\frac{1}{2}$');
     });
 
-    it('lanza ForbiddenException si el alumno no está matriculado', async () => {
+    it('genera sin exigir matrícula: basta con que el curso exista', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue(null);
+      ai.generate.mockResolvedValue(easyExerciseJson());
 
-      await expect(
-        service.generateForTopics('user-1', {
-          courseId: 'course-1',
-          topics: ['Tema A'],
-          perTopic: { easy: 1, medium: 0, hard: 0 },
-        }),
-      ).rejects.toThrow(ForbiddenException);
-      expect(ai.generate).not.toHaveBeenCalled();
+      const result = await service.generateForTopics({
+        courseId: 'course-1',
+        topics: ['Tema A'],
+        perTopic: { easy: 1, medium: 0, hard: 0 },
+      });
+
+      expect(result.exercises).toHaveLength(1);
+      expect(ai.generate).toHaveBeenCalledTimes(1);
     });
 
     it('lanza NotFoundException si el curso no existe', async () => {
       prisma.course.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.generateForTopics('user-1', {
+        service.generateForTopics({
           courseId: 'missing',
           topics: ['Tema A'],
           perTopic: { easy: 1, medium: 0, hard: 0 },
@@ -104,7 +100,6 @@ describe('ExercisesService', () => {
 
     it('reintenta (2x) un tema cuyo conteo por dificultad no cuadra, y acepta si el 2º intento es correcto', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       // 1er intento: la IA devuelve MEDIUM cuando se pidió EASY (conteo incumplido)
       ai.generate
         .mockResolvedValueOnce(
@@ -123,7 +118,7 @@ describe('ExercisesService', () => {
         )
         .mockResolvedValueOnce(easyExerciseJson());
 
-      const result = await service.generateForTopics('user-1', {
+      const result = await service.generateForTopics({
         courseId: 'course-1',
         topics: ['Fracciones'],
         perTopic: { easy: 1, medium: 0, hard: 0 },
@@ -137,7 +132,6 @@ describe('ExercisesService', () => {
 
     it('lanza error tras agotar los 2 intentos si el conteo por dificultad sigue sin cuadrar', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       // Ambos intentos devuelven MEDIUM cuando se pidió EASY
       ai.generate.mockResolvedValue(
         JSON.stringify({
@@ -155,7 +149,7 @@ describe('ExercisesService', () => {
       );
 
       await expect(
-        service.generateForTopics('user-1', {
+        service.generateForTopics({
           courseId: 'course-1',
           topics: ['Fracciones'],
           perTopic: { easy: 1, medium: 0, hard: 0 },

--- a/apps/api/src/exercises/exercises.service.ts
+++ b/apps/api/src/exercises/exercises.service.ts
@@ -1,5 +1,4 @@
 import {
-  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -66,8 +65,8 @@ const DIFFICULTY_GUIDANCE: Record<'EASY' | 'MEDIUM' | 'HARD', string> = {
 };
 
 /**
- * Genera ejercicios de práctica bajo demanda para un alumno matriculado
- * en un curso (flujo StudyPlan): una llamada IA por tema con reparto de
+ * Genera ejercicios de práctica bajo demanda sobre una asignatura
+ * (flujo StudyPlan): una llamada IA por tema con reparto de
  * dificultad. Los ejercicios los persiste el plan, no este servicio.
  * También evalúa las respuestas abiertas del alumno con la IA.
  */
@@ -87,7 +86,6 @@ export class ExercisesService {
    * semántico se regenera ese tema (2x).
    */
   async generateForTopics(
-    userId: string,
     params: GenerateExercisesForTopicsParams,
   ): Promise<GenerateTopicExercisesResult> {
     const course = await this.prisma.course.findUnique({
@@ -96,13 +94,6 @@ export class ExercisesService {
     });
     if (!course) {
       throw new NotFoundException(`Curso "${params.courseId}" no encontrado`);
-    }
-
-    const enrollment = await this.prisma.enrollment.findFirst({
-      where: { userId, courseId: params.courseId },
-    });
-    if (!enrollment) {
-      throw new ForbiddenException('No estás matriculado en este curso');
     }
 
     const total = params.perTopic.easy + params.perTopic.medium + params.perTopic.hard;

--- a/apps/api/src/study-plans/study-plans.service.spec.ts
+++ b/apps/api/src/study-plans/study-plans.service.spec.ts
@@ -9,8 +9,7 @@ import { StudyPlansService } from './study-plans.service';
 
 describe('StudyPlansService', () => {
   let prisma: {
-    course: { findUnique: jest.Mock };
-    enrollment: { findFirst: jest.Mock; findMany: jest.Mock };
+    course: { findUnique: jest.Mock; findMany: jest.Mock };
     module: { findUnique: jest.Mock };
     studyPlan: {
       create: jest.Mock;
@@ -44,17 +43,10 @@ describe('StudyPlansService', () => {
     ],
   };
 
-  // Matrículas: curso base de Matemáticas; opcionalmente también Lengua.
-  const mathEnrollment = {
-    id: 'enr-1',
-    courseId: 'course-mates',
-    course: { id: 'course-mates', subject: 'Matemáticas' },
-  };
-  const lenguaEnrollment = {
-    id: 'enr-2',
-    courseId: 'course-lengua',
-    course: { id: 'course-lengua', subject: 'Lengua' },
-  };
+  // Asignaturas publicadas: la base de Matemáticas; opcionalmente también Lengua.
+  // No hay matrícula: cualquier asignatura publicada es estudiable.
+  const mathCourse = { id: 'course-mates', subject: 'Matemáticas' };
+  const lenguaCourse = { id: 'course-lengua', subject: 'Lengua' };
 
   // Sirve tanto a getById como a requireOwnedPlan: mismo mock de
   // studyPlan.findUnique para ambos caminos (union de campos usados por los dos).
@@ -90,11 +82,10 @@ describe('StudyPlansService', () => {
   beforeEach(() => {
     prisma = {
       course: {
-        findUnique: jest.fn().mockResolvedValue({ id: 'course-mates', title: 'Matemáticas 3º ESO' }),
-      },
-      enrollment: {
-        findFirst: jest.fn().mockResolvedValue({ id: 'enr-1' }),
-        findMany: jest.fn().mockResolvedValue([mathEnrollment]),
+        findUnique: jest
+          .fn()
+          .mockResolvedValue({ id: 'course-mates', title: 'Matemáticas 3º ESO' }),
+        findMany: jest.fn().mockResolvedValue([mathCourse]),
       },
       module: { findUnique: jest.fn() },
       studyPlan: {
@@ -143,24 +134,24 @@ describe('StudyPlansService', () => {
   // ─── resolveAndAssertTopics: regla de coherencia (criterio 2) ─────────────
 
   describe('resolveAndAssertTopics', () => {
-    it('rechaza con 422 un tema con subject de una materia NO matriculada, listando las válidas', async () => {
-      // Matriculado solo en Matemáticas → "lengua" no es coherente
+    it('rechaza con 422 un tema con subject de una materia inexistente, listando las válidas', async () => {
+      // Solo existe Matemáticas → "lengua" no es coherente
       await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [
+        service.resolveAndAssertTopics('course-mates', [
           { title: 'análisis morfológico', subject: 'lengua' },
         ]),
       ).rejects.toThrow(UnprocessableEntityException);
 
       await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [
+        service.resolveAndAssertTopics('course-mates', [
           { title: 'análisis morfológico', subject: 'lengua' },
         ]),
       ).rejects.toThrow(/Materias válidas: Matemáticas/);
     });
 
-    it('acepta un tema con subject matriculado, ignorando mayúsculas y acentos', async () => {
+    it('acepta un tema con subject de una materia existente, ignorando mayúsculas y acentos', async () => {
       // "matematicas" (sin tilde, minúsculas) debe casar con "Matemáticas"
-      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+      const resolved = await service.resolveAndAssertTopics('course-mates', [
         { title: 'ecuaciones de segundo grado', subject: 'matematicas' },
       ]);
       expect(resolved).toHaveLength(1);
@@ -170,7 +161,7 @@ describe('StudyPlansService', () => {
     });
 
     it('atribuye a la asignatura base un tema libre sin subject', async () => {
-      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+      const resolved = await service.resolveAndAssertTopics('course-mates', [
         { title: 'proporcionalidad' },
       ]);
       expect(resolved[0]).toMatchObject({
@@ -182,11 +173,11 @@ describe('StudyPlansService', () => {
       });
     });
 
-    it('resuelve un tema de otra asignatura matriculada con el contexto de esa asignatura', async () => {
-      // Matriculado en Mates + Lengua → "análisis morfológico" (lengua) es coherente
-      prisma.enrollment.findMany.mockResolvedValue([mathEnrollment, lenguaEnrollment]);
+    it('resuelve un tema de otra asignatura con el contexto de esa asignatura', async () => {
+      // Existen Mates + Lengua → "análisis morfológico" (lengua) es coherente
+      prisma.course.findMany.mockResolvedValue([mathCourse, lenguaCourse]);
 
-      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+      const resolved = await service.resolveAndAssertTopics('course-mates', [
         { title: 'análisis morfológico', subject: 'lengua' },
       ]);
       expect(resolved[0].contextCourseId).toBe('course-lengua');
@@ -200,7 +191,7 @@ describe('StudyPlansService', () => {
         courseId: 'course-mates',
       });
 
-      const resolved = await service.resolveAndAssertTopics('user-1', 'course-mates', [
+      const resolved = await service.resolveAndAssertTopics('course-mates', [
         { moduleId: 'mod-1' },
       ]);
       expect(resolved[0]).toMatchObject({
@@ -215,20 +206,26 @@ describe('StudyPlansService', () => {
       prisma.module.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [{ moduleId: 'mod-fake' }]),
+        service.resolveAndAssertTopics('course-mates', [{ moduleId: 'mod-fake' }]),
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('rechaza con 403 un módulo de un curso donde el alumno NO está matriculado', async () => {
+    it('acepta un módulo de otra asignatura sin exigir matrícula, con el curso del módulo como contexto', async () => {
       prisma.module.findUnique.mockResolvedValue({
         id: 'mod-2',
         title: 'Sintaxis',
-        courseId: 'course-lengua', // solo matriculado en Mates
+        courseId: 'course-lengua', // la base es Mates: ya no hace falta matrícula
       });
 
-      await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [{ moduleId: 'mod-2' }]),
-      ).rejects.toThrow(ForbiddenException);
+      const resolved = await service.resolveAndAssertTopics('course-mates', [
+        { moduleId: 'mod-2' },
+      ]);
+      expect(resolved[0]).toMatchObject({
+        source: 'OFFICIAL',
+        moduleId: 'mod-2',
+        title: 'Sintaxis',
+        contextCourseId: 'course-lengua',
+      });
     });
 
     it('rechaza con 422 temas duplicados por moduleId', async () => {
@@ -239,7 +236,7 @@ describe('StudyPlansService', () => {
       });
 
       await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [
+        service.resolveAndAssertTopics('course-mates', [
           { moduleId: 'mod-1' },
           { moduleId: 'mod-1' },
         ]),
@@ -248,7 +245,7 @@ describe('StudyPlansService', () => {
 
     it('rechaza con 422 temas duplicados por título normalizado (acentos/mayúsculas)', async () => {
       await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [
+        service.resolveAndAssertTopics('course-mates', [
           { title: 'Ecuaciones' },
           { title: '  ecuaciónes '.replace('ó', 'o') }, // "ecuaciones" normalizado
         ]),
@@ -257,7 +254,7 @@ describe('StudyPlansService', () => {
 
     it('rechaza con 400 un tema con moduleId y title a la vez', async () => {
       await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [
+        service.resolveAndAssertTopics('course-mates', [
           { moduleId: 'mod-1', title: 'Fracciones' },
         ]),
       ).rejects.toThrow(BadRequestException);
@@ -265,7 +262,7 @@ describe('StudyPlansService', () => {
 
     it('rechaza con 400 un subject acompañando a un moduleId', async () => {
       await expect(
-        service.resolveAndAssertTopics('user-1', 'course-mates', [
+        service.resolveAndAssertTopics('course-mates', [
           { moduleId: 'mod-1', subject: 'lengua' } as never,
         ]),
       ).rejects.toThrow(BadRequestException);
@@ -309,7 +306,7 @@ describe('StudyPlansService', () => {
         courseId: 'course-mates',
         topic: 'Fracciones',
       });
-      expect(exercises.generateForTopics).toHaveBeenCalledWith('user-1', {
+      expect(exercises.generateForTopics).toHaveBeenCalledWith({
         courseId: 'course-mates',
         topics: ['Fracciones'],
         perTopic: { easy: 2, medium: 2, hard: 1 },
@@ -324,7 +321,7 @@ describe('StudyPlansService', () => {
     });
 
     it('la teoría de cada tema usa su contextCourseId (tema de otra asignatura)', async () => {
-      prisma.enrollment.findMany.mockResolvedValue([mathEnrollment, lenguaEnrollment]);
+      prisma.course.findMany.mockResolvedValue([mathCourse, lenguaCourse]);
       prisma.studyPlan.create.mockResolvedValue({
         id: 'plan-1',
         topics: [
@@ -519,7 +516,7 @@ describe('StudyPlansService', () => {
 
       await service.regenerateExercises('user-1', 'plan-1', {});
 
-      expect(exercises.generateForTopics).toHaveBeenCalledWith('user-1', {
+      expect(exercises.generateForTopics).toHaveBeenCalledWith({
         courseId: 'course-mates',
         topics: ['Fracciones'],
         perTopic: { easy: 3, medium: 1, hard: 0 },
@@ -539,7 +536,6 @@ describe('StudyPlansService', () => {
       await service.regenerateExercises('user-1', 'plan-1', { hard: 2 });
 
       expect(exercises.generateForTopics).toHaveBeenCalledWith(
-        'user-1',
         expect.objectContaining({ perTopic: { easy: 3, medium: 1, hard: 2 } }),
       );
     });

--- a/apps/api/src/study-plans/study-plans.service.ts
+++ b/apps/api/src/study-plans/study-plans.service.ts
@@ -32,7 +32,7 @@ const EXAM_LEVEL_PRESETS: Record<
   HARD: { numQuestions: 10, difficulty: 'HARD' },
 };
 
-// Tema del payload ya resuelto contra matrículas y temario (regla de coherencia).
+// Tema del payload ya resuelto contra las asignaturas y el temario (regla de coherencia).
 export interface ResolvedTopic {
   source: StudyTopicSource;
   moduleId: string | null;
@@ -68,36 +68,37 @@ export class StudyPlansService {
       .replace(/[\u0300-\u036f]/g, '');
   }
 
-  private async assertEnrolled(userId: string, courseId: string): Promise<void> {
-    const course = await this.prisma.course.findUnique({ where: { id: courseId } });
+  private async assertCourseExists(courseId: string): Promise<void> {
+    const course = await this.prisma.course.findUnique({
+      where: { id: courseId },
+      select: { id: true },
+    });
     if (!course) throw new NotFoundException(`Curso "${courseId}" no encontrado`);
-    const enrollment = await this.prisma.enrollment.findFirst({ where: { userId, courseId } });
-    if (!enrollment) throw new ForbiddenException('No estás matriculado en este curso');
   }
 
   /**
    * Regla de coherencia (determinista, sin IA) — única fuente de verdad, se
-   * ejecuta dentro del create. Para cada tema del payload, en orden:
-   *  1. moduleId (OFFICIAL): válido si el alumno está matriculado en el curso
-   *     del módulo (base u otro). contextCourseId = curso del módulo.
+   * ejecuta dentro del create. No exige matrícula: el alumno puede estudiar
+   * cualquier asignatura publicada. Para cada tema del payload, en orden:
+   *  1. moduleId (OFFICIAL): válido si el módulo existe. contextCourseId =
+   *     curso del módulo.
    *  2. title sin subject (CUSTOM in-subject): coherente por construcción,
    *     se atribuye a la asignatura base. contextCourseId = curso base.
-   *  3. title con subject (CUSTOM fuera de asignatura): válido si y solo si el
-   *     alumno está matriculado en ≥1 curso de esa materia (comparación
-   *     normalizada). contextCourseId = primer curso matriculado de la materia.
+   *  3. title con subject (CUSTOM fuera de asignatura): válido si y solo si
+   *     existe ≥1 asignatura publicada de esa materia (comparación
+   *     normalizada). contextCourseId = primera asignatura de esa materia.
    * Además: sin temas duplicados (mismo moduleId o mismo título normalizado).
    */
   async resolveAndAssertTopics(
-    userId: string,
     baseCourseId: string,
     topics: StudyPlanTopicInputDto[],
   ): Promise<ResolvedTopic[]> {
-    const enrollments = await this.prisma.enrollment.findMany({
-      where: { userId },
+    // Materias disponibles para etiquetar temas propios: todas las publicadas.
+    const availableCourses = await this.prisma.course.findMany({
+      where: { published: true },
       orderBy: { createdAt: 'asc' },
-      include: { course: { select: { id: true, subject: true } } },
+      select: { id: true, subject: true },
     });
-    const enrolledCourseIds = new Set(enrollments.map((e) => e.courseId));
 
     const resolved: ResolvedTopic[] = [];
     for (const input of topics) {
@@ -123,11 +124,6 @@ export class StudyPlansService {
         if (!module) {
           throw new NotFoundException(`Módulo "${input.moduleId}" no encontrado`);
         }
-        if (!enrolledCourseIds.has(module.courseId)) {
-          throw new ForbiddenException(
-            `No estás matriculado en el curso al que pertenece el tema "${module.title}"`,
-          );
-        }
         resolved.push({
           source: StudyTopicSource.OFFICIAL,
           moduleId: module.id,
@@ -145,22 +141,22 @@ export class StudyPlansService {
           contextCourseId: baseCourseId,
         });
       } else {
-        // 3. Tema propio de otra asignatura: exige matrícula en esa materia
+        // 3. Tema propio de otra asignatura: exige que la materia exista
         const wanted = this.normalize(input.subject);
-        const match = enrollments.find(
-          (e) => e.course.subject && this.normalize(e.course.subject) === wanted,
+        const match = availableCourses.find(
+          (c) => c.subject && this.normalize(c.subject) === wanted,
         );
         if (!match) {
           const subjects = [
             ...new Set(
-              enrollments
-                .map((e) => e.course.subject)
+              availableCourses
+                .map((c) => c.subject)
                 .filter((s): s is string => !!s && s.trim().length > 0),
             ),
           ];
           throw new UnprocessableEntityException(
             `El tema "${input.title!.trim()}" está etiquetado como "${input.subject.trim()}", ` +
-              `pero no estás matriculado en ninguna asignatura de esa materia. ` +
+              `pero no hay ninguna asignatura de esa materia. ` +
               `Materias válidas: ${subjects.join(', ') || '(ninguna)'}`,
           );
         }
@@ -169,7 +165,7 @@ export class StudyPlansService {
           moduleId: null,
           title: input.title!.trim(),
           subject: input.subject.trim(),
-          contextCourseId: match.courseId,
+          contextCourseId: match.id,
         });
       }
     }
@@ -205,10 +201,10 @@ export class StudyPlansService {
   }
 
   async create(userId: string, dto: CreateStudyPlanDto) {
-    await this.assertEnrolled(userId, dto.courseId);
+    await this.assertCourseExists(dto.courseId);
     this.assertPerTopicTotal(dto.exercisesPerTopic);
 
-    const resolvedTopics = await this.resolveAndAssertTopics(userId, dto.courseId, dto.topics);
+    const resolvedTopics = await this.resolveAndAssertTopics(dto.courseId, dto.topics);
 
     // Plan "cáscara" + temas en una transacción (nested create)
     const plan = await this.prisma.studyPlan.create({
@@ -247,7 +243,7 @@ export class StudyPlansService {
         ),
       ),
       Promise.allSettled([
-        this.exercises.generateForTopics(userId, {
+        this.exercises.generateForTopics({
           courseId: dto.courseId,
           topics: topicTitles,
           perTopic: dto.exercisesPerTopic,
@@ -313,7 +309,10 @@ export class StudyPlansService {
 
   private buildTitle(topics: { title: string }[]): string {
     // Título por defecto del curso multi-tema; el alumno puede renombrarlo después.
-    return topics.map((t) => t.title).join(' · ').slice(0, 200);
+    return topics
+      .map((t) => t.title)
+      .join(' · ')
+      .slice(0, 200);
   }
 
   async listMine(userId: string) {
@@ -471,7 +470,7 @@ export class StudyPlansService {
     this.assertPerTopicTotal(perTopic as ExercisesPerTopicDto);
 
     // Generar primero: si la IA falla, los ejercicios anteriores quedan intactos.
-    const res = await this.exercises.generateForTopics(userId, {
+    const res = await this.exercises.generateForTopics({
       courseId: plan.courseId,
       topics: plan.topics.map((t) => t.title),
       perTopic,

--- a/apps/api/src/theory/theory.service.spec.ts
+++ b/apps/api/src/theory/theory.service.spec.ts
@@ -5,7 +5,6 @@ import { TheoryService } from './theory.service';
 describe('TheoryService', () => {
   let prisma: {
     course: { findUnique: jest.Mock };
-    enrollment: { findFirst: jest.Mock };
     theoryModule: {
       create: jest.Mock;
       findMany: jest.Mock;
@@ -54,7 +53,6 @@ describe('TheoryService', () => {
   beforeEach(() => {
     prisma = {
       course: { findUnique: jest.fn() },
-      enrollment: { findFirst: jest.fn() },
       theoryModule: {
         create: jest.fn(),
         findMany: jest.fn(),
@@ -74,9 +72,8 @@ describe('TheoryService', () => {
   });
 
   describe('generate', () => {
-    it('persiste el módulo con sus lecciones cuando el alumno está matriculado', async () => {
+    it('persiste el módulo con sus lecciones', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
       const five = Array.from({ length: 5 }, (_, i) => ({
         youtubeId: `vid${i}`,
@@ -121,7 +118,6 @@ describe('TheoryService', () => {
 
     it('pide 5 candidatos a YoutubeService para la lección VIDEO', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
       youtube.findCandidates.mockResolvedValue([]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
@@ -135,7 +131,6 @@ describe('TheoryService', () => {
 
     it('persiste lección VIDEO con candidates=null y youtubeId=null si YouTube no encuentra resultados', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
       youtube.findCandidates.mockResolvedValue([]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
@@ -156,18 +151,18 @@ describe('TheoryService', () => {
       expect(ai.generate).not.toHaveBeenCalled();
     });
 
-    it('lanza ForbiddenException si el alumno no está matriculado', async () => {
+    it('genera sin exigir matrícula: basta con que el curso exista', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue(null);
-      await expect(
-        service.generate('user-1', { courseId: 'course-1', topic: 't' }),
-      ).rejects.toThrow(ForbiddenException);
-      expect(ai.generate).not.toHaveBeenCalled();
+      ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
+      youtube.findCandidates.mockResolvedValue([{ youtubeId: 'xyz' }]);
+      prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
+
+      await service.generate('user-1', { courseId: 'course-1', topic: 't' });
+      expect(prisma.theoryModule.create).toHaveBeenCalled();
     });
 
     it('parsea respuesta IA envuelta en ```json```', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(`\`\`\`json\n${JSON.stringify(validAiPayload)}\n\`\`\``);
       youtube.findCandidates.mockResolvedValue([{ youtubeId: 'xyz' }]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
@@ -178,7 +173,6 @@ describe('TheoryService', () => {
 
     it('lanza error si la IA devuelve JSON inválido', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue('no es json {malformado');
       await expect(
         service.generate('user-1', { courseId: 'course-1', topic: 't' }),
@@ -192,7 +186,6 @@ describe('TheoryService', () => {
         lessons: [{ kind: 'CONTENT', heading: 'sin body' }],
       };
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(broken));
       await expect(
         service.generate('user-1', { courseId: 'course-1', topic: 't' }),
@@ -205,7 +198,6 @@ describe('TheoryService', () => {
         lessons: [{ kind: 'UNKNOWN', heading: 'x', body: 'y' }],
       };
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(broken));
       await expect(
         service.generate('user-1', { courseId: 'course-1', topic: 't' }),
@@ -214,7 +206,6 @@ describe('TheoryService', () => {
 
     it('incluye título de curso, nivel y tema en el prompt', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
       youtube.findCandidates.mockResolvedValue([]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });
@@ -232,7 +223,6 @@ describe('TheoryService', () => {
 
     it('el prompt exige la estructura Winston (promesa, cycling, fencing, ejemplos paso a paso, cierre)', async () => {
       prisma.course.findUnique.mockResolvedValue(baseCourse);
-      prisma.enrollment.findFirst.mockResolvedValue({ id: 'enr-1' });
       ai.generate.mockResolvedValue(JSON.stringify(validAiPayload));
       youtube.findCandidates.mockResolvedValue([]);
       prisma.theoryModule.create.mockResolvedValue({ id: 'mod-1', lessons: [] });

--- a/apps/api/src/theory/theory.service.ts
+++ b/apps/api/src/theory/theory.service.ts
@@ -67,14 +67,6 @@ export class TheoryService {
       throw new NotFoundException(`Curso "${dto.courseId}" no encontrado`);
     }
 
-    const enrollment = await this.prisma.enrollment.findFirst({
-      where: { userId, courseId: dto.courseId },
-    });
-
-    if (!enrollment) {
-      throw new ForbiddenException('No estás matriculado en este curso');
-    }
-
     const schoolYearLabel = course.schoolYear?.label ?? '';
     const prompt = this.buildPrompt(course.title, schoolYearLabel, dto.topic);
 

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -40,7 +40,6 @@ function buildNavLinks(role: Role | undefined): NavItem[] {
   // STUDENT por defecto
   return [
     ...base,
-    { to: '/subjects', label: 'Asignaturas', icon: 'book' },
     { to: '/study', label: 'Estudiar', icon: 'brain' },
     { to: '/challenges', label: 'Retos', icon: 'trophy' },
     { to: '/profile', label: 'Mi perfil', icon: 'user' },

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -273,9 +273,9 @@ function StudentRail({ onNavigate }: { onNavigate: (to: string) => void }) {
           <button
             className="btn btn-primary btn-full"
             style={{ marginTop: 12, padding: '9px 16px', fontSize: '0.85rem' }}
-            onClick={() => onNavigate('/subjects')}
+            onClick={() => onNavigate('/study')}
           >
-            Elegir asignatura
+            Empezar a estudiar
           </button>
         </RailCard>
       )}

--- a/apps/web/src/pages/StudyPage.tsx
+++ b/apps/web/src/pages/StudyPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type FormEvent } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import type { StudyExercisesPerTopic, StudyPlanTopicInput } from '@vkbacademy/shared';
-import { useCourses, useCourse, useSubjects } from '../hooks/useCourses';
+import { useCourse, useSubjects } from '../hooks/useCourses';
 import { useMyStudyPlans, useCreateStudyPlan, useDeleteStudyPlan } from '../hooks/useStudyPlans';
 import { getApiErrorMessage } from '../utils/errorMessage';
 import PageHeader from '../components/ui/PageHeader';
@@ -33,12 +33,11 @@ export default function StudyPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
-  const { data: coursesData } = useCourses(1);
-  const courses = coursesData?.data ?? [];
-
   const [courseId, setCourseId] = useState(searchParams.get('courseId') ?? '');
   const { data: courseDetail } = useCourse(courseId);
+  // Todas las asignaturas disponibles del nivel del alumno: no hace falta estar matriculado.
   const { data: subjects } = useSubjects();
+  const courses = subjects ?? [];
 
   const [selectedTopics, setSelectedTopics] = useState<SelectedTopic[]>([]);
   const [customTitle, setCustomTitle] = useState('');
@@ -64,13 +63,13 @@ export default function StudyPage() {
     setCustomSubject('');
   }
 
-  // Materias de otras asignaturas matriculadas (con subject propio, distintas de la base),
+  // Materias de otras asignaturas disponibles (con subject propio, distintas de la base),
   // deduplicadas por nombre de materia normalizado.
   const otherSubjectOptions = useMemo(() => {
     if (!subjects) return [];
     const seen = new Map<string, string>();
     for (const c of subjects) {
-      if (!c.isEnrolled || !c.subject || c.id === courseId) continue;
+      if (!c.subject || c.id === courseId) continue;
       const key = c.subject.trim().toLowerCase();
       if (!seen.has(key)) seen.set(key, c.subject.trim());
     }
@@ -348,9 +347,9 @@ export default function StudyPage() {
               Exámenes
             </h3>
             <p style={s.muted}>
-              Los exámenes se generan después, en la pestaña Examen del curso: niveles básico,
-              medio y difícil, de todos los temas juntos o de cada tema por separado. El reto es
-              aprobar los 3 niveles.
+              Los exámenes se generan después, en la pestaña Examen del curso: niveles básico, medio
+              y difícil, de todos los temas juntos o de cada tema por separado. El reto es aprobar
+              los 3 niveles.
             </p>
             {selectedTopics.length === 0 && (
               <p style={s.warn}>Añade al menos 1 tema para poder crear el curso.</p>
@@ -363,7 +362,12 @@ export default function StudyPage() {
             </div>
           )}
 
-          <button type="submit" className="btn btn-primary" disabled={!canSubmit} style={s.submitBtn}>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={!canSubmit}
+            style={s.submitBtn}
+          >
             {create.isPending ? (
               <span className="spinner" />
             ) : (
@@ -381,7 +385,10 @@ export default function StudyPage() {
         <h2 className="section-label">Mis cursos de estudio</h2>
         {removePlan.isError && (
           <div className="alert alert-error" style={{ marginTop: 14 }}>
-            {getApiErrorMessage(removePlan.error, 'No se pudo borrar el curso. Inténtalo de nuevo.')}
+            {getApiErrorMessage(
+              removePlan.error,
+              'No se pudo borrar el curso. Inténtalo de nuevo.',
+            )}
           </div>
         )}
         {plansLoading && <p style={s.muted}>Cargando…</p>}
@@ -502,7 +509,12 @@ const s: Record<string, React.CSSProperties> = {
     flexDirection: 'column',
     gap: 8,
   },
-  topicChip: { width: '100%', justifyContent: 'flex-start', cursor: 'default', padding: '8px 14px' },
+  topicChip: {
+    width: '100%',
+    justifyContent: 'flex-start',
+    cursor: 'default',
+    padding: '8px 14px',
+  },
   topicChipNum: {
     fontFamily: 'var(--font-display)',
     color: 'var(--brand-deep)',


### PR DESCRIPTION
## Qué cambia

**1. El menú lateral del alumno pierde "Asignaturas".** La ruta `/subjects` y los endpoints de auto-matriculación siguen existiendo (accesible por URL), solo desaparece del nav. El CTA "Elegir asignatura" del dashboard vacío pasa a apuntar a `/study`, que era el único enlace que quedaba a la página retirada.

**2. "Estudiar" deja de exigir matrícula.** Consecuencia directa de lo anterior: si el alumno ya no puede matricularse, el flujo de estudio no puede depender de la matrícula.

### Frontend (`StudyPage.tsx`)
- El desplegable de asignatura base sale de `GET /courses/subjects` (todas las publicadas de su nivel) en vez de `GET /courses`, que devolvía solo el nivel + las matriculadas.
- El selector "¿De qué asignatura es?" de los temas propios ya no filtra por `isEnrolled`.

### Backend — caen las cuatro puertas de matrícula del flujo
- `study-plans.service.ts`: `assertEnrolled` → `assertCourseExists` (solo 404 si el curso no existe); un tema oficial ya no exige matrícula en el curso del módulo; un tema propio con `subject` se valida contra las asignaturas publicadas en vez de contra las matrículas (mensaje 422 actualizado).
- `theory.service.ts`, `exercises.service.ts`, `ai-exams.service.ts`: fuera el `ForbiddenException('No estás matriculado…')`; basta con que el curso exista. De paso, `ExercisesService.generateForTopics` pierde el parámetro `userId`, que ya no usaba.

## Lo que NO cambia

El filtrado por nivel (`schoolYear`) sigue intacto: `GET /courses/subjects` devuelve las asignaturas del nivel del alumno y `GET /courses/:id` sigue dando 403 fuera de nivel, así que el temario oficial de otro nivel no es alcanzable desde la UI. Se interpretó "todas las asignaturas" como "todas las de su nivel, esté matriculado o no".

## Verificación

- `pnpm --filter @vkbacademy/api test` → 440/440 en verde.
- `tsc --noEmit` limpio en API y web.
- Tests reescritos donde la semántica se invirtió: el que exigía 403 en un módulo de curso no matriculado ahora comprueba que resuelve con el curso del módulo como contexto.
- **Verificado por mutación**: reintroduciendo el `throw` de matrícula en `resolveAndAssertTopics` falla exactamente ese test nuevo y ningún otro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)