### PR TITLE
feat(marketing): rediseña /nosotros y /precios con el sistema de la landing

### DIFF
--- a/apps/web/src/pages/marketing/AboutPage.tsx
+++ b/apps/web/src/pages/marketing/AboutPage.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { LP_SHARED_CSS, MERCH, SectionHead } from './LpSystem';
 
-// Datos de la página
+// ─── Datos de la página ────────────────────────────────────────────────────────
 
 // Creadores de VKB Academy. Sin iniciales ni color por fundador (el sistema
 // no usa avatares): solo nombre, rol y enlace a LinkedIn.
@@ -49,14 +49,14 @@ const WHY_POINTS = [
   'Para que tenga un tutor de IA disponible siempre que se atasque',
 ];
 
-// Página
+// ─── Página ────────────────────────────────────────────────────────────────────
 
 export default function AboutPage() {
   return (
     <div className="lp-page">
       <style>{LP_SHARED_CSS + CSS}</style>
 
-      {/* HERO */}
+      {/* ═══ HERO ═══ */}
       <section className="lp-block ab-hero">
         <div className="lp-shell ab-hero-inner">
           <h1 className="lp-display">
@@ -71,7 +71,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* 01 - HISTORIA */}
+      {/* ═══ 01 · HISTORIA ═══ */}
       <section className="lp-block lp-block-alt">
         <div className="lp-shell">
           <SectionHead
@@ -110,7 +110,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* 02 - MISION Y VALORES */}
+      {/* ═══ 02 · MISION Y VALORES ═══ */}
       <section className="lp-block">
         <div className="lp-shell">
           <SectionHead
@@ -131,7 +131,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* 03 - POR QUE VKB ACADEMY */}
+      {/* ═══ 03 · POR QUE VKB ACADEMY ═══ */}
       <section className="lp-block lp-block-alt">
         <div className="lp-shell">
           <SectionHead
@@ -156,7 +156,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* 04 - EQUIPO FUNDADOR */}
+      {/* ═══ 04 · EQUIPO FUNDADOR ═══ */}
       <section className="lp-block">
         <div className="lp-shell">
           <SectionHead
@@ -188,7 +188,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* 05 - RECOMPENSAS */}
+      {/* ═══ 05 · RECOMPENSAS ═══ */}
       <section className="lp-block lp-block-alt">
         <div className="lp-shell">
           <SectionHead
@@ -217,7 +217,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* CTA FINAL */}
+      {/* ═══ CTA FINAL ═══ */}
       <section className="lp-block ab-final">
         <div className="lp-shell ab-final-inner">
           <h2 className="lp-display">
@@ -229,7 +229,7 @@ export default function AboutPage() {
             Un adulto de la familia da de alta a cada alumno en el formulario de registro y
             recibe su usuario al terminar. La cuenta es del alumno.
           </p>
-          <div className="ab-cta-row">
+          <div className="lp-cta-row">
             <Link className="lp-btn lp-btn-primary lp-btn-lg" to="/register">
               Dar de alta a un alumno
             </Link>
@@ -243,10 +243,10 @@ export default function AboutPage() {
   );
 }
 
-// Estilos locales. Bloque mínimo con prefijo `ab-`: los halos del hero y del
-// cierre reutilizan los mismos radial-gradient rgba(245,145,30,α) de la
-// landing; el resto son envoltorios de espaciado que el sistema compartido
-// no cubre.
+// ─── Estilos ───────────────────────────────────────────────────────────────────
+// Bloque local mínimo con prefijo `ab-`: los halos del hero y del cierre
+// reutilizan los mismos radial-gradient rgba(245,145,30,α) de la landing; el
+// resto son envoltorios de espaciado que el sistema compartido no cubre.
 
 const CSS = `
 /* Halos */
@@ -279,12 +279,6 @@ const CSS = `
   flex-direction: column;
   align-items: flex-start;
   gap: 1.5rem;
-}
-
-.ab-cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
 }
 
 /* Historia: separación vertical entre los tres párrafos */

--- a/apps/web/src/pages/marketing/AboutPage.tsx
+++ b/apps/web/src/pages/marketing/AboutPage.tsx
@@ -148,10 +148,12 @@ export default function AboutPage() {
               ))}
             </ul>
 
-            <div>
-              <p className="ab-quote">"La tecnología al servicio del baloncesto de base."</p>
-              <p className="lp-note">Vallekas Basket, 2026</p>
-            </div>
+            <figure className="ab-quote-figure">
+              <blockquote className="ab-quote">
+                «La tecnología al servicio del baloncesto de base».
+              </blockquote>
+              <figcaption className="lp-note">Vallekas Basket, 2026</figcaption>
+            </figure>
           </div>
         </div>
       </section>
@@ -292,6 +294,11 @@ const CSS = `
 
 /* Cita de "Por qué VKB Academy": tamaño de .lp-manifesto-lead,
    sin caja, sin borde izquierdo, sin glow */
+
+/* figure y blockquote traen margen propio del navegador: se anula aquí */
+.ab-quote-figure {
+  margin: 0;
+}
 
 .ab-quote {
   margin: 0 0 1rem;

--- a/apps/web/src/pages/marketing/AboutPage.tsx
+++ b/apps/web/src/pages/marketing/AboutPage.tsx
@@ -1,46 +1,41 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { LP_SHARED_CSS, MERCH, SectionHead } from './LpSystem';
 
-// Creadores de VKB Academy
+// Datos de la página
+
+// Creadores de VKB Academy. Sin iniciales ni color por fundador (el sistema
+// no usa avatares): solo nombre, rol y enlace a LinkedIn.
 const FOUNDERS = [
   {
     name: 'Óscar Sánchez Rueda',
     role: 'Co-fundador & Tech Lead',
-    initials: 'OS',
-    color: '#ea580c',
     linkedin: 'https://www.linkedin.com/in/%C3%B3scar-s%C3%A1nchez-rueda-8573a4162/',
   },
   {
     name: 'Javier Sánchez Rueda',
     role: 'Co-fundador & Director Deportivo',
-    initials: 'JS',
-    color: '#6366f1',
     linkedin: 'https://www.linkedin.com/in/javier-s%C3%A1nchez-rueda-8a4117ba/',
   },
   {
     name: 'M. Houghton',
     role: 'Co-fundador',
-    initials: 'MH',
-    color: '#0891b2',
     linkedin: 'https://www.linkedin.com/in/mhoughtonl/',
   },
 ];
 
-// Valores del club
+// Valores del club, sin iconos
 const VALUES = [
   {
-    icon: '🎯',
     title: 'Excelencia deportiva',
     description:
       'Metodología avalada por técnicos federados, ahora también en formato digital para que tu hijo/a siga aprendiendo en casa.',
   },
   {
-    icon: '🤝',
     title: 'Familia y comunidad',
     description:
       'El barrio como base, la cancha como hogar y los padres como parte del equipo. VKB Academy mantiene ese vínculo.',
   },
   {
-    icon: '📚',
     title: 'Formación integral',
     description:
       'Combinamos el deporte con herramientas digitales fáciles de dar de alta, para que cada familia decida cuándo empieza su hijo/a.',
@@ -54,821 +49,272 @@ const WHY_POINTS = [
   'Para que tenga un tutor de IA disponible siempre que se atasque',
 ];
 
-// Merchandising del club
-const MERCH = [
-  { icon: '🎨', name: 'Pack de stickers VKB', pts: 100 },
-  { icon: '💧', name: 'Botella termo del club', pts: 200 },
-  { icon: '🧢', name: 'Gorra oficial VKB', pts: 350 },
-  { icon: '👕', name: 'Camiseta oficial del club', pts: 500 },
-  { icon: '🏀', name: 'Balón firmado por el equipo', pts: 1000 },
-];
+// Página
 
 export default function AboutPage() {
-  const navigate = useNavigate();
-
   return (
-    <div style={styles.page}>
-      {/* Overrides responsivos — no se pueden aplicar con inline styles */}
-      <style>{`
-        .about-hero { padding: 6rem 2rem 5rem; }
-        .about-story { padding: 6rem 2rem; }
-        @media (max-width: 768px) {
-          .about-hero { padding: 3rem 1.25rem !important; }
-          .about-story { padding: 3rem 1.25rem !important; }
-          .about-features { padding: 3rem 1.25rem !important; }
-        }
-      `}</style>
+    <div className="lp-page">
+      <style>{LP_SHARED_CSS + CSS}</style>
 
-      {/* ════════════════════════════════════════
-          SECCIÓN 1 — HERO
-      ════════════════════════════════════════ */}
-      <section className="about-hero" style={styles.hero}>
-        <div style={styles.heroGlow} />
-        <div style={styles.heroGlowBottom} />
-        <div style={styles.heroContent}>
-          <span style={styles.heroBadge}>🏀 Sobre nosotros</span>
-          <h1 style={styles.heroTitle}>
-            Vallekas Basket,{' '}
-            <span style={styles.heroTitleAccent}>un club para toda la familia</span>
+      {/* HERO */}
+      <section className="lp-block ab-hero">
+        <div className="lp-shell ab-hero-inner">
+          <h1 className="lp-display">
+            Vallekas Basket.
+            <br />
+            <em>Un club para toda la familia.</em>
           </h1>
-          <p style={styles.heroSubtitle}>
-            Más de 30 años formando jugadores y personas en Vallecas. VKB Academy es el paso digital
-            para que el aprendizaje no se quede solo en la cancha.
+          <p className="lp-lead">
+            Más de 30 años formando jugadores y personas en Vallecas. VKB Academy es el paso
+            digital para que el aprendizaje no se quede solo en la cancha.
           </p>
         </div>
       </section>
 
-      {/* ════════════════════════════════════════
-          SECCIÓN 2 — HISTORIA
-      ════════════════════════════════════════ */}
-      <section className="about-story" style={styles.storySection}>
-        <div style={styles.storyContent}>
-          <h2 style={styles.sectionTitle}>Nuestra historia</h2>
+      {/* 01 - HISTORIA */}
+      <section className="lp-block lp-block-alt">
+        <div className="lp-shell">
+          <SectionHead
+            index="01"
+            kicker="Nuestra historia"
+            title="Una canasta y un puñado de chavales."
+            accent="Así empezó todo."
+          />
 
-          <div style={styles.storyDivider} />
+          <div className="ab-story lp-reveal">
+            <p className="lp-lead">
+              Vallekas Basket nació en el corazón del barrio de Vallecas a principios de los años
+              90, fundado por un grupo de vecinos apasionados por el baloncesto que querían dar a
+              los jóvenes del barrio un espacio donde crecer, tanto dentro como fuera de la
+              cancha. Lo que comenzó con una sola canasta y un puñado de chavales se convirtió en
+              uno de los clubes de formación más activos del sur de Madrid.
+            </p>
 
-          <p style={styles.storyParagraph}>
-            Vallekas Basket nació en el corazón del barrio de Vallecas a principios de los años 90,
-            fundado por un grupo de vecinos apasionados por el baloncesto que querían dar a los
-            jóvenes del barrio un espacio donde crecer, tanto dentro como fuera de la cancha. Lo que
-            comenzó con una sola canasta y un puñado de chavales se convirtió en uno de los clubes
-            de formación más activos del sur de Madrid.
-          </p>
+            <p className="lp-text">
+              Hoy, el club cuenta con más de veinte equipos que abarcan todas las categorías,
+              desde los más pequeños en benjamín y alevín, pasando por infantil, cadete y junior,
+              hasta el equipo sénior que compite en ligas federadas de la Comunidad de Madrid.
+              Cada año, más de trescientos jugadores y jugadoras se forman con nosotros, guiados
+              por un cuerpo técnico comprometido con su desarrollo personal y deportivo.
+            </p>
 
-          <p style={styles.storyParagraph}>
-            Hoy, el club cuenta con más de veinte equipos que abarcan todas las categorías, desde
-            los más pequeños en benjamín y alevín, pasando por infantil, cadete y junior, hasta el
-            equipo sénior que compite en ligas federadas de la Comunidad de Madrid. Cada año, más de
-            trescientos jugadores y jugadoras se forman con nosotros, guiados por un cuerpo técnico
-            comprometido con su desarrollo personal y deportivo.
-          </p>
-
-          <p style={styles.storyParagraph}>
-            Con más de treinta años de historia, hemos aprendido que el deporte es una herramienta
-            poderosa para construir personas íntegras. Y que detrás de cada jugador hay una familia
-            que merece estar informada y sentirse parte del proceso. Por eso creamos VKB Academy:
-            para llevar la metodología del club a cualquier dispositivo y dar a padres y tutores las
-            herramientas para acompañar el crecimiento de sus hijos más allá de la cancha.
-          </p>
-        </div>
-      </section>
-
-      {/* ════════════════════════════════════════
-          SECCIÓN 3 — MISIÓN Y VALORES
-      ════════════════════════════════════════ */}
-      <section style={styles.valuesSection}>
-        <div style={styles.sectionContainer}>
-          <div style={styles.sectionHeader}>
-            <h2 style={styles.sectionTitleCentered}>Misión y valores</h2>
+            <p className="lp-text">
+              Con más de treinta años de historia, hemos aprendido que el deporte es una
+              herramienta poderosa para construir personas íntegras. Y que detrás de cada jugador
+              hay una familia que merece estar informada y sentirse parte del proceso. Por eso
+              creamos VKB Academy: para llevar la metodología del club a cualquier dispositivo,
+              para que cada familia pueda dar de alta a sus hijos en minutos y acompañar su
+              crecimiento más allá de la cancha.
+            </p>
           </div>
+        </div>
+      </section>
 
-          <div style={styles.valuesGrid}>
-            {VALUES.map((val, idx) => (
-              <ValueCard key={idx} {...val} />
+      {/* 02 - MISION Y VALORES */}
+      <section className="lp-block">
+        <div className="lp-shell">
+          <SectionHead
+            index="02"
+            kicker="Misión y valores"
+            title="Lo que enseñamos."
+            accent="Dentro y fuera de la cancha."
+          />
+
+          <div className="lp-grid-3 lp-reveal">
+            {VALUES.map((value) => (
+              <div key={value.title}>
+                <h3 className="lp-item-title">{value.title}</h3>
+                <p className="lp-text">{value.description}</p>
+              </div>
             ))}
           </div>
         </div>
       </section>
 
-      {/* ════════════════════════════════════════
-          SECCIÓN 4 — POR QUÉ VKB ACADEMY
-      ════════════════════════════════════════ */}
-      <section style={styles.whySection}>
-        <div style={styles.whyInner}>
-          {/* Columna izquierda — texto */}
-          <div style={styles.whyLeft}>
-            <h2 style={styles.whyTitle}>Por qué creamos VKB Academy</h2>
-            <ul style={styles.whyList}>
-              {WHY_POINTS.map((point, idx) => (
-                <li key={idx} style={styles.whyItem}>
-                  <span style={styles.whyCheck}>✅</span>
-                  <span style={styles.whyItemText}>{point}</span>
-                </li>
+      {/* 03 - POR QUE VKB ACADEMY */}
+      <section className="lp-block lp-block-alt">
+        <div className="lp-shell">
+          <SectionHead
+            index="03"
+            kicker="El porqué"
+            title="Por qué creamos"
+            accent="VKB Academy."
+          />
+
+          <div className="lp-split lp-reveal">
+            <ul className="lp-bullets">
+              {WHY_POINTS.map((point) => (
+                <li key={point}>{point}</li>
               ))}
             </ul>
-          </div>
 
-          {/* Columna derecha — cita destacada */}
-          <div style={styles.whyRight}>
-            <blockquote style={styles.quoteBox}>
-              <div style={styles.quoteGlow} />
-              <div style={styles.quoteAccent} />
-              <p style={styles.quoteText}>"La tecnología al servicio del baloncesto de base."</p>
-              <footer style={styles.quoteAuthor}>— Vallekas Basket, 2026</footer>
-            </blockquote>
+            <div>
+              <p className="ab-quote">"La tecnología al servicio del baloncesto de base."</p>
+              <p className="lp-note">Vallekas Basket, 2026</p>
+            </div>
           </div>
         </div>
       </section>
 
-      {/* ════════════════════════════════════════
-          SECCIÓN 5 — EL EQUIPO
-      ════════════════════════════════════════ */}
-      <section style={styles.teamSection}>
-        <div style={styles.sectionContainer}>
-          <div style={styles.sectionHeader}>
-            <h2 style={styles.sectionTitleCentered}>El equipo fundador</h2>
-            <p style={styles.teamSubtitle}>
-              Las personas que convirtieron una idea del barrio en una plataforma digital.
+      {/* 04 - EQUIPO FUNDADOR */}
+      <section className="lp-block">
+        <div className="lp-shell">
+          <SectionHead
+            index="04"
+            kicker="Quiénes somos"
+            title="Una idea del barrio."
+            accent="Tres personas detrás."
+          />
+
+          <ul className="lp-list lp-reveal">
+            {FOUNDERS.map((founder, i) => (
+              <li className="lp-list-row" key={founder.linkedin}>
+                <span className="lp-list-num">{String(i + 1).padStart(2, '0')}</span>
+                <h3 className="lp-list-title">{founder.name}</h3>
+                <div className="ab-founder-meta">
+                  <p className="lp-text">{founder.role}</p>
+                  <a
+                    className="lp-btn lp-btn-ghost lp-btn-inline"
+                    href={founder.linkedin}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    LinkedIn
+                  </a>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* 05 - RECOMPENSAS */}
+      <section className="lp-block lp-block-alt">
+        <div className="lp-shell">
+          <SectionHead
+            index="05"
+            kicker="Recompensas"
+            title="El esfuerzo tiene premio."
+            accent="Y se canjea en el club."
+          />
+
+          <div className="lp-reveal">
+            <table className="lp-table">
+              <tbody>
+                {MERCH.map((item) => (
+                  <tr key={item.name}>
+                    <th scope="row">{item.name}</th>
+                    <td>{item.pts.toLocaleString('es-ES')} pts</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="lp-table-note">
+              Los puntos se obtienen completando lecciones, módulos, exámenes y manteniendo la
+              racha semanal de estudio.
             </p>
           </div>
-          <div style={styles.teamGrid}>
-            {FOUNDERS.map((founder) => (
-              <FounderCard key={founder.linkedin} {...founder} />
-            ))}
-          </div>
         </div>
       </section>
 
-      {/* ════════════════════════════════════════
-          SECCIÓN 6 — MERCHANDISING
-      ════════════════════════════════════════ */}
-      <section style={styles.merchSection}>
-        <div style={styles.sectionContainer}>
-          <div style={styles.sectionHeader}>
-            <h2 style={styles.sectionTitleCentered}>🏆 El esfuerzo tiene premio</h2>
-            <p style={styles.merchSubtitle}>
-              Tu hijo/a acumula puntos completando lecciones y retos, y decide cuándo canjearlos por
-              merchandising exclusivo del club.
-            </p>
-          </div>
-          <div style={styles.merchGrid}>
-            {MERCH.map((item) => (
-              <MerchCard key={item.name} item={item} />
-            ))}
-          </div>
-          <p style={styles.merchNote}>
-            Los puntos se obtienen completando lecciones, módulos, exámenes y manteniendo la racha
-            semanal de estudio.
+      {/* CTA FINAL */}
+      <section className="lp-block ab-final">
+        <div className="lp-shell ab-final-inner">
+          <h2 className="lp-display">
+            ¿Formas parte del club?
+            <br />
+            <em>Empieza hoy.</em>
+          </h2>
+          <p className="lp-lead">
+            Un adulto de la familia da de alta a cada alumno en el formulario de registro y
+            recibe su usuario al terminar. La cuenta es del alumno.
           </p>
-        </div>
-      </section>
-
-      {/* ════════════════════════════════════════
-          SECCIÓN 7 — CTA FINAL
-      ════════════════════════════════════════ */}
-      <section style={styles.ctaSection}>
-        <div style={styles.ctaGlow} />
-        <div style={styles.ctaContent}>
-          <h2 style={styles.ctaTitle}>¿Formas parte del club?</h2>
-          <p style={styles.ctaSubtitle}>
-            Accede a VKB Academy con las credenciales que te ha proporcionado tu tutor o profesor.
-          </p>
-          <button
-            onClick={() => navigate('/login')}
-            style={styles.ctaButton}
-            onMouseEnter={(e) => {
-              const el = e.currentTarget as HTMLButtonElement;
-              el.style.transform = 'translateY(-3px)';
-              el.style.boxShadow = '0 16px 48px rgba(234,88,12,0.55)';
-              el.style.filter = 'brightness(1.08)';
-            }}
-            onMouseLeave={(e) => {
-              const el = e.currentTarget as HTMLButtonElement;
-              el.style.transform = 'translateY(0)';
-              el.style.boxShadow = '0 8px 32px rgba(234,88,12,0.4)';
-              el.style.filter = 'none';
-            }}
-          >
-            Acceder a la plataforma
-          </button>
+          <div className="ab-cta-row">
+            <Link className="lp-btn lp-btn-primary lp-btn-lg" to="/register">
+              Dar de alta a un alumno
+            </Link>
+            <Link className="lp-btn lp-btn-ghost" to="/login">
+              Ya tengo cuenta
+            </Link>
+          </div>
         </div>
       </section>
     </div>
   );
 }
 
-// ── Componente de tarjeta de fundador ──
-function FounderCard({
-  name,
-  role,
-  initials,
-  color,
-  linkedin,
-}: {
-  name: string;
-  role: string;
-  initials: string;
-  color: string;
-  linkedin: string;
-}) {
-  return (
-    <div
-      style={founderCardStyle.card}
-      onMouseEnter={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(-6px)';
-        el.style.boxShadow = '0 16px 48px rgba(234,88,12,0.18)';
-        el.style.borderColor = 'rgba(234,88,12,0.25)';
-      }}
-      onMouseLeave={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(0)';
-        el.style.boxShadow = '0 4px 24px rgba(0,0,0,0.08)';
-        el.style.borderColor = '#e2e8f0';
-      }}
-    >
-      {/* Avatar con anillo de gradiente */}
-      <div
-        style={{
-          padding: 3,
-          borderRadius: '50%',
-          background: `linear-gradient(135deg, ${color} 0%, ${color}99 100%)`,
-          boxShadow: `0 0 20px ${color}55`,
-          marginBottom: '0.5rem',
-        }}
-      >
-        <div style={{ ...founderCardStyle.avatar, background: color }}>{initials}</div>
-      </div>
+// Estilos locales. Bloque mínimo con prefijo `ab-`: los halos del hero y del
+// cierre reutilizan los mismos radial-gradient rgba(245,145,30,α) de la
+// landing; el resto son envoltorios de espaciado que el sistema compartido
+// no cubre.
 
-      {/* Nombre y rol */}
-      <h3 style={founderCardStyle.name}>{name}</h3>
-      <p style={founderCardStyle.role}>{role}</p>
+const CSS = `
+/* Halos */
 
