### PR TITLE
fix(landing): el eyebrow del hero deja de llevar articulo

### DIFF
--- a/apps/web/src/pages/marketing/LandingPage.tsx
+++ b/apps/web/src/pages/marketing/LandingPage.tsx
@@ -144,9 +144,12 @@ export default function LandingPage({ clubName = 'Vallekas Basket' }: { clubName
         <CourtLines />
 
         <div className="lp-shell lp-hero-inner">
+          {/* Solo el nombre: los registros de academia lo traen ya con su sufijo
+              ("Vallekas Basket Academy"), y cualquier artículo delante duplicaba
+              la palabra o fallaba de género según el club. */}
           <p className="lp-tag">
             <span className="lp-tag-dot" />
-            La academia del {clubName}
+            {clubName}
           </p>
 
           <h1 className="lp-display">


### PR DESCRIPTION
Al parametrizar la landing por academia (#70), el eyebrow del hero quedaba así en los
dominios de academia, que es lo que son PRE y PROD:

> La academia del Vallekas Basket Academy

El registro de la academia trae el nombre comercial con su sufijo (`academy.name` =
"Vallekas Basket Academy") y el copy esperaba el nombre del club ("Vallekas Basket").

El eyebrow pasa a ser el nombre a secas. Funciona con cualquier academia sin depender
del artículo ni del género del nombre, y no toca datos ni schema. Las otras tres
interpolaciones del copy aguantan bien y se quedan como están.

Verificación: `tsc --noEmit` en verde, `vitest run` 102/102.
