### PR TITLE
fix(ai): pinnea gemini-3.5-flash — el modelo en main devuelve 404

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,11 +240,12 @@ el único proveedor: si su saldo se agota, la API devuelve 400 en cada llamada y
 generación falla. Configura siempre `GEMINI_API_KEY`, también en PRE y PROD.
 
 **Nunca uses un alias de modelo** (`gemini-flash-latest` y similares): Google los repunta
-sin avisar — el 21-01-2026 saltó a Gemini 3, donde `thinkingBudget: 0` dejó de apagar el
-thinking, y los thinking tokens se comieron el `maxOutputTokens` truncando el JSON. El
-modelo va pinneado en `AiProviderService` y se cambia con `GEMINI_MODEL`; el código elige
-solo entre `thinkingBudget` (Gemini ≤2.x) y `thinkingLevel` (≥3), que no pueden viajar
-juntos en la misma request.
+sin avisar y con ellos cambia la semántica de los parámetros. Medido contra la API el
+13-08-2026: el alias con `thinkingBudget: 0` devuelve **400 INVALID_ARGUMENT en cada
+llamada** (sin `thinkingConfig` responde 200), y `gemini-2.5-flash` ya da 404 *"no longer
+available to new users"*. El modelo va pinneado en `AiProviderService` (`gemini-3.5-flash`)
+y se cambia con `GEMINI_MODEL`; el código elige `thinkingBudget` en Gemini ≤2.x y
+`thinkingLevel` en ≥3, que no pueden viajar juntos en la misma request.
 
 ---
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -42,11 +42,13 @@ ANTHROPIC_API_KEY=""
 # Proveedor: "auto" (Gemini → Haiku, por defecto) | "gemini" (solo Gemini) | "haiku" (solo Haiku).
 AI_PROVIDER="auto"
 #
-# Modelo de Gemini. Vacío = el pinneado en el código (gemini-2.5-flash, apagado
-# previsto el 16-10-2026). NUNCA un alias "-latest": Google los repunta sin avisar
-# y el salto a Gemini 3 cambió la semántica del thinking, tumbando la generación.
-# Para migrar a Gemini 3 basta cambiar esta variable: el código ya envía
-# thinkingLevel en vez de thinkingBudget cuando detecta familia ≥3.
+# Modelo de Gemini. Vacío = el pinneado en el código (gemini-3.5-flash).
+# NUNCA un alias "-latest": Google los repunta sin avisar y con ellos cambia la
+# semántica de los parámetros. Medido el 13-08-2026: gemini-flash-latest con
+# thinkingBudget devuelve 400 en cada llamada, y gemini-2.5-flash ya da 404
+# ("no longer available to new users") en cuentas nuevas.
+# Para cambiar de familia basta esta variable: el código envía thinkingBudget
+# en Gemini ≤2.x y thinkingLevel en ≥3.
 GEMINI_MODEL=""
 #
 # Timeout por llamada a Gemini/Haiku, en ms. Evita que un proveedor colgado bloquee la request HTTP.

--- a/apps/api/src/ai/ai-provider.service.spec.ts
+++ b/apps/api/src/ai/ai-provider.service.spec.ts
@@ -117,7 +117,7 @@ describe('AiProviderService', () => {
         response: { text: () => '{"ok":true}' },
       });
 