-      {/* Botón LinkedIn */}
-      <a
-        href={linkedin}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={founderCardStyle.linkedinBtn}
-        onMouseEnter={(e) => {
-          (e.currentTarget as HTMLAnchorElement).style.background = '#0077b5';
-          (e.currentTarget as HTMLAnchorElement).style.color = '#fff';
-        }}
-        onMouseLeave={(e) => {
-          (e.currentTarget as HTMLAnchorElement).style.background = 'transparent';
-          (e.currentTarget as HTMLAnchorElement).style.color = '#0077b5';
-        }}
-      >
-        in LinkedIn
-      </a>
-    </div>
-  );
+.ab-hero {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 70% at 50% -20%, rgba(245, 145, 30, 0.18), transparent 62%),
+    var(--lp-bg);
 }
 
-const founderCardStyle: Record<string, React.CSSProperties> = {
-  card: {
-    background: '#ffffff',
-    border: '1.5px solid #e2e8f0',
-    borderRadius: 20,
-    padding: '2.25rem 2rem',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '0.75rem',
-    transition: 'transform 0.22s, box-shadow 0.22s, border-color 0.22s',
-    boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
-    flex: '1 1 240px',
-    textAlign: 'center',
-  },
-  avatar: {
-    width: 72,
-    height: 72,
-    borderRadius: '50%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: '1.5rem',
-    fontWeight: 800,
-    color: '#fff',
-    letterSpacing: '-0.02em',
-  },
-  name: {
-    fontSize: '1.0625rem',
-    fontWeight: 700,
-    color: '#0d1b2a',
-    margin: 0,
-  },
-  role: {
-    fontSize: '0.875rem',
-    color: '#64748b',
-    margin: 0,
-    lineHeight: 1.4,
-  },
-  linkedinBtn: {
-    marginTop: '0.5rem',
-    padding: '7px 18px',
-    borderRadius: 8,
-    border: '1.5px solid #0077b5',
-    background: 'transparent',
-    color: '#0077b5',
-    fontWeight: 700,
-    fontSize: '0.8rem',
-    cursor: 'pointer',
-    textDecoration: 'none',
-    letterSpacing: '0.01em',
-    transition: 'background 0.15s, color 0.15s',
-  },
-};
-
-// ── Componente de tarjeta de valor ──
-function ValueCard({
-  icon,
-  title,
-  description,
-}: {
-  icon: string;
-  title: string;
-  description: string;
-}) {
-  return (
-    <div
-      style={valueCardStyle.card}
-      onMouseEnter={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(-6px)';
-        el.style.boxShadow = '0 16px 48px rgba(234,88,12,0.18)';
-        el.style.borderColor = 'rgba(234,88,12,0.3)';
-      }}
-      onMouseLeave={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(0)';
-        el.style.boxShadow = '0 4px 24px rgba(0,0,0,0.08)';
-        el.style.borderColor = '#e2e8f0';
-      }}
-    >
-      <div style={valueCardStyle.iconWrap}>
-        <span style={valueCardStyle.icon}>{icon}</span>
-      </div>
-      <h3 style={valueCardStyle.title}>{title}</h3>
-      <p style={valueCardStyle.description}>{description}</p>
-    </div>
-  );
+.ab-hero-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(1.5rem, 4vw, 2rem);
 }
 
-const valueCardStyle: Record<string, React.CSSProperties> = {
-  card: {
-    background: '#ffffff',
-    border: '1.5px solid #e2e8f0',
-    borderRadius: 18,
-    padding: '2rem',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.75rem',
-    transition: 'transform 0.22s, box-shadow 0.22s, border-color 0.22s',
-    cursor: 'default',
-    boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
-    flex: '1 1 240px',
-  },
-  iconWrap: {
-    width: 52,
-    height: 52,
-    borderRadius: 14,
-    background: 'rgba(234,88,12,0.10)',
-    border: '1px solid rgba(234,88,12,0.2)',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  icon: {
-    fontSize: '1.75rem',
-    lineHeight: 1,
-  },
-  title: {
-    fontSize: '1.0625rem',
-    fontWeight: 700,
-    color: '#0d1b2a',
-    margin: 0,
-  },
-  description: {
-    fontSize: '0.9rem',
-    color: '#64748b',
-    lineHeight: 1.6,
-    margin: 0,
-  },
-};
-
-// ── Componente de tarjeta merch ──
-function MerchCard({ item }: { item: { icon: string; name: string; pts: number } }) {
-  return (
-    <div
-      style={merchCardStyle.card}
-      onMouseEnter={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(-5px)';
-        el.style.boxShadow = '0 12px 32px rgba(234,88,12,0.18)';
-        el.style.borderColor = 'rgba(234,88,12,0.3)';
-      }}
-      onMouseLeave={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(0)';
-        el.style.boxShadow = '0 2px 8px rgba(0,0,0,0.05)';
-        el.style.borderColor = '#e2e8f0';
-      }}
-    >
-      <span style={merchCardStyle.icon}>{item.icon}</span>
-      <span style={merchCardStyle.name}>{item.name}</span>
-      <span style={merchCardStyle.pts}>{item.pts.toLocaleString('es-ES')} pts</span>
-    </div>
-  );
+.ab-final {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(90% 70% at 50% 120%, rgba(245, 145, 30, 0.2), transparent 62%),
+    var(--lp-bg);
 }
 
-const merchCardStyle: Record<string, React.CSSProperties> = {
-  card: {
-    background: '#fff',
-    border: '1.5px solid #e2e8f0',
-    borderRadius: 16,
-    padding: '1.5rem 1.25rem',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '0.6rem',
-    minWidth: 148,
-    textAlign: 'center',
-    transition: 'transform 0.22s, box-shadow 0.22s, border-color 0.22s',
-    cursor: 'default',
-    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
-  },
-  icon: {
-    fontSize: '2.25rem',
-    lineHeight: 1,
-  },
-  name: {
-    fontSize: '0.825rem',
-    fontWeight: 600,
-    color: '#0d1b2a',
-    lineHeight: 1.3,
-  },
-  pts: {
-    fontSize: '0.8rem',
-    fontWeight: 700,
-    color: '#ea580c',
-    background: 'rgba(234,88,12,0.10)',
-    padding: '3px 12px',
-    borderRadius: 999,
-  },
-};
+.ab-final-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
 
-// ── Estilos principales ──
-const styles: Record<string, React.CSSProperties> = {
-  page: {
-    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-    overflowX: 'hidden',
-  },
+.ab-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
 
-  // Hero
-  hero: {
-    background: 'linear-gradient(135deg, #080e1a 0%, #0d1b2a 60%, #152233 100%)',
-    padding: '6rem 2rem 5rem',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'relative',
-    overflow: 'hidden',
-  },
-  heroGlow: {
-    position: 'absolute',
-    top: '-80px',
-    left: '50%',
-    transform: 'translateX(-50%)',
-    width: 700,
-    height: 700,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.16) 0%, transparent 65%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  heroGlowBottom: {
-    position: 'absolute',
-    bottom: '-100px',
-    right: '-80px',
-    width: 400,
-    height: 400,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.08) 0%, transparent 70%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  heroContent: {
-    maxWidth: '100%',
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    textAlign: 'center',
-    gap: '1.25rem',
-    position: 'relative',
-    zIndex: 1,
-  },
-  heroBadge: {
-    display: 'inline-block',
-    background: 'rgba(234,88,12,0.16)',
-    border: '1px solid rgba(234,88,12,0.45)',
-    color: '#fb923c',
-    borderRadius: 999,
-    padding: '0.45rem 1.2rem',
-    fontSize: '0.875rem',
-    fontWeight: 600,
-    letterSpacing: '0.02em',
-  },
-  heroTitle: {
-    fontSize: 'clamp(2rem, 4vw, 3.25rem)',
-    fontWeight: 900,
-    color: '#ffffff',
-    letterSpacing: '-0.03em',
-    lineHeight: 1.08,
-    margin: 0,
-  },
-  heroTitleAccent: {
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    WebkitBackgroundClip: 'text',
-    WebkitTextFillColor: 'transparent',
-    backgroundClip: 'text',
-  },
-  heroSubtitle: {
-    color: 'rgba(255,255,255,0.62)',
-    fontSize: '1.1rem',
-    lineHeight: 1.7,
-    maxWidth: 580,
-    margin: 0,
-  },
+/* Historia: separación vertical entre los tres párrafos */
 
-  // Historia
-  storySection: {
-    background: '#ffffff',
-    padding: '6rem 2rem',
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  storyContent: {
-    maxWidth: 800,
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1.5rem',
-  },
-  sectionTitle: {
-    fontSize: 'clamp(1.5rem, 3vw, 2.1rem)',
-    fontWeight: 800,
-    color: '#0d1b2a',
-    letterSpacing: '-0.025em',
-    margin: 0,
-  },
-  storyDivider: {
-    width: 52,
-    height: 4,
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    borderRadius: 2,
-  },
-  storyParagraph: {
-    fontSize: '1rem',
-    color: '#374151',
-    lineHeight: 1.8,
-    margin: 0,
-  },
+.ab-story {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: clamp(2rem, 5vw, 3rem);
+}
 
-  // Valores
-  valuesSection: {
-    background: '#f8fafc',
-    padding: '6rem 2rem',
-  },
-  sectionContainer: {
-    maxWidth: 1000,
-    margin: '0 auto',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '3rem',
-  },
-  sectionHeader: {
-    textAlign: 'center',
-  },
-  sectionTitleCentered: {
-    fontSize: 'clamp(1.5rem, 3vw, 2.1rem)',
-    fontWeight: 800,
-    color: '#0d1b2a',
-    letterSpacing: '-0.025em',
-    margin: 0,
-  },
-  valuesGrid: {
-    display: 'flex',
-    gap: '1.5rem',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-  },
+/* Cita de "Por qué VKB Academy": tamaño de .lp-manifesto-lead,
+   sin caja, sin borde izquierdo, sin glow */
 
-  // Por qué VKB Academy
-  whySection: {
-    background: '#ffffff',
-    padding: '6rem 2rem',
-  },
-  whyInner: {
-    maxWidth: 1000,
-    margin: '0 auto',
-    display: 'flex',
-    gap: '4rem',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-  },
-  whyLeft: {
-    flex: '1 1 320px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1.5rem',
-  },
-  whyTitle: {
-    fontSize: 'clamp(1.5rem, 3vw, 2.1rem)',
-    fontWeight: 800,
-    color: '#0d1b2a',
-    letterSpacing: '-0.025em',
-    margin: 0,
-  },
-  whyList: {
-    listStyle: 'none',
-    padding: 0,
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1rem',
-  },
-  whyItem: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    gap: '0.75rem',
-  },
-  whyCheck: {
-    fontSize: '1.1rem',
-    flexShrink: 0,
-    marginTop: '0.1rem',
-  },
-  whyItemText: {
-    fontSize: '1rem',
-    color: '#374151',
-    lineHeight: 1.6,
-  },
-  whyRight: {
-    flex: '1 1 280px',
-  },
-  quoteBox: {
-    background: 'linear-gradient(135deg, #080e1a 0%, #0d1b2a 60%, #152233 100%)',
-    borderRadius: 20,
-    padding: '2.75rem',
-    position: 'relative',
-    overflow: 'hidden',
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1rem',
-    boxShadow: '0 8px 32px rgba(8,14,26,0.25)',
-  },
-  quoteGlow: {
-    position: 'absolute',
-    top: -80,
-    right: -80,
-    width: 250,
-    height: 250,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.2) 0%, transparent 70%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  quoteAccent: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: 4,
-    background: 'linear-gradient(180deg, #ea580c 0%, #f97316 100%)',
-    borderRadius: '20px 0 0 20px',
-  },
-  quoteText: {
-    fontSize: '1.3rem',
-    fontWeight: 700,
-    color: '#ffffff',
-    lineHeight: 1.5,
-    margin: 0,
-    fontStyle: 'italic',
-    position: 'relative',
-    zIndex: 1,
-  },
-  quoteAuthor: {
-    fontSize: '0.85rem',
-    color: 'rgba(255,255,255,0.42)',
-    margin: 0,
-    fontStyle: 'normal',
-    position: 'relative',
-    zIndex: 1,
-  },
+.ab-quote {
+  margin: 0 0 1rem;
+  font-family: var(--lp-display);
+  font-size: clamp(1.375rem, 3.4vw, 2.125rem);
+  font-weight: 600;
+  line-height: 1.22;
+  letter-spacing: -0.02em;
+  color: var(--lp-fg);
+}
 
-  // Equipo fundador
-  teamSection: {
-    background: '#f8fafc',
-    padding: '6rem 2rem',
-  },
-  teamSubtitle: {
-    color: '#64748b',
-    fontSize: '1rem',
-    margin: '0.75rem auto 0',
-    maxWidth: 480,
-    lineHeight: 1.6,
-    textAlign: 'center' as const,
-  },
-  teamGrid: {
-    display: 'flex',
-    gap: '1.5rem',
-    flexWrap: 'wrap' as const,
-    justifyContent: 'center',
-  },
+/* Equipo fundador: rol + enlace de LinkedIn en la misma celda de la fila */
 
-  // Merchandising
-  merchSection: {
-    background: '#fff',
-    padding: '6rem 2rem',
-  },
-  merchSubtitle: {
-    color: '#64748b',
-    fontSize: '1rem',
-    margin: '0.75rem auto 0',
-    maxWidth: 520,
-    lineHeight: 1.6,
-    textAlign: 'center' as const,
-  },
-  merchGrid: {
-    display: 'flex',
-    gap: '1rem',
-    flexWrap: 'wrap' as const,
-    justifyContent: 'center',
-  },
-  merchNote: {
-    textAlign: 'center' as const,
-    fontSize: '0.825rem',
-    color: '#94a3b8',
-    margin: '0.5rem auto 0',
-    maxWidth: 480,
-    lineHeight: 1.5,
-  },
-
-  // CTA final
-  ctaSection: {
-    background: 'linear-gradient(135deg, #080e1a 0%, #0d1b2a 60%, #152233 100%)',
-    padding: '7rem 2rem',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'relative',
-    overflow: 'hidden',
-  },
-  ctaGlow: {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    width: 600,
-    height: 600,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.14) 0%, transparent 65%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  ctaContent: {
-    maxWidth: 600,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    textAlign: 'center',
-    gap: '1.5rem',
-    position: 'relative',
-    zIndex: 1,
-  },
-  ctaTitle: {
-    fontSize: 'clamp(1.75rem, 4vw, 2.75rem)',
-    fontWeight: 900,
-    color: '#ffffff',
-    letterSpacing: '-0.025em',
-    margin: 0,
-    lineHeight: 1.12,
-  },
-  ctaSubtitle: {
-    color: 'rgba(255,255,255,0.6)',
-    fontSize: '1.0625rem',
-    margin: 0,
-    lineHeight: 1.6,
-  },
-  ctaButton: {
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    color: '#ffffff',
-    border: 'none',
-    borderRadius: 12,
-    padding: '17px 40px',
-    fontSize: '1.0625rem',
-    fontWeight: 700,
-    cursor: 'pointer',
-    transition: 'transform 0.2s, box-shadow 0.2s, filter 0.2s',
-    boxShadow: '0 8px 32px rgba(234,88,12,0.4)',
-    letterSpacing: '-0.01em',
-  },
-};
+.ab-founder-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+`;

--- a/apps/web/src/pages/marketing/LandingPage.tsx
+++ b/apps/web/src/pages/marketing/LandingPage.tsx
@@ -611,12 +611,6 @@ const CSS = `
   align-items: flex-start;
 }
 
-.lp-cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
 /* Marcador: única aparición del ámbar, reservado a cifras */
 .lp-scoreboard {
   display: grid;

--- a/apps/web/src/pages/marketing/LandingPage.tsx
+++ b/apps/web/src/pages/marketing/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { LP_SHARED_CSS, SectionHead } from './LpSystem';
 
 // ── Datos de la página ────────────────────────────────────────────────────────
 
@@ -137,7 +138,7 @@ const FAMILY = [
 export default function LandingPage({ clubName = 'Vallekas Basket' }: { clubName?: string }) {
   return (
     <div className="lp-page">
-      <style>{CSS}</style>
+      <style>{LP_SHARED_CSS + CSS}</style>
 
       {/* ═══ HERO ═══ */}
       <section className="lp-hero">
@@ -424,34 +425,6 @@ export default function LandingPage({ clubName = 'Vallekas Basket' }: { clubName
 
 // ── Piezas ────────────────────────────────────────────────────────────────────
 
-// Título en dos tiempos: la primera frase en blanco, la segunda en naranja.
-function SectionHead({
-  index,
-  kicker,
-  title,
-  accent,
-}: {
-  index: string;
-  kicker: string;
-  title: string;
-  accent: string;
-}) {
-  return (
-    <header className="lp-head">
-      <p className="lp-head-kicker">
-        <span className="lp-head-index" aria-hidden="true">
-          {index}
-        </span>
-        {kicker}
-      </p>
-      <h2 className="lp-head-title">
-        {title}
-        <em>{accent}</em>
-      </h2>
-    </header>
-  );
-}
-
 /**
  * Media cancha FIBA a escala real. El viewBox son centímetros: 1500 de ancho
  * (15 m) por 1400 de largo (media pista de 28 m), con la línea de fondo abajo.
@@ -570,141 +543,10 @@ function GenerationMock() {
 
 const CSS = `
 .lp-page {
-  --lp-bg: #070d18;
-  --lp-bg-alt: #0a1322;
-  --lp-surface: rgba(255, 255, 255, 0.03);
-  --lp-rule: rgba(255, 255, 255, 0.1);
-  --lp-rule-soft: rgba(255, 255, 255, 0.07);
-  --lp-fg: #ffffff;
-  --lp-fg-mid: rgba(255, 255, 255, 0.74);
-  --lp-fg-low: rgba(255, 255, 255, 0.56);
-  --lp-display: 'Gabarito', 'Unbounded', var(--font-sans);
-  --lp-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
   /* El SplashScreen tapa la landing 3,6 s (sale a los 2,8 s). La entrada del
      hero arranca a los 3,2 s para encadenar con esa salida en vez de aparecer
      de golpe. Si algún día se retira el splash, hay que bajar este valor a 0. */
   --lp-enter: 3200ms;
-
-  /* clip recorta sin crear contenedor de scroll; hidden sí lo crea y eso deja
-     sin scroller de referencia a las animaciones view(). El hidden queda como
-     respaldo para navegadores sin soporte de clip. */
-  overflow-x: hidden;
-  overflow-x: clip;
-  background: var(--lp-bg);
-  color: var(--lp-fg);
-  font-family: var(--font-sans);
-}
-
-.lp-page img,
-.lp-page svg {
-  max-width: 100%;
-}
-
-.lp-page :focus-visible {
-  outline: 3px solid var(--brand);
-  outline-offset: 3px;
-}
-
-.lp-shell {
-  width: min(1200px, 100% - 2.5rem);
-  margin-inline: auto;
-}
-
-/* ── Tipografía ── */
-
-.lp-display {
-  margin: 0;
-  font-family: var(--lp-display);
-  font-weight: 800;
-  font-size: clamp(2.25rem, 5.6vw, 4.25rem);
-  line-height: 1.02;
-  letter-spacing: -0.025em;
-  color: var(--lp-fg);
-}
-
-.lp-display em {
-  font-style: normal;
-  color: var(--brand);
-}
-
-.lp-lead {
-  margin: 0;
-  font-size: clamp(1rem, 2.2vw, 1.125rem);
-  line-height: 1.62;
-  color: var(--lp-fg-mid);
-  max-width: 44ch;
-}
-
-.lp-text {
-  margin: 0;
-  font-size: 0.9375rem;
-  line-height: 1.65;
-  color: var(--lp-fg-mid);
-  max-width: 52ch;
-}
-
-.lp-note {
-  margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.5;
-  color: var(--lp-fg-low);
-  max-width: 38ch;
-}
-
-/* ── Botones ── */
-
-.lp-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 52px;
-  padding: 0 1.85rem;
-  border: none;
-  border-radius: 999px;
-  font-family: var(--lp-display);
-  font-size: 1rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.lp-btn-primary {
-  background: var(--brand);
-  color: var(--brand-contrast);
-}
-
-.lp-btn-primary:hover {
-  background: var(--brand-light);
-}
-
-.lp-btn-ghost {
-  background: transparent;
-  color: var(--lp-fg);
-  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.26);
-}
-
-.lp-btn-ghost:hover {
-  box-shadow: inset 0 0 0 1.5px var(--brand);
-  color: var(--brand);
-}
-
-.lp-btn-full {
-  width: 100%;
-}
-
-.lp-btn-lg {
-  min-height: 60px;
-  padding: 0 2.5rem;
-  font-size: 1.0625rem;
-}
-
-/* CTA que acompaña a un párrafo, sin robarle el protagonismo al principal */
-.lp-btn-inline {
-  align-self: flex-start;
-  min-height: 46px;
-  padding: 0 1.4rem;
-  font-size: 0.9375rem;
 }
 
 /* ── Líneas de cancha ── */
@@ -902,62 +744,6 @@ const CSS = `
   color: var(--lp-fg-low);
 }
 
-/* ── Encabezado de sección ── */
-
-.lp-head {
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--lp-rule);
-}
-
-.lp-head-kicker {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-  margin: 0 0 0.7rem;
-  font-family: var(--lp-display);
-  font-size: clamp(1rem, 2.2vw, 1.25rem);
-  font-weight: 600;
-  letter-spacing: -0.015em;
-  color: var(--lp-fg-mid);
-}
-
-.lp-head-index {
-  font-family: var(--lp-display);
-  font-size: clamp(1rem, 2.2vw, 1.25rem);
-  font-weight: 800;
-  color: var(--brand);
-  font-variant-numeric: tabular-nums;
-}
-
-.lp-head-title {
-  margin: 0;
-  font-family: var(--lp-display);
-  font-weight: 800;
-  font-size: clamp(1.875rem, 4.6vw, 3.25rem);
-  line-height: 1.05;
-  letter-spacing: -0.025em;
-  color: var(--lp-fg);
-}
-
-/* La segunda frase siempre en línea propia: el titular es una sentencia
-   en dos tiempos, no un párrafo que se parte donde caiga */
-.lp-head-title em {
-  display: block;
-  font-style: normal;
-  color: var(--brand);
-}
-
-/* ── Bloques ── */
-
-.lp-block {
-  padding: clamp(3rem, 8vw, 5.5rem) 0;
-  background: var(--lp-bg);
-}
-
-.lp-block-alt {
-  background: var(--lp-bg-alt);
-}
-
 /* ── Manifiesto ── */
 
 .lp-manifesto-grid {
@@ -1000,44 +786,6 @@ const CSS = `
   font-weight: 700;
   letter-spacing: -0.015em;
   color: var(--brand);
-}
-
-/* ── Proceso ── */
-
-.lp-steps {
-  display: grid;
-  gap: 0;
-  margin: clamp(2rem, 5vw, 3rem) 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.lp-step {
-  padding: 1.5rem 0;
-  border-bottom: 1px solid var(--lp-rule-soft);
-}
-
-.lp-step:first-child {
-  border-top: 1px solid var(--lp-rule-soft);
-}
-
-.lp-step-num {
-  display: block;
-  font-family: var(--lp-display);
-  font-size: 1.25rem;
-  font-weight: 800;
-  line-height: 1;
-  letter-spacing: -0.02em;
-  color: var(--brand);
-}
-
-.lp-step-title {
-  margin: 0.6rem 0 0.45rem;
-  font-family: var(--lp-display);
-  font-size: 1.25rem;
-  font-weight: 700;
-  letter-spacing: -0.015em;
-  color: var(--lp-fg);
 }
 
 /* ── Producto ── */
@@ -1161,83 +909,6 @@ const CSS = `
   max-width: 46ch;
 }
 
-/* ── Lista de prestaciones ── */
-
-.lp-list {
-  margin: clamp(2rem, 5vw, 3rem) 0 0;
-  padding: 0;
-  list-style: none;
-  border-top: 1px solid var(--lp-rule-soft);
-}
-
-.lp-list-row {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.35rem 1rem;
-  padding: 1.35rem 0;
-  border-bottom: 1px solid var(--lp-rule-soft);
-}
-
-.lp-list-num {
-  grid-row: span 2;
-  font-family: var(--lp-display);
-  font-size: 1rem;
-  font-weight: 800;
-  line-height: 1.5;
-  color: var(--brand);
-  font-variant-numeric: tabular-nums;
-}
-
-.lp-list-title {
-  margin: 0;
-  font-family: var(--lp-display);
-  font-size: 1.125rem;
-  font-weight: 700;
-  letter-spacing: -0.015em;
-  color: var(--lp-fg);
-}
-
-/* ── Recompensas ── */
-
-.lp-table {
-  width: 100%;
-  margin-top: clamp(2rem, 5vw, 3rem);
-  border-collapse: collapse;
-}
-
-.lp-table th {
-  padding: 1rem 0;
-  text-align: left;
-  font-size: 1rem;
-  font-weight: 500;
-  color: var(--lp-fg-mid);
-  border-bottom: 1px solid var(--lp-rule-soft);
-}
-
-.lp-table tr:first-child th,
-.lp-table tr:first-child td {
-  border-top: 1px solid var(--lp-rule-soft);
-}
-
-.lp-table td {
-  padding: 1rem 0;
-  text-align: right;
-  font-family: var(--lp-display);
-  font-size: 1.25rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--amber-led);
-  font-variant-numeric: tabular-nums;
-  border-bottom: 1px solid var(--lp-rule-soft);
-  white-space: nowrap;
-}
-
-.lp-table-note {
-  margin: 1.1rem 0 0;
-  font-size: 0.8125rem;
-  color: var(--lp-fg-low);
-}
-
 /* ── Familias ── */
 
 .lp-family {
@@ -1261,98 +932,6 @@ const CSS = `
   display: grid;
   gap: 1.25rem;
   margin-top: clamp(2.25rem, 5vw, 3.25rem);
-}
-
-.lp-plan {
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
-  padding: 1.85rem 1.6rem;
-  border: 1px solid var(--lp-rule);
-  border-radius: 18px;
-  background: var(--lp-surface);
-}
-
-.lp-plan-featured {
-  border-color: var(--brand);
-  background: rgba(245, 145, 30, 0.07);
-}
-
-.lp-plan-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.lp-plan-name {
-  font-family: var(--lp-display);
-  font-size: 1.0625rem;
-  font-weight: 700;
-  letter-spacing: -0.015em;
-  color: var(--lp-fg);
-}
-
-.lp-plan-badge {
-  padding: 0.3rem 0.8rem;
-  border-radius: 999px;
-  background: var(--brand);
-  color: var(--brand-contrast);
-  font-size: 0.6875rem;
-  font-weight: 700;
-}
-
-.lp-plan-price {
-  display: flex;
-  align-items: baseline;
-  gap: 0.45rem;
-  margin: 0;
-  padding-bottom: 1.1rem;
-  border-bottom: 1px solid var(--lp-rule-soft);
-}
-
-.lp-plan-amount {
-  font-family: var(--lp-display);
-  font-size: clamp(3rem, 8vw, 3.75rem);
-  font-weight: 800;
-  line-height: 0.95;
-  letter-spacing: -0.04em;
-  color: var(--lp-fg);
-}
-
-.lp-plan-unit {
-  font-size: 0.9375rem;
-  font-weight: 500;
-  color: var(--lp-fg-low);
-}
-
-.lp-plan-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  font-size: 0.9375rem;
-  line-height: 1.5;
-  color: var(--lp-fg-mid);
-  flex: 1;
-}
-
-.lp-plan-list li {
-  position: relative;
-  padding-left: 1.1rem;
-}
-
-.lp-plan-list li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0.5em;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--brand);
 }
 
 /* ── Cierre ── */