-      const provider = createProvider({ AI_PROVIDER: 'gemini' });
+      const provider = createProvider({ AI_PROVIDER: 'gemini', GEMINI_MODEL: 'gemini-2.5-flash' });
       await provider.generate('prompt', 512);
 
       expect(mockGeminiGetGenerativeModel).toHaveBeenCalledWith(
@@ -140,9 +140,11 @@ describe('AiProviderService', () => {
       });
       await provider.generate('prompt', 512);
 
-      const [args] = mockGeminiGetGenerativeModel.mock.calls[0] as unknown as [{
-        generationConfig: { thinkingConfig: Record<string, unknown> };
-      }];
+      const [args] = mockGeminiGetGenerativeModel.mock.calls[0] as unknown as [
+        {
+          generationConfig: { thinkingConfig: Record<string, unknown> };
+        },
+      ];
       const { generationConfig } = args;
       expect(generationConfig.thinkingConfig).toEqual({ thinkingLevel: 'minimal' });
       expect(generationConfig.thinkingConfig).not.toHaveProperty('thinkingBudget');
@@ -229,8 +231,27 @@ describe('AiProviderService', () => {
       const provider = createProvider({ AI_PROVIDER: 'gemini' });
       await provider.generate('prompt', 512);
 
-      const [{ model }] = mockGeminiGetGenerativeModel.mock.calls[0] as unknown as [{ model: string }];
+      const [{ model }] = mockGeminiGetGenerativeModel.mock.calls[0] as unknown as [
+        { model: string },
+      ];
       expect(model).not.toMatch(/-latest$/);
+    });
+
+    it('el modelo por defecto no usa thinkingBudget (medido: el alias lo rechaza con 400)', async () => {
+      // Contra la API real, gemini-flash-latest + thinkingBudget: 0 devuelve
+      // 400 INVALID_ARGUMENT en cada llamada. El default debe ser un modelo
+      // cuya config de thinking esté validada, no heredar la de Gemini 2.5.
+      mockGeminiGenerateContent.mockResolvedValue({
+        response: { text: () => '{"ok":true}' },
+      });
+
+      const provider = createProvider({ AI_PROVIDER: 'gemini' });
+      await provider.generate('prompt', 512);
+
+      const [args] = mockGeminiGetGenerativeModel.mock.calls[0] as unknown as [
+        { generationConfig: { thinkingConfig: Record<string, unknown> } },
+      ];
+      expect(args.generationConfig.thinkingConfig).toEqual({ thinkingLevel: 'minimal' });
     });
 
     it('GEMINI_MODEL sobreescribe el modelo por defecto', async () => {

--- a/apps/api/src/ai/ai-provider.service.ts
+++ b/apps/api/src/ai/ai-provider.service.ts
@@ -4,12 +4,16 @@ import { GoogleGenerativeAI, GoogleGenerativeAIAbortError } from '@google/genera
 import Anthropic, { APIConnectionTimeoutError } from '@anthropic-ai/sdk';
 
 // Modelo por defecto, PINNEADO a propósito. No usar alias móviles
-// ("gemini-flash-latest"): Google los repunta sin avisar — el 21-01-2026
-// gemini-flash-latest saltó a Gemini 3, donde `thinkingBudget: 0` dejó de
-// apagar el thinking, y la generación empezó a fallar sin tocar el repo.
-// Overridable con GEMINI_MODEL para migrar sin desplegar código.
-// OJO: gemini-2.5-flash tiene fecha de apagado el 16-10-2026.
-const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
+// ("gemini-flash-latest"): Google los repunta sin avisar y con ellos viaja la
+// semántica de los parámetros. Medido contra la API el 13-08-2026:
+//   gemini-flash-latest + thinkingBudget: 0  → 400 INVALID_ARGUMENT (siempre)
+//   gemini-flash-latest sin thinkingConfig   → 200 OK
+//   gemini-3.5-flash    + thinkingLevel      → 200 OK, 0 thinking tokens
+//   gemini-2.5-flash                         → 404 "no longer available to new users"
+// Es decir: el alias saltó a un modelo que rechaza el parámetro de thinking de
+// Gemini 2.5, y cada llamada moría en 400 sin que nadie tocara el repo.
+// Overridable con GEMINI_MODEL para migrar de familia sin desplegar código.
+const DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash';
 
 /**
  * Proveedor de IA unificado con fallback automático.

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -69,8 +69,8 @@ export const envValidationSchema = Joi.object({
   ANTHROPIC_API_KEY: Joi.string().allow('').optional(),
   AI_PROVIDER: Joi.string().valid('gemini', 'haiku', 'auto').default('auto'),
   // Modelo de Gemini. Sin valor usa el pinneado en AiProviderService. No pongas
-  // un alias "-latest": Google los repunta sin avisar y cambia la semántica del
-  // thinking, que es lo que tumbó la generación en agosto de 2026.
+  // un alias "-latest": Google los repunta sin avisar y con ellos cambia la
+  // semántica del thinking, que es lo que tumbó la generación en agosto de 2026.
   GEMINI_MODEL: Joi.string().allow('').optional(),
   // Timeout por llamada a Gemini/Haiku (ms). Evita que una IA colgada bloquee la request HTTP.
   AI_TIMEOUT_MS: Joi.number().integer().min(1000).default(60000),


### PR DESCRIPTION
## Urgente: `main` está roto ahora mismo

El #67 se mergeó en squash antes de que llegara el commit con la corrección medida, así que en `main` quedó `DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash'` — un modelo que **devuelve 404 para nuestra cuenta**:

```
gemini-2.5-flash → 404 "This model is no longer available to new users"
```

O sea: la generación con Gemini sigue rota en PROD, solo que ahora falla con 404 en vez de con el 400 original.

## Qué cambia

Pinnea **`gemini-3.5-flash`**, el modelo verificado contra la API con la key real:

| Petición | Resultado |
|---|---|
| `gemini-3.5-flash` + `thinkingLevel: "minimal"` | 200 OK, 0 thinking tokens |
| `gemini-3.5-flash`, prompt realista de teoría (4 lecciones, `maxOutputTokens: 6000`) | 200 OK, `finishReason: STOP`, JSON válido |
| `gemini-2.5-flash` (lo que hay en `main`) | 404 |
| `gemini-flash-latest` + `thinkingBudget: 0` (lo que había antes del #67) | 400 INVALID_ARGUMENT |

Añade además un test que fija la regla medida: el modelo por defecto no debe enviar `thinkingBudget`, porque la familia ≥3 lo rechaza.

Actualiza `.env.example`, `env.schema.ts` y `CLAUDE.md` con las cuatro medidas, para que el próximo que toque esto no repita el camino.

## Verificación

- 449 tests en verde, `tsc --noEmit` limpio.
- El modelo elegido está validado end-to-end contra la API, no inferido de documentación.

## Después de mergear

Nada que tocar en Render. En el log de arranque debe verse `gemini=true (gemini-3.5-flash)`; si sale `gemini-2.5-flash`, es que el deploy no ha entrado todavía.

🤖 Generated with [Claude Code](https://claude.com/claude-code)