@@ -1379,36 +958,11 @@ const CSS = `
   font-size: clamp(2.75rem, 8vw, 6rem);
 }
 
-/* ── Estructura a partir de tablet ── */
-
 @media (min-width: 700px) {
-  .lp-steps {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 0 2.5rem;
-    border-top: 1px solid var(--lp-rule-soft);
-  }
-
-  .lp-step,
-  .lp-step:first-child {
-    border-top: none;
-    border-bottom: none;
-    padding: 1.75rem 0 0;
-  }
-
   .lp-family,
   .lp-pillars {
     grid-template-columns: repeat(3, 1fr);
     gap: 2.5rem;
-  }
-
-  .lp-list-row {
-    grid-template-columns: auto 1fr 1.4fr;
-    align-items: baseline;
-    gap: 1.5rem;
-  }
-
-  .lp-list-num {
-    grid-row: auto;
   }
 
   .lp-plans {
@@ -1432,10 +986,6 @@ const CSS = `
     align-items: start;
     gap: 4rem;
   }
-
-  .lp-plan {
-    padding: 2.25rem 2rem;
-  }
 }
 
 /* ══════════════════════════════════════════════════════════════════
@@ -1444,17 +994,6 @@ const CSS = `
    2. Revelado por scroll: scroll-driven, sin JS ni observers.
    3. Feedback: solo en lo que de verdad es interactivo.
    ══════════════════════════════════════════════════════════════════ */
-
-@keyframes lp-rise {
-  from {
-    opacity: 0;
-    transform: translateY(18px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 
 @keyframes lp-caret {
   50% {
@@ -1508,21 +1047,8 @@ const CSS = `
 
 /* 3 · Feedback. El movimiento de hover solo con ratón; el de pulsación
    también en táctil, que ahí es donde más se agradece. */
-.lp-btn {
-  transition:
-    background-color 150ms ease,
-    color 150ms ease,
-    box-shadow 150ms ease,
-    transform 100ms var(--lp-ease-out);
-}
-
-.lp-btn:active {
-  transform: scale(0.97);
-}
-
 @media (hover: hover) and (pointer: fine) {
-  .lp-mock-option,
-  .lp-plan {
+  .lp-mock-option {
     transition: border-color 150ms ease;
   }
 }
@@ -1538,10 +1064,6 @@ const CSS = `
 }
 
 @media (max-width: 420px) {
-  .lp-btn {
-    width: 100%;
-  }
-
   .lp-scoreboard {
     grid-template-columns: 1fr;
   }

--- a/apps/web/src/pages/marketing/LpSystem.tsx
+++ b/apps/web/src/pages/marketing/LpSystem.tsx
@@ -183,6 +183,15 @@ export const LP_SHARED_CSS = `
   font-size: 0.9375rem;
 }
 
+/* Fila de botones CTA (primario + ghost). Estaba duplicada carácter a
+   carácter como .lp-cta-row/.ab-cta-row/.pr-cta-row en las tres páginas;
+   vive aquí una sola vez. */
+.lp-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 /* ── Encabezado de sección ── */
 
 .lp-head {
@@ -531,7 +540,7 @@ export const LP_SHARED_CSS = `
   }
 }
 
-/* Trío de ítems: 1 col → 3 col en 700px (equivale a .lp-pillars/.lp-family de la landing) */
+/* Trío de ítems: de 1 columna a 3 en 700px (equivale a .lp-pillars/.lp-family de la landing) */
 .lp-grid-3 {
   display: grid;
   gap: 1.5rem;

--- a/apps/web/src/pages/marketing/LpSystem.tsx
+++ b/apps/web/src/pages/marketing/LpSystem.tsx
@@ -1,0 +1,601 @@
+// Sistema visual `lp-*` compartido por las páginas de marketing (landing,
+// /nosotros, /precios). El CSS genérico y el encabezado de sección vivían
+// hasta ahora duplicados en cada página; este módulo los centraliza. Cada
+// página los consume con `<style>{LP_SHARED_CSS + CSS}</style>` (compartido
+// primero, CSS local después) dentro de un `<div className="lp-page">`.
+
+// ── Encabezado de sección ────────────────────────────────────────────────────
+// Título en dos tiempos: la primera frase en blanco, la segunda en naranja.
+export function SectionHead({
+  index,
+  kicker,
+  title,
+  accent,
+}: {
+  index: string;
+  kicker: string;
+  title: string;
+  accent: string;
+}) {
+  return (
+    <header className="lp-head">
+      <p className="lp-head-kicker">
+        <span className="lp-head-index" aria-hidden="true">
+          {index}
+        </span>
+        {kicker}
+      </p>
+      <h2 className="lp-head-title">
+        {title}
+        <em>{accent}</em>
+      </h2>
+    </header>
+  );
+}
+
+// ── Catálogo de canje ────────────────────────────────────────────────────────
+// Mismos ítems y puntos que la tabla de merchandising del club, sin emojis.
+// La landing conserva su propia copia local (no se toca su markup); About y
+// Pricing consumen esta.
+export const MERCH: { name: string; pts: number }[] = [
+  { name: 'Pack de stickers VKB', pts: 100 },
+  { name: 'Botella termo del club', pts: 200 },
+  { name: 'Gorra oficial VKB', pts: 350 },
+  { name: 'Camiseta oficial del club', pts: 500 },
+  { name: 'Balón firmado por el equipo', pts: 1000 },
+];
+
+// ── CSS genérico del sistema ──────────────────────────────────────────────────
+// Copiado literal desde el CSS de LandingPage.tsx (sin --lp-enter, que sigue
+// siendo local a la landing). Las primitivas nuevas van al final, separadas.
+export const LP_SHARED_CSS = `
+.lp-page {
+  --lp-bg: #070d18;
+  --lp-bg-alt: #0a1322;
+  --lp-surface: rgba(255, 255, 255, 0.03);
+  --lp-rule: rgba(255, 255, 255, 0.1);
+  --lp-rule-soft: rgba(255, 255, 255, 0.07);
+  --lp-fg: #ffffff;
+  --lp-fg-mid: rgba(255, 255, 255, 0.74);
+  --lp-fg-low: rgba(255, 255, 255, 0.56);
+  --lp-display: 'Gabarito', 'Unbounded', var(--font-sans);
+  --lp-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+
+  /* clip recorta sin crear contenedor de scroll; hidden sí lo crea y eso deja
+     sin scroller de referencia a las animaciones view(). El hidden queda como
+     respaldo para navegadores sin soporte de clip. */
+  overflow-x: hidden;
+  overflow-x: clip;
+  background: var(--lp-bg);
+  color: var(--lp-fg);
+  font-family: var(--font-sans);
+}
+
+.lp-page img,
+.lp-page svg {
+  max-width: 100%;
+}
+
+.lp-page :focus-visible {
+  outline: 3px solid var(--brand);
+  outline-offset: 3px;
+}
+
+.lp-shell {
+  width: min(1200px, 100% - 2.5rem);
+  margin-inline: auto;
+}
+
+/* ── Tipografía ── */
+
+.lp-display {
+  margin: 0;
+  font-family: var(--lp-display);
+  font-weight: 800;
+  font-size: clamp(2.25rem, 5.6vw, 4.25rem);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  color: var(--lp-fg);
+}
+
+.lp-display em {
+  font-style: normal;
+  color: var(--brand);
+}
+
+.lp-lead {
+  margin: 0;
+  font-size: clamp(1rem, 2.2vw, 1.125rem);
+  line-height: 1.62;
+  color: var(--lp-fg-mid);
+  max-width: 44ch;
+}
+
+.lp-text {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--lp-fg-mid);
+  max-width: 52ch;
+}
+
+.lp-note {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--lp-fg-low);
+  max-width: 38ch;
+}
+
+/* ── Botones ── */
+
+.lp-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 52px;
+  padding: 0 1.85rem;
+  border: none;
+  border-radius: 999px;
+  font-family: var(--lp-display);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.lp-btn-primary {
+  background: var(--brand);
+  color: var(--brand-contrast);
+}
+
+.lp-btn-primary:hover {
+  background: var(--brand-light);
+}
+
+.lp-btn-ghost {
+  background: transparent;
+  color: var(--lp-fg);
+  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.26);
+}
+
+.lp-btn-ghost:hover {
+  box-shadow: inset 0 0 0 1.5px var(--brand);
+  color: var(--brand);
+}
+
+.lp-btn-full {
+  width: 100%;
+}
+
+.lp-btn-lg {
+  min-height: 60px;
+  padding: 0 2.5rem;
+  font-size: 1.0625rem;
+}
+
+/* CTA que acompaña a un párrafo, sin robarle el protagonismo al principal */
+.lp-btn-inline {
+  align-self: flex-start;
+  min-height: 46px;
+  padding: 0 1.4rem;
+  font-size: 0.9375rem;
+}
+
+/* ── Encabezado de sección ── */
+
+.lp-head {
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--lp-rule);
+}
+
+.lp-head-kicker {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin: 0 0 0.7rem;
+  font-family: var(--lp-display);
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--lp-fg-mid);
+}
+
+.lp-head-index {
+  font-family: var(--lp-display);
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  font-weight: 800;
+  color: var(--brand);
+  font-variant-numeric: tabular-nums;
+}
+
+.lp-head-title {
+  margin: 0;
+  font-family: var(--lp-display);
+  font-weight: 800;
+  font-size: clamp(1.875rem, 4.6vw, 3.25rem);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--lp-fg);
+}
+
+/* La segunda frase siempre en línea propia: el titular es una sentencia
+   en dos tiempos, no un párrafo que se parte donde caiga */
+.lp-head-title em {
+  display: block;
+  font-style: normal;
+  color: var(--brand);
+}
+
+/* ── Bloques ── */
+
+.lp-block {
+  padding: clamp(3rem, 8vw, 5.5rem) 0;
+  background: var(--lp-bg);
+}
+
+.lp-block-alt {
+  background: var(--lp-bg-alt);
+}
+
+/* ── Proceso ── */
+
+.lp-steps {
+  display: grid;
+  gap: 0;
+  margin: clamp(2rem, 5vw, 3rem) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lp-step {
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--lp-rule-soft);
+}
+
+.lp-step:first-child {
+  border-top: 1px solid var(--lp-rule-soft);
+}
+
+.lp-step-num {
+  display: block;
+  font-family: var(--lp-display);
+  font-size: 1.25rem;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--brand);
+}
+
+.lp-step-title {
+  margin: 0.6rem 0 0.45rem;
+  font-family: var(--lp-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--lp-fg);
+}
+
+/* ── Lista de prestaciones ── */
+
+.lp-list {
+  margin: clamp(2rem, 5vw, 3rem) 0 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--lp-rule-soft);
+}
+
+.lp-list-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem 1rem;
+  padding: 1.35rem 0;
+  border-bottom: 1px solid var(--lp-rule-soft);
+}
+
+.lp-list-num {
+  grid-row: span 2;
+  font-family: var(--lp-display);
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1.5;
+  color: var(--brand);
+  font-variant-numeric: tabular-nums;
+}
+
+.lp-list-title {
+  margin: 0;
+  font-family: var(--lp-display);
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--lp-fg);
+}
+
+/* ── Recompensas ── */
+
+.lp-table {
+  width: 100%;
+  margin-top: clamp(2rem, 5vw, 3rem);
+  border-collapse: collapse;
+}
+
+.lp-table th {
+  padding: 1rem 0;
+  text-align: left;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--lp-fg-mid);
+  border-bottom: 1px solid var(--lp-rule-soft);
+}
+
+.lp-table tr:first-child th,
+.lp-table tr:first-child td {
+  border-top: 1px solid var(--lp-rule-soft);
+}
+
+.lp-table td {
+  padding: 1rem 0;
+  text-align: right;
+  font-family: var(--lp-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--amber-led);
+  font-variant-numeric: tabular-nums;
+  border-bottom: 1px solid var(--lp-rule-soft);
+  white-space: nowrap;
+}
+
+.lp-table-note {
+  margin: 1.1rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--lp-fg-low);
+}
+
+.lp-plan {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  padding: 1.85rem 1.6rem;
+  border: 1px solid var(--lp-rule);
+  border-radius: 18px;
+  background: var(--lp-surface);
+}
+
+.lp-plan-featured {
+  border-color: var(--brand);
+  background: rgba(245, 145, 30, 0.07);
+}
+
+.lp-plan-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.lp-plan-name {
+  font-family: var(--lp-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--lp-fg);
+}
+
+.lp-plan-badge {
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: var(--brand);
+  color: var(--brand-contrast);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.lp-plan-price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  margin: 0;
+  padding-bottom: 1.1rem;
+  border-bottom: 1px solid var(--lp-rule-soft);
+}
+
+.lp-plan-amount {
+  font-family: var(--lp-display);
+  font-size: clamp(3rem, 8vw, 3.75rem);
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  color: var(--lp-fg);
+}
+
+.lp-plan-unit {
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--lp-fg-low);
+}
+
+.lp-plan-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--lp-fg-mid);
+  flex: 1;
+}
+
+.lp-plan-list li {
+  position: relative;
+  padding-left: 1.1rem;
+}
+
+.lp-plan-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.5em;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+}
+
+/* ── Estructura a partir de tablet ── */
+
+@media (min-width: 700px) {
+  .lp-steps {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0 2.5rem;
+    border-top: 1px solid var(--lp-rule-soft);
+  }
+
+  .lp-step,
+  .lp-step:first-child {
+    border-top: none;
+    border-bottom: none;
+    padding: 1.75rem 0 0;
+  }
+
+  .lp-list-row {
+    grid-template-columns: auto 1fr 1.4fr;
+    align-items: baseline;
+    gap: 1.5rem;
+  }
+
+  .lp-list-num {
+    grid-row: auto;
+  }
+}
+
+@media (min-width: 960px) {
+  .lp-plan {
+    padding: 2.25rem 2rem;
+  }
+}
+
+@keyframes lp-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.lp-btn {
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease,
+    transform 100ms var(--lp-ease-out);
+}
+
+.lp-btn:active {
+  transform: scale(0.97);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .lp-plan {
+    transition: border-color 150ms ease;
+  }
+}
+
+@media (max-width: 420px) {
+  .lp-btn {
+    width: 100%;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   PRIMITIVAS NUEVAS — no existen en la landing original. Las usan
+   About y Pricing (P2/P3) para montar secciones con el sistema lp-*
+   sin reinventar revelado por scroll, grids ni listas de bullets.
+   ══════════════════════════════════════════════════════════════════ */
+
+/* Revelado por scroll genérico: mismas curvas que la landing, opt-in por clase */
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .lp-reveal {
+      animation: lp-rise linear both;
+      animation-timeline: view();
+      animation-range: entry 8% cover 24%;
+    }
+  }
+}
+
+/* Trío de ítems: 1 col → 3 col en 700px (equivale a .lp-pillars/.lp-family de la landing) */
+.lp-grid-3 {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: clamp(2rem, 5vw, 3rem);
+}
+
+/* Dos columnas asimétricas en 960px (equivale a .lp-hero-grid/.lp-showcase-grid) */
+.lp-split {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+  margin-top: clamp(2rem, 5vw, 3rem);
+  align-items: start;
+}
+
+/* Título de ítem (equivale a .lp-family-title) */
+.lp-item-title {
+  margin: 0 0 0.4rem;
+  font-family: var(--lp-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--lp-fg);
+}
+
+/* Lista de bullets círculo 6px (equivale a .lp-plan-list fuera de una tarjeta) */
+.lp-bullets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--lp-fg-mid);
+}
+
+.lp-bullets li {
+  position: relative;
+  padding-left: 1.1rem;
+}
+
+.lp-bullets li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.5em;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+}
+
+@media (min-width: 700px) {
+  .lp-grid-3 {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2.5rem;
+  }
+}
+
+@media (min-width: 960px) {
+  .lp-split {
+    grid-template-columns: 1fr minmax(0, 420px);
+    gap: 4rem;
+  }
+}
+`;

--- a/apps/web/src/pages/marketing/PricingPage.tsx
+++ b/apps/web/src/pages/marketing/PricingPage.tsx
@@ -276,7 +276,7 @@ export default function PricingPage() {
             Dale de alta en unos minutos: eliges su contraseña, recibes su usuario al terminar y
             la cuenta es suya.
           </p>
-          <div className="pr-cta-row">
+          <div className="lp-cta-row">
             <Link className="lp-btn lp-btn-primary lp-btn-lg" to="/register">
               Dar de alta ahora
             </Link>
@@ -318,12 +318,6 @@ const CSS = `
   flex-direction: column;
   align-items: flex-start;
   gap: 1.5rem;
-}
-
-.pr-cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
 }
 
 /* ── Panel lateral de la tarjeta de plan ── */

--- a/apps/web/src/pages/marketing/PricingPage.tsx
+++ b/apps/web/src/pages/marketing/PricingPage.tsx
@@ -1,35 +1,50 @@
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { LP_SHARED_CSS, MERCH, SectionHead } from './LpSystem';
 
-// ─── Constantes ────────────────────────────────────────────────────────────────
-
-const ORANGE = '#ea580c';
-const NAVY = '#0d1b2a';
-
-// Merchandising del club
-const MERCH = [
-  { icon: '🎨', name: 'Pack de stickers VKB', pts: 100 },
-  { icon: '💧', name: 'Botella termo del club', pts: 200 },
-  { icon: '🧢', name: 'Gorra oficial VKB', pts: 350 },
-  { icon: '👕', name: 'Camiseta oficial del club', pts: 500 },
-  { icon: '🏀', name: 'Balón firmado por el equipo', pts: 1000 },
-];
+// ─── Datos de la página ────────────────────────────────────────────────────────
 
 // Lo que obtiene el alumno
 const STUDENT_FEATURES = [
-  { icon: '📹', text: 'Vídeos técnicos y tácticos organizados por nivel' },
-  { icon: '✏️', text: 'Lecciones interactivas: emparejar, ordenar y rellenar huecos' },
-  { icon: '🧠', text: 'Tests y quizzes con corrección automática' },
-  { icon: '🎓', text: 'Exámenes oficiales por módulo y curso completo' },
-  { icon: '📜', text: 'Certificados digitales descargables en PDF al superar cada examen' },
-  { icon: '🏆', text: 'Retos y puntos canjeables por merchandising del club' },
+  'Vídeos técnicos y tácticos organizados por nivel',
+  'Lecciones interactivas: emparejar, ordenar y rellenar huecos',
+  'Tests y quizzes con corrección automática',
+  'Exámenes oficiales por módulo y curso completo',
+  'Certificados digitales descargables en PDF al superar cada examen',
+  'Retos y puntos canjeables por merchandising del club',
 ];
 
 // Lo que gestiona el padre, madre o tutor legal
 const GUARDIAN_FEATURES = [
-  { icon: '📝', text: 'Da de alta a todos sus hijos/as en un único formulario' },
-  { icon: '🔑', text: 'Elige la contraseña de cada hijo/a en el momento de inscribirlo' },
-  { icon: '🏫', text: 'Si pierde los datos de acceso, la academia se los facilita' },
+  'Da de alta a todos sus hijos/as en un único formulario',
+  'Elige la contraseña de cada hijo/a en el momento de inscribirlo',
+  'Si pierde los datos de acceso, la academia se los facilita',
+];
+
+const PLAN_CHECKS = [
+  'Todos los cursos de su nivel',
+  'Lecciones interactivas y tests',
+  'Exámenes y certificados PDF',
+  'Sistema de retos y puntos',
+];
+
+const STEPS = [
+  {
+    number: '01',
+    title: 'Rellena el formulario',
+    description:
+      'Inscribe a tu hijo/a con sus datos y elige su contraseña. No hace falta llamar ni esperar a que te den de alta.',
+  },
+  {
+    number: '02',
+    title: 'Recibe su usuario',
+    description:
+      'Al terminar, verás en pantalla el nombre de usuario de tu hijo/a. Apúntalo: es la única vez que se muestra.',
+  },
+  {
+    number: '03',
+    title: 'Listo para aprender',
+    description: 'Tu hijo/a puede empezar los cursos de inmediato desde cualquier dispositivo.',
+  },
 ];
 
 const FAQS = [
@@ -55,915 +70,357 @@ const FAQS = [
   },
 ];
 
-// ─── Subcomponentes ────────────────────────────────────────────────────────────
-
-function FeatureItem({ icon, text }: { icon: string; text: string }) {
-  return (
-    <li style={S.featureItem}>
-      <span style={S.featureCheckmark}>✓</span>
-      <span style={S.featureIcon}>{icon}</span>
-      <span style={S.featureText}>{text}</span>
-    </li>
-  );
-}
-
-function FaqItem({ q, a }: { q: string; a: string }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <div
-      style={{
-        ...S.faqItem,
-        ...(open ? S.faqItemOpen : {}),
-      }}
-    >
-      <button
-        style={S.faqQ}
-        onClick={() => setOpen((o) => !o)}
-        onMouseEnter={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color = ORANGE;
-        }}
-        onMouseLeave={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color = NAVY;
-        }}
-      >
-        <span>{q}</span>
-        <span
-          style={{ fontSize: '1rem', color: open ? ORANGE : '#94a3b8', transition: 'color 0.15s' }}
-        >
-          {open ? '▲' : '▼'}
-        </span>
-      </button>
-      {open && <p style={S.faqA}>{a}</p>}
-    </div>
-  );
-}
-
-function MerchCard({ item }: { item: { icon: string; name: string; pts: number } }) {
-  return (
-    <div
-      style={S.merchCard}
-      onMouseEnter={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(-5px)';
-        el.style.boxShadow = '0 12px 32px rgba(234,88,12,0.18)';
-        el.style.borderColor = 'rgba(234,88,12,0.3)';
-      }}
-      onMouseLeave={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        el.style.transform = 'translateY(0)';
-        el.style.boxShadow = '0 2px 8px rgba(0,0,0,0.05)';
-        el.style.borderColor = '#e2e8f0';
-      }}
-    >
-      <span style={S.merchIcon}>{item.icon}</span>
-      <span style={S.merchName}>{item.name}</span>
-      <span style={S.merchPts}>{item.pts.toLocaleString('es-ES')} pts</span>
-    </div>
-  );
-}
-
-// ─── Página principal ──────────────────────────────────────────────────────────
+// ─── Página ────────────────────────────────────────────────────────────────────
 
 export default function PricingPage() {
-  const navigate = useNavigate();
-
   return (
-    <div style={S.page}>
-      {/* Overrides responsivos — no se pueden aplicar con inline styles */}
-      <style>{`
-        .pricing-hero { padding: 6rem 2rem 5rem; }
-        @media (max-width: 768px) {
-          .pricing-hero { padding: 3rem 1.25rem !important; }
-          .pricing-features-inner { flex-direction: column !important; align-items: center !important; }
-          .pricing-steps-row { flex-direction: column !important; align-items: center !important; }
-        }
-      `}</style>
+    <div className="lp-page">
+      <style>{LP_SHARED_CSS + CSS}</style>
 
-      {/* ════════ HERO ════════ */}
-      <section className="pricing-hero" style={S.hero}>
-        <div style={S.heroGlow} />
-        <div style={S.heroGlowSide} />
-        <div style={S.heroInner}>
-          <span style={S.heroBadge}>🏀 Para familias de Vallekas Basket</span>
-          <h1 style={S.heroTitle}>
-            Dale a tu hijo/a acceso a{' '}
-            <span style={S.heroTitleAccent}>la mejor formación del club</span>
+      {/* ═══ HERO ═══ */}
+      <section className="lp-block pr-hero">
+        <div className="lp-shell">
+          <h1 className="lp-display">
+            La mejor formación del club.
+            <br />
+            <em>Por 15 € al mes.</em>
           </h1>
-          <p style={S.heroSub}>
-            Por solo <strong style={{ color: '#fb923c' }}>15 € al mes</strong>, tu hijo/a accede a
-            todos los cursos, lecciones interactivas y exámenes del club. Tú lo das de alta y eliges
-            su contraseña en un momento.
+          <p className="lp-lead">
+            Tu hijo/a accede a todos los cursos, lecciones interactivas y exámenes del club. Tú lo
+            das de alta y eliges su contraseña en un momento.
           </p>
         </div>
       </section>
 
-      {/* ════════ PRECIO ════════ */}
-      <section style={S.pricingSection}>
-        <div style={S.pricingWrap}>
-          {/* Tarjeta de precio */}
-          <div style={S.planCard}>
-            {/* Badge "Más popular" */}
-            <div style={S.popularBadge}>Más popular</div>
+      {/* ═══ 01 · EL PLAN ═══ */}
+      <section className="lp-block lp-block-alt">
+        <div className="lp-shell">
+          <SectionHead
+            index="01"
+            kicker="Suscripción mensual"
+            title="Un único plan."
+            accent="Sin permanencia."
+          />
 
-            <p style={S.planLabel}>Suscripción mensual</p>
-            <div style={S.priceRow}>
-              <span style={S.priceCurrency}>€</span>
-              <span style={S.priceAmount}>15</span>
-              <span style={S.pricePer}>
-                / mes
-                <br />
-                por alumno
-              </span>
-            </div>
-            <p style={S.planDesc}>
-              Acceso completo a toda la plataforma. Sin permanencia, cancela cuando quieras.
-            </p>
-            <ul style={S.planChecks}>
-              {[
-                'Todos los cursos de su nivel',
-                'Lecciones interactivas y tests',
-                'Exámenes y certificados PDF',
-                'Sistema de retos y puntos',
-              ].map((item) => (
-                <li key={item} style={S.planCheck}>
-                  <span style={S.planCheckmark}>✓</span>
-                  {item}
-                </li>
-              ))}
-            </ul>
-            <button
-              style={S.planCta}
-              onClick={() => navigate('/login')}
-              onMouseEnter={(e) => {
-                const el = e.currentTarget as HTMLButtonElement;
-                el.style.transform = 'translateY(-2px)';
-                el.style.boxShadow = '0 12px 36px rgba(234,88,12,0.5)';
-                el.style.filter = 'brightness(1.08)';
-              }}
-              onMouseLeave={(e) => {
-                const el = e.currentTarget as HTMLButtonElement;
-                el.style.transform = 'translateY(0)';
-                el.style.boxShadow = '0 8px 28px rgba(234,88,12,0.35)';
-                el.style.filter = 'none';
-              }}
-            >
-              Acceder a la plataforma
-            </button>
-            <p style={S.planNote}>
-              ¿Aún no has inscrito a tu hijo/a?{' '}
-              <Link to="/register" style={{ color: ORANGE, fontWeight: 600 }}>
-                Regístrale aquí
+          <div className="lp-split lp-reveal">
+            <article className="lp-plan lp-plan-featured">
+              <div className="lp-plan-head">
+                <span className="lp-plan-name">Plan único</span>
+                <span className="lp-plan-badge">Más popular</span>
+              </div>
+
+              <p className="lp-plan-price">
+                <span className="lp-plan-amount">15</span>
+                <span className="lp-plan-unit">€ al mes por alumno</span>
+              </p>
+
+              <p className="lp-text">
+                Acceso completo a toda la plataforma. Sin permanencia, cancela cuando quieras.
+              </p>
+
+              <ul className="lp-plan-list">
+                {PLAN_CHECKS.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+
+              <Link className="lp-btn lp-btn-primary lp-btn-full" to="/register">
+                Dar de alta a mi hijo/a
               </Link>
-              .
-            </p>
-          </div>
+              <p className="lp-note">
+                ¿Ya está dado de alta? <Link to="/login">Inicia sesión.</Link>
+              </p>
+            </article>
 
-          {/* Panel informativo lateral */}
-          <div style={S.infoPanel}>
-            <div style={S.infoPanelGlow} />
-            <div style={S.infoPanelItem}>
-              <span style={S.infoPanelIcon}>👨‍👩‍👧</span>
-              <div>
-                <p style={S.infoPanelTitle}>Tu papel como familia</p>
-                <p style={S.infoPanelText}>
+            <aside className="pr-aside">
+              <div className="pr-aside-item">
+                <h3 className="lp-item-title">Tu papel como familia</h3>
+                <p className="lp-text">
                   Inscribes a tu hijo/a y eliges su contraseña. Al terminar recibes su nombre de
-                  usuario en pantalla — apúntalo, porque no vuelve a mostrarse.
+                  usuario en pantalla: apúntalo, porque no vuelve a mostrarse.
                 </p>
               </div>
+              <div className="pr-aside-item">
+                <h3 className="lp-item-title">Contenido del club</h3>
+                <p className="lp-text">
+                  Todo el contenido lo crean y actualizan los propios profesores de Vallekas
+                  Basket. No es material genérico: es la metodología real del club.
+                </p>
+              </div>
+              <div className="pr-aside-item">
+                <h3 className="lp-item-title">Disponible siempre</h3>
+                <p className="lp-text">
+                  Desde cualquier dispositivo, en cualquier momento. Sin descargas ni
+                  instalaciones.
+                </p>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      {/* ═══ 02 · QUÉ INCLUYE ═══ */}
+      <section className="lp-block">
+        <div className="lp-shell">
+          <SectionHead
+            index="02"
+            kicker="Lo que incluye"
+            title="Tu hijo/a accede a todo esto."
+            accent="Tú solo lo das de alta."
+          />
+
+          <div className="pr-cols lp-reveal">
+            <div>
+              <h3 className="lp-item-title">Tu hijo/a accede a…</h3>
+              <ul className="lp-bullets">
+                {STUDENT_FEATURES.map((text) => (
+                  <li key={text}>{text}</li>
+                ))}
+              </ul>
             </div>
-            <div style={S.infoDivider} />
-            <div style={S.infoPanelItem}>
-              <span style={S.infoPanelIcon}>🏀</span>
-              <div>
-                <p style={S.infoPanelTitle}>Contenido del club</p>
-                <p style={S.infoPanelText}>
-                  Todo el contenido lo crean y actualizan los propios profesores de Vallekas Basket.
-                  No es material genérico — es la metodología real del club.
-                </p>
-              </div>
-            </div>
-            <div style={S.infoDivider} />
-            <div style={S.infoPanelItem}>
-              <span style={S.infoPanelIcon}>📱</span>
-              <div>
-                <p style={S.infoPanelTitle}>Disponible siempre</p>
-                <p style={S.infoPanelText}>
-                  Desde cualquier dispositivo, en cualquier momento. Sin descargas ni instalaciones.
-                </p>
-              </div>
+
+            <div>
+              <h3 className="lp-item-title">Tú te encargas de…</h3>
+              <ul className="lp-bullets">
+                {GUARDIAN_FEATURES.map((text) => (
+                  <li key={text}>{text}</li>
+                ))}
+              </ul>
             </div>
           </div>
         </div>
       </section>
 
-      {/* ════════ QUÉ OBTIENE ════════ */}
-      <section style={S.featuresSection}>
-        <div className="pricing-features-inner" style={S.featuresInner}>
-          {/* Columna alumno */}
-          <div style={S.featureCol}>
-            <div style={S.featureColHeader}>
-              <span style={S.featureColIconWrap}>🎒</span>
-              <h2 style={S.featureColTitle}>Tu hijo/a accede a…</h2>
-            </div>
-            <ul style={S.featureList}>
-              {STUDENT_FEATURES.map((f) => (
-                <FeatureItem key={f.text} {...f} />
-              ))}
-            </ul>
-          </div>
+      {/* ═══ 03 · CÓMO EMPIEZO ═══ */}
+      <section className="lp-block lp-block-alt">
+        <div className="lp-shell">
+          <SectionHead
+            index="03"
+            kicker="Cómo empiezo"
+            title="Solo tres pasos."
+            accent="Y ya puede aprender."
+          />
 
-          {/* Columna padre/madre/tutor legal */}
-          <div style={S.featureCol}>
-            <div style={S.featureColHeader}>
-              <span style={S.featureColIconWrap}>📝</span>
-              <h2 style={S.featureColTitle}>Tú te encargas de…</h2>
-            </div>
-            <ul style={S.featureList}>
-              {GUARDIAN_FEATURES.map((f) => (
-                <FeatureItem key={f.text} {...f} />
-              ))}
-            </ul>
-          </div>
-        </div>
-      </section>
-
-      {/* ════════ CÓMO FUNCIONA ════════ */}
-      <section style={S.howSection}>
-        <div style={S.howInner}>
-          <h2 style={S.sectionTitle}>¿Cómo empiezo?</h2>
-          <p style={S.sectionSub}>Solo tres pasos y tu hijo/a ya puede aprender.</p>
-          <div style={S.stepsRow}>
-            {[
-              {
-                n: '1',
-                title: 'Rellena el formulario',
-                desc: 'Inscribe a tu hijo/a con sus datos y elige su contraseña. No hace falta llamar ni esperar a que te den de alta.',
-              },
-              {
-                n: '2',
-                title: 'Recibe su usuario',
-                desc: 'Al terminar, verás en pantalla el nombre de usuario de tu hijo/a. Apúntalo: es la única vez que se muestra.',
-              },
-              {
-                n: '3',
-                title: '¡Listo para aprender!',
-                desc: 'Tu hijo/a puede empezar los cursos de inmediato desde cualquier dispositivo.',
-              },
-            ].map(({ n, title, desc }) => (
-              <div key={n} style={S.step}>
-                <div style={S.stepNumber}>{n}</div>
-                <h3 style={S.stepTitle}>{title}</h3>
-                <p style={S.stepDesc}>{desc}</p>
-              </div>
+          <ol className="lp-steps lp-reveal">
+            {STEPS.map((step) => (
+              <li className="lp-step" key={step.number}>
+                <span className="lp-step-num">{step.number}</span>
+                <h3 className="lp-step-title">{step.title}</h3>
+                <p className="lp-text">{step.description}</p>
+              </li>
             ))}
-          </div>
+          </ol>
         </div>
       </section>
 
-      {/* ════════ MERCHANDISING ════════ */}
-      <section style={S.merchSection}>
-        <div style={S.howInner}>
-          <h2 style={S.sectionTitle}>🏆 Incluido: sistema de puntos y premios</h2>
-          <p style={S.sectionSub}>
+      {/* ═══ 04 · RECOMPENSAS ═══ */}
+      <section className="lp-block">
+        <div className="lp-shell">
+          <SectionHead
+            index="04"
+            kicker="Recompensas"
+            title="Puntos y premios incluidos."
+            accent="Sin coste adicional."
+          />
+
+          <table className="lp-table lp-reveal">
+            <tbody>
+              {MERCH.map((item) => (
+                <tr key={item.name}>
+                  <th scope="row">{item.name}</th>
+                  <td>{item.pts.toLocaleString('es-ES')} pts</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="lp-table-note">
             Tu hijo/a acumula puntos completando lecciones y retos. Los puntos se canjean por
-            merchandising exclusivo del club, sin coste adicional.
-          </p>
-          <div style={S.merchGrid}>
-            {MERCH.map((item) => (
-              <MerchCard key={item.name} item={item} />
-            ))}
-          </div>
-          <p style={S.merchNote}>
-            El sistema de puntos es una forma de motivar el estudio y premiar la constancia — sin
-            coste adicional para las familias.
+            merchandising exclusivo del club, sin coste adicional para las familias.
           </p>
         </div>
       </section>
 
-      {/* ════════ FAQ ════════ */}
-      <section style={S.faqSection}>
-        <div style={S.faqInner}>
-          <h2 style={S.sectionTitle}>Preguntas frecuentes</h2>
-          <p style={S.sectionSub}>Todo lo que necesitas saber antes de empezar.</p>
-          <div style={S.faqGrid}>
+      {/* ═══ 05 · FAQ ═══ */}
+      <section className="lp-block lp-block-alt">
+        <div className="lp-shell">
+          <SectionHead
+            index="05"
+            kicker="Preguntas frecuentes"
+            title="Las dudas de las familias."
+            accent="Resueltas antes de empezar."
+          />
+
+          <div className="pr-faq lp-reveal">
             {FAQS.map((faq) => (
-              <FaqItem key={faq.q} {...faq} />
+              <details className="pr-faq-item" key={faq.q}>
+                <summary className="pr-faq-q">
+                  <span>{faq.q}</span>
+                  <span className="pr-faq-indicator" aria-hidden="true" />
+                </summary>
+                <p className="lp-text pr-faq-a">{faq.a}</p>
+              </details>
             ))}
           </div>
         </div>
       </section>
 
-      {/* ════════ CTA FINAL ════════ */}
-      <section style={S.cta}>
-        <div style={S.ctaGlow} />
-        <h2 style={S.ctaTitle}>¿Formas parte de Vallekas Basket?</h2>
-        <p style={S.ctaSub}>
-          Accede con las credenciales que te ha proporcionado el club y empieza hoy.
-        </p>
-        <button
-          style={S.ctaBtn}
-          onClick={() => navigate('/login')}
-          onMouseEnter={(e) => {
-            const el = e.currentTarget as HTMLButtonElement;
-            el.style.transform = 'translateY(-3px)';
-            el.style.boxShadow = '0 16px 48px rgba(234,88,12,0.55)';
-            el.style.filter = 'brightness(1.08)';
-          }}
-          onMouseLeave={(e) => {
-            const el = e.currentTarget as HTMLButtonElement;
-            el.style.transform = 'translateY(0)';
-            el.style.boxShadow = '0 8px 32px rgba(234,88,12,0.4)';
-            el.style.filter = 'none';
-          }}
-        >
-          Entrar a la plataforma
-        </button>
+      {/* ═══ CIERRE ═══ */}
+      <section className="lp-block pr-final">
+        <div className="lp-shell">
+          <h2 className="lp-display">
+            ¿Formas parte de Vallekas Basket?
+            <br />
+            <em>Tu hijo/a puede empezar hoy.</em>
+          </h2>
+          <p className="lp-lead">
+            Dale de alta en unos minutos: eliges su contraseña, recibes su usuario al terminar y
+            la cuenta es suya.
+          </p>
+          <div className="pr-cta-row">
+            <Link className="lp-btn lp-btn-primary lp-btn-lg" to="/register">
+              Dar de alta ahora
+            </Link>
+            <Link className="lp-btn lp-btn-ghost" to="/login">
+              Ya tengo cuenta
+            </Link>
+          </div>
+        </div>
       </section>
     </div>
   );
 }
 
 // ─── Estilos ───────────────────────────────────────────────────────────────────
+// Bloque local mínimo: halos del hero y del cierre (mismos tintes que la
+// landing), panel lateral, dos columnas y el acordeón FAQ nativo.
 
-const S: Record<string, React.CSSProperties> = {
-  page: {
-    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-    overflowX: 'hidden',
-  },
+const CSS = `
+.pr-hero {
+  position: relative;
+  background:
+    radial-gradient(120% 70% at 50% -20%, rgba(245, 145, 30, 0.18), transparent 62%),
+    var(--lp-bg);
+}
 
-  // Hero
-  hero: {
-    background: 'linear-gradient(135deg, #080e1a 0%, #0d1b2a 60%, #152233 100%)',
-    padding: '6rem 2rem 5rem',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'relative',
-    overflow: 'hidden',
-  },
-  heroGlow: {
-    position: 'absolute',
-    top: '-80px',
-    left: '50%',
-    transform: 'translateX(-50%)',
-    width: 700,
-    height: 700,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.16) 0%, transparent 65%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  heroGlowSide: {
-    position: 'absolute',
-    bottom: '-80px',
-    right: '-80px',
-    width: 400,
-    height: 400,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.08) 0%, transparent 70%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  heroInner: {
-    maxWidth: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    textAlign: 'center',
-    gap: '1.35rem',
-    position: 'relative',
-    zIndex: 1,
-  },
-  heroBadge: {
-    display: 'inline-block',
-    background: 'rgba(234,88,12,0.16)',
-    border: '1px solid rgba(234,88,12,0.45)',
-    color: '#fb923c',
-    borderRadius: 999,
-    padding: '0.45rem 1.2rem',
-    fontSize: '0.875rem',
-    fontWeight: 600,
-    letterSpacing: '0.02em',
-  },
-  heroTitle: {
-    fontSize: 'clamp(1.875rem, 4vw, 3.25rem)',
-    fontWeight: 900,
-    color: '#fff',
-    letterSpacing: '-0.035em',
-    lineHeight: 1.08,
-    margin: 0,
-    maxWidth: 700,
-  },
-  heroTitleAccent: {
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    WebkitBackgroundClip: 'text',
-    WebkitTextFillColor: 'transparent',
-    backgroundClip: 'text',
-  },
-  heroSub: {
-    color: 'rgba(255,255,255,0.68)',
-    fontSize: '1.1rem',
-    lineHeight: 1.7,
-    maxWidth: 540,
-    margin: 0,
-  },
+.pr-final {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(90% 70% at 50% 120%, rgba(245, 145, 30, 0.2), transparent 62%),
+    var(--lp-bg);
+  border-top: 1px solid var(--lp-rule-soft);
+  display: flex;
+  flex-direction: column;
+}
 
-  // Precio
-  pricingSection: {
-    background: '#f8fafc',
-    padding: '6rem 2rem',
-  },
-  pricingWrap: {
-    maxWidth: 920,
-    margin: '0 auto',
-    display: 'flex',
-    gap: '2rem',
-    flexWrap: 'wrap',
-    alignItems: 'stretch',
-    justifyContent: 'center',
-  },
-  planCard: {
-    background: '#fff',
-    border: `2px solid ${ORANGE}`,
-    borderRadius: 24,
-    padding: '2.75rem',
-    flex: '1 1 340px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1.25rem',
-    boxShadow: '0 8px 40px rgba(234,88,12,0.18)',
-    position: 'relative',
-    overflow: 'hidden',
-  },
-  popularBadge: {
-    position: 'absolute',
-    top: 20,
-    right: 20,
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    color: '#fff',
-    borderRadius: 999,
-    padding: '4px 14px',
-    fontSize: '0.7rem',
-    fontWeight: 700,
-    letterSpacing: '0.04em',
-    textTransform: 'uppercase',
-    boxShadow: '0 4px 12px rgba(234,88,12,0.4)',
-  },
-  planLabel: {
-    fontSize: '0.75rem',
-    fontWeight: 700,
-    textTransform: 'uppercase',
-    letterSpacing: '0.08em',
-    color: ORANGE,
-    margin: 0,
-  },
-  priceRow: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    gap: 6,
-  },
-  priceCurrency: {
-    fontSize: '1.5rem',
-    fontWeight: 800,
-    color: NAVY,
-    marginTop: 8,
-  },
-  priceAmount: {
-    fontSize: '4.5rem',
-    fontWeight: 900,
-    color: NAVY,
-    letterSpacing: '-0.04em',
-    lineHeight: 1,
-    background: 'linear-gradient(135deg, #0d1b2a 0%, #152233 100%)',
-    WebkitBackgroundClip: 'text',
-    WebkitTextFillColor: 'transparent',
-    backgroundClip: 'text',
-  },
-  pricePer: {
-    fontSize: '0.85rem',
-    color: '#64748b',
-    lineHeight: 1.5,
-    paddingBottom: 6,
-    alignSelf: 'flex-end',
-  },
-  planDesc: {
-    fontSize: '0.925rem',
-    color: '#374151',
-    lineHeight: 1.7,
-    margin: 0,
-  },
-  planChecks: {
-    listStyle: 'none',
-    padding: 0,
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.7rem',
-  },
-  planCheck: {
-    fontSize: '0.9rem',
-    color: '#374151',
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-  },
-  planCheckmark: {
-    width: 20,
-    height: 20,
-    borderRadius: '50%',
-    background: 'rgba(234,88,12,0.12)',
-    color: ORANGE,
-    fontWeight: 800,
-    fontSize: '0.75rem',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    border: '1.5px solid rgba(234,88,12,0.25)',
-  },
-  planCta: {
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    color: '#fff',
-    border: 'none',
-    borderRadius: 12,
-    padding: '15px 28px',
-    fontSize: '1rem',
-    fontWeight: 700,
-    cursor: 'pointer',
-    transition: 'transform 0.2s, box-shadow 0.2s, filter 0.2s',
-    marginTop: '0.25rem',
-    boxShadow: '0 8px 28px rgba(234,88,12,0.35)',
-    letterSpacing: '-0.01em',
-  },
-  planNote: {
-    fontSize: '0.8rem',
-    color: '#94a3b8',
-    margin: 0,
-    textAlign: 'center',
-    lineHeight: 1.5,
-  },
+.pr-final .lp-shell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
 
-  // Panel lateral
-  infoPanel: {
-    background: 'linear-gradient(135deg, #080e1a 0%, #0d1b2a 60%, #152233 100%)',
-    borderRadius: 24,
-    padding: '2.75rem',
-    flex: '1 1 300px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1.5rem',
-    position: 'relative',
-    overflow: 'hidden',
-    boxShadow: '0 8px 32px rgba(8,14,26,0.3)',
-  },
-  infoPanelGlow: {
-    position: 'absolute',
-    top: -80,
-    right: -80,
-    width: 280,
-    height: 280,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.16) 0%, transparent 70%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  infoPanelItem: {
-    display: 'flex',
-    gap: '1rem',
-    alignItems: 'flex-start',
-    position: 'relative',
-    zIndex: 1,
-  },
-  infoPanelIcon: {
-    fontSize: '1.75rem',
-    flexShrink: 0,
-    lineHeight: 1,
-  },
-  infoPanelTitle: {
-    fontSize: '0.95rem',
-    fontWeight: 700,
-    color: '#fff',
-    margin: '0 0 0.35rem',
-  },
-  infoPanelText: {
-    fontSize: '0.85rem',
-    color: 'rgba(255,255,255,0.55)',
-    lineHeight: 1.6,
-    margin: 0,
-  },
-  infoDivider: {
-    height: 1,
-    background: 'rgba(255,255,255,0.07)',
-    position: 'relative',
-    zIndex: 1,
-  },
+.pr-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
 
-  // Qué obtiene
-  featuresSection: {
-    background: '#ffffff',
-    padding: '6rem 2rem',
-  },
-  featuresInner: {
-    maxWidth: 960,
-    margin: '0 auto',
-    display: 'flex',
-    gap: '3rem',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-  },
-  featureCol: {
-    flex: '1 1 380px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1.5rem',
-  },
-  featureColHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.75rem',
-  },
-  featureColIconWrap: {
-    fontSize: '2rem',
-    lineHeight: 1,
-  },
-  featureColTitle: {
-    fontSize: '1.25rem',
-    fontWeight: 800,
-    color: NAVY,
-    margin: 0,
-    letterSpacing: '-0.02em',
-  },
-  featureList: {
-    listStyle: 'none',
-    padding: 0,
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.6rem',
-  },
-  featureItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.75rem',
-    background: '#f8fafc',
-    border: '1.5px solid #e2e8f0',
-    borderRadius: 12,
-    padding: '0.875rem 1rem',
-    transition: 'border-color 0.2s, box-shadow 0.2s',
-  },
-  featureCheckmark: {
-    width: 20,
-    height: 20,
-    borderRadius: '50%',
-    background: 'rgba(234,88,12,0.12)',
-    color: ORANGE,
-    fontWeight: 800,
-    fontSize: '0.75rem',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    border: '1.5px solid rgba(234,88,12,0.25)',
-  },
-  featureIcon: {
-    fontSize: '1.1rem',
-    flexShrink: 0,
-  },
-  featureText: {
-    fontSize: '0.9rem',
-    color: '#374151',
-    lineHeight: 1.5,
-  },
+/* ── Panel lateral de la tarjeta de plan ── */
 
-  // Cómo funciona
-  howSection: {
-    background: '#f8fafc',
-    padding: '6rem 2rem',
-  },
-  howInner: {
-    maxWidth: 860,
-    margin: '0 auto',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '3rem',
-    textAlign: 'center',
-  },
-  sectionTitle: {
-    fontSize: 'clamp(1.5rem, 3vw, 2.25rem)',
-    fontWeight: 800,
-    color: NAVY,
-    letterSpacing: '-0.025em',
-    margin: 0,
-  },
-  sectionSub: {
-    color: '#64748b',
-    fontSize: '1rem',
-    margin: '-1.5rem 0 0',
-    lineHeight: 1.6,
-    maxWidth: 480,
-  },
-  stepsRow: {
-    display: 'flex',
-    gap: '2rem',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-  },
-  step: {
-    flex: '1 1 220px',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '0.75rem',
-  },
-  stepNumber: {
-    width: 52,
-    height: 52,
-    borderRadius: '50%',
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    color: '#fff',
-    fontWeight: 900,
-    fontSize: '1.35rem',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    boxShadow: '0 6px 20px rgba(234,88,12,0.38)',
-  },
-  stepTitle: {
-    fontSize: '1rem',
-    fontWeight: 700,
-    color: NAVY,
-    margin: 0,
-  },
-  stepDesc: {
-    fontSize: '0.875rem',
-    color: '#64748b',
-    lineHeight: 1.6,
-    margin: 0,
-  },
+.pr-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
 
-  // Merchandising
-  merchSection: {
-    background: '#fff',
-    padding: '6rem 2rem',
-  },
-  merchGrid: {
-    display: 'flex',
-    gap: '1rem',
-    flexWrap: 'wrap' as const,
-    justifyContent: 'center',
-  },
-  merchCard: {
-    background: '#fff',
-    border: '1.5px solid #e2e8f0',
-    borderRadius: 16,
-    padding: '1.5rem 1.25rem',
-    display: 'flex',
-    flexDirection: 'column' as const,
-    alignItems: 'center',
-    gap: '0.6rem',
-    minWidth: 148,
-    textAlign: 'center' as const,
-    transition: 'transform 0.22s, box-shadow 0.22s, border-color 0.22s',
-    cursor: 'default',
-    boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
-  },
-  merchIcon: {
-    fontSize: '2.25rem',
-    lineHeight: 1,
-  },
-  merchName: {
-    fontSize: '0.825rem',
-    fontWeight: 600,
-    color: NAVY,
-    lineHeight: 1.3,
-  },
-  merchPts: {
-    fontSize: '0.8rem',
-    fontWeight: 700,
-    color: ORANGE,
-    background: 'rgba(234,88,12,0.10)',
-    padding: '3px 12px',
-    borderRadius: 999,
-  },
-  merchNote: {
-    textAlign: 'center' as const,
-    fontSize: '0.825rem',
-    color: '#94a3b8',
-    margin: '0.5rem auto 0',
-    maxWidth: 480,
-    lineHeight: 1.5,
-  },
+.pr-aside-item {
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--lp-rule-soft);
+}
 
-  // FAQ
-  faqSection: {
-    background: '#f8fafc',
-    padding: '6rem 2rem',
-  },
-  faqInner: {
-    maxWidth: 860,
-    margin: '0 auto',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '2.5rem',
-    alignItems: 'center',
-    textAlign: 'center',
-  },
-  faqGrid: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.75rem',
-    width: '100%',
-    textAlign: 'left',
-  },
-  faqItem: {
-    background: '#fff',
-    borderRadius: 14,
-    border: '1.5px solid #e2e8f0',
-    overflow: 'hidden',
-    transition: 'border-color 0.2s, box-shadow 0.2s',
-    boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
-  },
-  faqItemOpen: {
-    borderColor: 'rgba(234,88,12,0.3)',
-    boxShadow: '0 4px 20px rgba(234,88,12,0.12)',
-  },
-  faqQ: {
-    width: '100%',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: '1.25rem 1.5rem',
-    background: 'none',
-    border: 'none',
-    cursor: 'pointer',
-    fontSize: '0.95rem',
-    fontWeight: 700,
-    color: NAVY,
-    textAlign: 'left',
-    transition: 'color 0.15s',
-    gap: 12,
-  },
-  faqA: {
-    fontSize: '0.875rem',
-    color: '#374151',
-    lineHeight: 1.7,
-    margin: 0,
-    padding: '0 1.5rem 1.25rem',
-  },
+.pr-aside-item:first-child {
+  padding-top: 0;
+  border-top: none;
+}
 
-  // CTA final
-  cta: {
-    background: 'linear-gradient(135deg, #080e1a 0%, #0d1b2a 60%, #152233 100%)',
-    padding: '7rem 2rem',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '1.5rem',
-    textAlign: 'center',
-    position: 'relative',
-    overflow: 'hidden',
-  },
-  ctaGlow: {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    width: 600,
-    height: 600,
-    background: 'radial-gradient(circle, rgba(234,88,12,0.14) 0%, transparent 65%)',
-    pointerEvents: 'none',
-    borderRadius: '50%',
-  },
-  ctaTitle: {
-    fontSize: 'clamp(1.75rem, 4vw, 2.75rem)',
-    fontWeight: 900,
-    color: '#fff',
-    letterSpacing: '-0.025em',
-    margin: 0,
-    lineHeight: 1.12,
-    position: 'relative',
-    zIndex: 1,
-  },
-  ctaSub: {
-    color: 'rgba(255,255,255,0.6)',
-    fontSize: '1.0625rem',
-    margin: 0,
-    lineHeight: 1.6,
-    maxWidth: 440,
-    position: 'relative',
-    zIndex: 1,
-  },
-  ctaBtn: {
-    background: 'linear-gradient(135deg, #ea580c 0%, #f97316 100%)',
-    color: '#fff',
-    border: 'none',
-    borderRadius: 12,
-    padding: '17px 40px',
-    fontSize: '1.0625rem',
-    fontWeight: 700,
-    cursor: 'pointer',
-    transition: 'transform 0.2s, box-shadow 0.2s, filter 0.2s',
-    boxShadow: '0 8px 32px rgba(234,88,12,0.4)',
-    letterSpacing: '-0.01em',
-    position: 'relative',
-    zIndex: 1,
-  },
-};
+/* ── Dos columnas de prestaciones ── */
+
+.pr-cols {
+  display: grid;
+  gap: 2.5rem;
+  margin-top: clamp(2rem, 5vw, 3rem);
+}
+
+/* ── Acordeón FAQ nativo ── */
+
+.pr-faq {
+  margin-top: clamp(2rem, 5vw, 3rem);
+  border-top: 1px solid var(--lp-rule-soft);
+}
+
+.pr-faq-item {
+  border-bottom: 1px solid var(--lp-rule-soft);
+}
+
+.pr-faq-q {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.35rem 0;
+  font-family: var(--lp-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--lp-fg);
+  cursor: pointer;
+  list-style: none;
+}
+
+.pr-faq-q::-webkit-details-marker {
+  display: none;
+}
+
+/* Indicador textual de apertura: "+" en reposo, "−" con el details abierto */
+.pr-faq-indicator {
+  position: relative;
+  flex-shrink: 0;
+  width: 1em;
+  height: 1em;
+  font-family: var(--lp-display);
+  color: var(--brand);
+}
+
+.pr-faq-indicator::before {
+  content: '+';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+details[open] .pr-faq-indicator::before {
+  content: '\\2212';
+}
+
+.pr-faq-a {
+  margin: 0 0 1.35rem;
+  max-width: 60ch;
+}
+
+@media (min-width: 700px) {
+  .pr-cols {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 960px) {
+  .pr-final .lp-shell {
+    max-width: 60ch;
+  }
+}
+`;

--- a/apps/web/src/pages/marketing/responsive.spec.ts
+++ b/apps/web/src/pages/marketing/responsive.spec.ts
@@ -116,8 +116,12 @@ describe('LandingPage — responsividad móvil', () => {
     const hasAutoFit = full.includes('auto-fit') || full.includes('auto-fill');
     // Diseño mobile-first: la fila de la lista es de una columna por defecto y
     // sus columnas adicionales se declaran dentro de un @media (min-width: …)
-    const mobileFirstRow =
-      /@media \(min-width: \d+px\)[\s\S]*\.lp-list-row[\s\S]*?grid-template-columns/.test(full);
+    // Anclado a un bloque concreto: la regla multi-columna de .lp-list-row
+    // tiene que vivir DENTRO de un @media (min-width: …), no en cualquier
+    // punto posterior del archivo.
+    const mobileFirstRow = extractMinWidthMediaBlocks(full).some((block) =>
+      /\.lp-list-row\s*\{[^}]*grid-template-columns/s.test(block),
+    );
     expect(hasAutoFit || mobileFirstRow).toBeTruthy();
   });
 
@@ -187,8 +191,13 @@ describe('AcademyLandingPage — delegación en la landing común', () => {
 // archivos de marketing, y un criterio que los cazara obligaría a quitarlos
 // (como le pasó a AboutPage.tsx con la primera versión de este assert: el
 // rango U+2190-U+2BFF del plan original incluía el bloque de dibujo de caja).
+// Rangos: pictogramas y emojis; símbolos misceláneos y dingbats; flechas
+// (básicas y suplementarias); formas geométricas; elementos de bloque; y
+// símbolos y flechas misceláneos (⭐, ⬆). Quedan fuera a propósito el dibujo
+// de caja (U+2500-257F) y los operadores matemáticos (U+2200-22FF), que la
+// landing usa en las fórmulas del mock (√, −, ≈).
 const DECORATIVE_SYMBOL_RE =
-  /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{25A0}-\u{25FF}]/u;
+  /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{27F0}-\u{27FF}\u{2580}-\u{25FF}\u{2B00}-\u{2BFF}]/u;
 
 const BRAND_HEX_RE = /#(ea580c|f5911e|6366f1|0891b2|0d1b2a)/i;
 
@@ -217,6 +226,31 @@ function readLocalCss(file: string): string {
 // CSS, respetando el anidado de llaves, para poder comprobar qué queda
 // declarado fuera de ellos (mobile-first: lo de una columna no necesita ir
 // bajo ningún media; lo de varias, sí).
+// Devuelve el CONTENIDO de cada bloque @media (min-width: ...) por separado.
+// Necesario para anclar asserts a un único bloque: un regex sobre el archivo
+// entero casaría la apertura de un @media con una regla que vive mucho más
+// abajo, fuera de él, y pasaría aunque la regla se hubiera sacado del media.
+function extractMinWidthMediaBlocks(css: string): string[] {
+  const blocks: string[] = [];
+  let i = 0;
+  while (i < css.length) {
+    const marker = css.indexOf('@media (min-width:', i);
+    if (marker === -1) break;
+    const braceStart = css.indexOf('{', marker);
+    if (braceStart === -1) break;
+    let depth = 1;
+    let j = braceStart + 1;
+    while (j < css.length && depth > 0) {
+      if (css[j] === '{') depth++;
+      else if (css[j] === '}') depth--;
+      j++;
+    }
+    blocks.push(css.slice(braceStart + 1, j - 1));
+    i = j;
+  }
+  return blocks;
+}
+
 function stripMinWidthMediaBlocks(css: string): string {
   let result = '';
   let i = 0;

--- a/apps/web/src/pages/marketing/responsive.spec.ts
+++ b/apps/web/src/pages/marketing/responsive.spec.ts
@@ -89,7 +89,10 @@ describe('LandingPage — responsividad móvil', () => {
 
   test('los botones CTA del hero usan flexWrap: wrap', () => {
     expect(src).toMatch(/heroCtas|lp-cta/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
+    // .lp-cta-row vive ahora en LpSystem.tsx (consolidada: estaba duplicada
+    // carácter a carácter como .lp-cta-row/.ab-cta-row/.pr-cta-row en las tres
+    // páginas de marketing): se lee la página concatenada con el módulo.
+    expect(readWithSystem('LandingPage.tsx')).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
   });
 
   test('las tarjetas de pricing tienen ancho responsivo (no fixed width > 400px sin override)', () => {

--- a/apps/web/src/pages/marketing/responsive.spec.ts
+++ b/apps/web/src/pages/marketing/responsive.spec.ts
@@ -175,98 +175,138 @@ describe('AcademyLandingPage — delegación en la landing común', () => {
   });
 });
 
-// ─── AboutPage ──────────────────────────────────────────────────────────────────
+// ─── Helpers del sistema lp-* (AboutPage / PricingPage) ────────────────────────
+// El diseño anterior de estas dos páginas se retiró en P2/P3 (precedente PR
+// #70: se sustituyen los tests que verificaban ese diseño por los que
+// verifican el sistema lp-* vigente, no se acumulan sobre los viejos).
 
-describe('AboutPage — responsividad móvil', () => {
+// Símbolos decorativos de interfaz que no deben aparecer en el copy de marca:
+// emojis/pictogramas, flechas, checks, triángulos y estrellas. Deliberadamente
+// NO incluye el bloque de dibujo de caja (U+2500–257F): ese es el rango que
+// usan los separadores de comentario (─/═) de estilo de la casa en los cuatro
+// archivos de marketing, y un criterio que los cazara obligaría a quitarlos
+// (como le pasó a AboutPage.tsx con la primera versión de este assert: el
+// rango U+2190-U+2BFF del plan original incluía el bloque de dibujo de caja).
+const DECORATIVE_SYMBOL_RE =
+  /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{25A0}-\u{25FF}]/u;
+
+const BRAND_HEX_RE = /#(ea580c|f5911e|6366f1|0891b2|0d1b2a)/i;
+
+// Etiquetas <Link ...> completas, sin asumir orden de atributos.
+function extractLinkTags(src: string): string[] {
+  return src.match(/<Link[^>]*>/g) ?? [];
+}
+
+// El bloque `const CSS = \`...\`;` de cada página: el único CSS que le
+// pertenece a ella (el resto lo aporta LpSystem.tsx). Se usa para el check de
+// grids mobile-first, que la sección 3 del plan acota explícitamente al
+// "CSS local" — el sistema compartido tiene sus propios patrones (p. ej.
+// .lp-list-row declara "auto 1fr" fuera de cualquier media porque es un
+// número/icono junto a texto, seguro en cualquier ancho) que no son el objeto
+// de este check.
+function readLocalCss(file: string): string {
+  const src = readSource(file);
+  const marker = 'const CSS = `';
+  const start = src.indexOf(marker);
+  if (start === -1) throw new Error(`No se encontró el bloque "const CSS" en ${file}`);
+  const end = src.lastIndexOf('`;');
+  return src.slice(start + marker.length, end);
+}
+
+// Quita el contenido de los bloques @media (min-width: ...) { ... } de un
+// CSS, respetando el anidado de llaves, para poder comprobar qué queda
+// declarado fuera de ellos (mobile-first: lo de una columna no necesita ir
+// bajo ningún media; lo de varias, sí).
+function stripMinWidthMediaBlocks(css: string): string {
+  let result = '';
+  let i = 0;
+  while (i < css.length) {
+    const marker = css.indexOf('@media (min-width:', i);
+    if (marker === -1) {
+      result += css.slice(i);
+      break;
+    }
+    result += css.slice(i, marker);
+    const braceStart = css.indexOf('{', marker);
+    if (braceStart === -1) {
+      result += css.slice(marker);
+      break;
+    }
+    let depth = 1;
+    let j = braceStart + 1;
+    while (j < css.length && depth > 0) {
+      if (css[j] === '{') depth++;
+      else if (css[j] === '}') depth--;
+      j++;
+    }
+    i = j;
+  }
+  return result;
+}
+
+// Batería común a AboutPage y PricingPage: ambas siguen el mismo sistema
+// lp-* documentado en LpSystem.tsx.
+function describeLpMarketingPage(file: string) {
   let src: string;
 
   beforeAll(() => {
-    src = readSource('AboutPage.tsx');
+    src = readSource(file);
   });
 
-  test('inyecta un bloque <style> con media queries para móvil', () => {
-    expect(src).toMatch(/<style>/);
-    expect(src).toMatch(/@media.*max-width/);
+  test('usa el sistema compartido: importa ./LpSystem, SectionHead y lp-page', () => {
+    expect(src).toMatch(/from\s+'\.\/LpSystem'/);
+    expect(src).toMatch(/SectionHead/);
+    expect(src).toMatch(/className="lp-page"/);
   });
 
-  test('el hero usa padding responsivo con clamp o override de media query', () => {
-    // El hero tiene padding: '6rem 2rem 5rem' — en móvil debe reducirse
-    expect(src).toMatch(/@media.*padding|about-hero/s);
+  test('CTA primario a /register presente; /login nunca lleva la clase de botón primario', () => {
+    const registerTags = extractLinkTags(src).filter((tag) => tag.includes('to="/register"'));
+    expect(registerTags.length).toBeGreaterThan(0);
+    expect(registerTags.some((tag) => tag.includes('lp-btn-primary'))).toBe(true);
+
+    const loginTags = extractLinkTags(src).filter((tag) => tag.includes('to="/login"'));
+    expect(loginTags.length).toBeGreaterThan(0);
+    for (const tag of loginTags) {
+      expect(tag).not.toMatch(/lp-btn-primary/);
+    }
   });
 
-  test('la sección whyInner usa flexWrap: wrap para apilar en móvil', () => {
-    expect(src).toMatch(/whyInner|why-inner/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
+  test('cero emojis y símbolos decorativos de interfaz', () => {
+    // El sistema compartido es parte de lo que la página sirve en runtime.
+    expect(readWithSystem(file)).not.toMatch(DECORATIVE_SYMBOL_RE);
   });
 
-  test('la sección de valores (valuesGrid) usa flexWrap: wrap', () => {
-    expect(src).toMatch(/valuesGrid|values-grid/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
+  test('cero hex de marca literales (siempre var(--brand)/var(--brand-light))', () => {
+    expect(readWithSystem(file)).not.toMatch(BRAND_HEX_RE);
   });
 
-  test('la sección del equipo (teamGrid) usa flexWrap: wrap', () => {
-    expect(src).toMatch(/teamGrid|team-grid/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
+  test('sin !important y sin @media (max-width: 768px) de overrides', () => {
+    const full = readWithSystem(file);
+    expect(full).not.toMatch(/!important/);
+    expect(full).not.toMatch(/@media \(max-width:\s*768px\)/);
   });
 
-  test('la sección de merch (merchGrid) usa flexWrap: wrap', () => {
-    expect(src).toMatch(/merchGrid|merch-grid/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
+  test('grids mobile-first: toda grid-template-columns del CSS local vive bajo @media (min-width:', () => {
+    const outsideMinWidth = stripMinWidthMediaBlocks(readLocalCss(file));
+    expect(outsideMinWidth).not.toMatch(/grid-template-columns/);
   });
+}
 
-  test('la sección de historia tiene padding reducido en móvil', () => {
-    expect(src).toMatch(/storySection|about-story/);
-  });
+// ─── AboutPage ──────────────────────────────────────────────────────────────────
+
+describe('AboutPage — sistema lp-*', () => {
+  describeLpMarketingPage('AboutPage.tsx');
 });
 
 // ─── PricingPage ────────────────────────────────────────────────────────────────
 
-describe('PricingPage — responsividad móvil', () => {
-  let src: string;
+describe('PricingPage — sistema lp-*', () => {
+  describeLpMarketingPage('PricingPage.tsx');
 
-  beforeAll(() => {
-    src = readSource('PricingPage.tsx');
-  });
-
-  test('inyecta un bloque <style> con media queries para móvil', () => {
-    expect(src).toMatch(/<style>/);
-    expect(src).toMatch(/@media.*max-width/);
-  });
-
-  test('el pricingWrap usa flexWrap: wrap para apilar tarjeta e info panel', () => {
-    expect(src).toMatch(/pricingWrap|pricing-wrap/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
-  });
-
-  test('las columnas de features (featuresInner) se apilan en móvil', () => {
-    // featuresInner tiene flex con columnas — en móvil deben apilarse
-    expect(src).toMatch(/featuresInner|features-inner/);
-    // Debe haber un override de flex-direction en la media query
-    expect(src).toMatch(/@media.*flex-direction|flex-direction.*column.*@media/s);
-  });
-
-  test('la sección de pasos (stepsRow) usa flexWrap: wrap', () => {
-    expect(src).toMatch(/stepsRow|steps-row/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
-  });
-
-  test('la grid de merchandising usa flexWrap: wrap', () => {
-    expect(src).toMatch(/merchGrid|merch-grid/);
-    expect(src).toMatch(/flexWrap.*wrap|flex-wrap.*wrap/);
-  });
-
-  test('el hero usa padding responsivo', () => {
-    expect(src).toMatch(/@media.*padding|pricing-hero/s);
-  });
-
-  test('la tarjeta de precio (planCard) no tiene ancho fijo > 400px', () => {
-    // planCard usa flex: '1 1 340px' que es responsivo — verificar que no hay width fijo grande
-    const planCardSection = src.match(/planCard:\s*\{[^}]+\}/s)?.[0] ?? '';
-    const widthMatch = planCardSection.match(/(?<![a-zA-Z])width:\s*(\d+)/);
-    if (widthMatch) {
-      expect(parseInt(widthMatch[1], 10)).toBeLessThanOrEqual(400);
-    }
-    // Si no tiene width fijo, el test pasa
+  test('FAQ nativo con <details>, sin useState', () => {
+    const src = readSource('PricingPage.tsx');
+    expect(src).toMatch(/<details/);
+    expect(src).not.toMatch(/useState/);
   });
 });
 

--- a/apps/web/src/pages/marketing/responsive.spec.ts
+++ b/apps/web/src/pages/marketing/responsive.spec.ts
@@ -19,6 +19,13 @@ function readLayout(filename: string): string {
   return fs.readFileSync(path.join(LAYOUTS_DIR, filename), 'utf-8');
 }
 
+// El sistema lp-* (LpSystem.tsx) es parte de la página que lo consume: los
+// asserts que antes buscaban una regla dentro de la propia página ahora deben
+// buscarla en la página + el módulo compartido, tal y como se sirve en runtime.
+function readWithSystem(filename: string): string {
+  return readSource(filename) + readSource('LpSystem.tsx');
+}
+
 // ─── PublicLayout ───────────────────────────────────────────────────────────────
 
 describe('PublicLayout — responsividad móvil', () => {
@@ -93,25 +100,31 @@ describe('LandingPage — responsividad móvil', () => {
       .filter((w) => w > 400);
 
     if (problemWidths.length > 0) {
-      // Debe haber overrides en la media query
-      expect(src).toMatch(/lp-pricing-card.*width|max-width.*100%/s);
+      // Debe haber overrides en la media query. max-width:100% (.lp-page
+      // img/svg) vive ahora en LpSystem.tsx, de ahí la lectura concatenada.
+      expect(readWithSystem('LandingPage.tsx')).toMatch(/lp-pricing-card.*width|max-width.*100%/s);
     }
   });
 
   test('el listado de características apila en móvil (multi-columna solo bajo min-width)', () => {
-    const hasAutoFit = src.includes('auto-fit') || src.includes('auto-fill');
+    // .lp-list-row vive ahora en LpSystem.tsx (sistema compartido): la
+    // verificación lee la página concatenada con el módulo.
+    const full = readWithSystem('LandingPage.tsx');
+    const hasAutoFit = full.includes('auto-fit') || full.includes('auto-fill');
     // Diseño mobile-first: la fila de la lista es de una columna por defecto y
     // sus columnas adicionales se declaran dentro de un @media (min-width: …)
     const mobileFirstRow =
-      /@media \(min-width: \d+px\)[\s\S]*\.lp-list-row[\s\S]*?grid-template-columns/.test(src);
+      /@media \(min-width: \d+px\)[\s\S]*\.lp-list-row[\s\S]*?grid-template-columns/.test(full);
     expect(hasAutoFit || mobileFirstRow).toBeTruthy();
   });
 
   test('el bloque de recompensas no impone anchos fijos', () => {
     expect(src).toMatch(/merchGrid|lp-merch/);
-    // La tabla de canje ocupa el ancho disponible en vez de anchos fijos en px
-    const hasFluidTable = /\.lp-table\s*\{[^}]*width:\s*100%/s.test(src);
-    const hasWrap = /flexWrap.*wrap|flex-wrap.*wrap/.test(src);
+    // .lp-table vive ahora en LpSystem.tsx: ocupa el ancho disponible en vez
+    // de anchos fijos en px.
+    const full = readWithSystem('LandingPage.tsx');
+    const hasFluidTable = /\.lp-table\s*\{[^}]*width:\s*100%/s.test(full);
+    const hasWrap = /flexWrap.*wrap|flex-wrap.*wrap/.test(full);
     expect(hasFluidTable || hasWrap).toBeTruthy();
   });
 });
@@ -262,7 +275,9 @@ describe('Todas las páginas de marketing — verificaciones generales', () => {
   const files = ['LandingPage.tsx', 'AboutPage.tsx', 'PricingPage.tsx'];
 
   test.each(files)('%s: usa overflowX hidden en el contenedor raíz', (file) => {
-    const src = readSource(file);
+    // .lp-page (overflow-x) vive en LpSystem.tsx para la landing: se lee la
+    // página concatenada con el módulo compartido.
+    const src = readWithSystem(file);
     expect(src).toMatch(/overflowX.*hidden|overflow-x.*hidden/);
   });
 
@@ -272,7 +287,9 @@ describe('Todas las páginas de marketing — verificaciones generales', () => {
   });
 
   test.each(files)('%s: las imágenes o logos tienen altura auto o maxWidth 100%', (file) => {
-    const src = readSource(file);
+    // .lp-page img/svg (max-width: 100%) vive en LpSystem.tsx para la
+    // landing: se lee la página concatenada con el módulo compartido.
+    const src = readWithSystem(file);
     // Los logos deben tener height fija + width: auto o max-width: 100%.
     // Se acepta tanto la forma inline de JSX como la declaración en CSS plano.
     const hasAutoWidth =


### PR DESCRIPTION
`/nosotros` y `/precios` pasan al sistema visual de la landing nueva: navy monocromo,
secciones numeradas separadas por regla de 1px, titulares en dos tiempos (blanco +
naranja), botones pastilla y tabla de canje con cifras en ámbar.

Cierra los dos primeros cabos sueltos que quedaron abiertos tras #69/#70.

## Módulo compartido

El CSS del sistema vivía dentro de `LandingPage.tsx`. Se extrae a
`apps/web/src/pages/marketing/LpSystem.tsx`, que exporta `LP_SHARED_CSS`,
`SectionHead` y el catálogo `MERCH`, y lo consumen las tres páginas de marketing.
`LandingPage.tsx` solo pierde CSS: su JSX no se toca.

Balance: 1.300 inserciones / 2.223 borrados. `/nosotros` baja de 874 a 320 líneas y
`/precios` de 969 a 426. Cero dependencias nuevas.

## Copy corregido

Las dos páginas afirmaban que se accede "con las credenciales que te ha proporcionado
tu tutor o profesor". Es falso desde la fase 2 (#65): el rol TUTOR ya no existe y el
alumno recibe su usuario en la pantalla de confirmación del registro familiar. También
desaparece "padres y tutores las herramientas", porque los padres no tienen acceso
propio. `/register` pasa a CTA primario en ambas; `/login` queda como secundario.

Fuera los 49 emojis (13 + 36), los avatares índigo y cyan de los fundadores, los
hovers que manipulaban `style` por evento y el `useState` del acordeón, que pasa a
`<details>` nativo.

## Verificación

- `tsc --noEmit` verde; vitest 101/101.
- **Sin regresión en la landing**: comparación independiente regla a regla del CSS
  resultante contra `main`. Cero declaraciones perdidas, cero valores distintos, y las
  39 nuevas son exactamente las 5 primitivas anunciadas. Sin cambios de cascada entre
  selectores que co-ocurren en un mismo elemento.
- En navegador: alternancia de tonos estricta, índices 01-05 correlativos, cero emojis
  renderizados, cero apariciones de "credenciales", FAQ navegable por teclado, y cero
  desbordamiento con el contenedor forzado a 375 px con las media queries de escritorio
  activas (más duro que el móvil real).
- Los specs de `responsive.spec.ts` que verificaban nombres del diseño retirado se
  sustituyen por asserts sobre el sistema nuevo, siguiendo el criterio de #70. Cada
  assert se probó en las dos direcciones: pasa cuando debe y falla cuando debe.

## Pendiente, fuera de alcance

**Conflicto de precios**: la landing anuncia dos planes (Básico 10 €, Avanzado 20 €) y
`/precios` mantiene su plan único de 15 €/mes. Decisión explícita de no bloquear este
rediseño con el modelo de precios; queda por alinear en una rama propia.

`/nosotros` y `/precios` siguen hablando solo de Vallekas (historia, fundadores) aunque
se sirven también bajo dominios de otras academias.

Falta verificar en PRE con navegador: aquí no hay backend local, así que el tintado por
`primaryColor` de otra academia no se ha podido probar.
