### PR TITLE
fix(auth): recupera la sesión al recargar en vez de expulsar al usuario

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -55,9 +55,12 @@ function RouteLoadingFallback() {
   );
 }
 
-// Guarda: redirige a /dashboard si ya está autenticado
+// Guarda: exige sesión. Espera al arranque antes de decidir, porque el access
+// token no se persiste y al recargar tarda un instante en renovarse.
 function PrivateRoute({ children }: { children: React.ReactNode }) {
+  const sessionReady = useAuthStore((s) => s.sessionReady);
   const isAuthenticated = useAuthStore((s) => !!s.accessToken);
+  if (!sessionReady) return <RouteLoadingFallback />;
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" replace />;
 }
 
@@ -70,9 +73,13 @@ function AdminRoute({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
-// Guarda: redirige al dashboard si ya está autenticado (para /login y /register)
+// Guarda: redirige al dashboard si ya está autenticado (para /login y /register).
+// También espera al arranque: sin ello, recargar en /login enseñaría el
+// formulario un instante antes de saltar al dashboard.
 function PublicOnlyRoute({ children }: { children: React.ReactNode }) {
+  const sessionReady = useAuthStore((s) => s.sessionReady);
   const isAuthenticated = useAuthStore((s) => !!s.accessToken);
+  if (!sessionReady) return <RouteLoadingFallback />;
   return isAuthenticated ? <Navigate to="/dashboard" replace /> : <>{children}</>;
 }
 

--- a/apps/web/src/lib/session-bootstrap.ts
+++ b/apps/web/src/lib/session-bootstrap.ts
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import { useAuthStore } from '../store/auth.store';
+
+const BASE_URL = import.meta.env.VITE_API_URL ?? '/api';
+
+// Memoriza la promesa: /auth/refresh ROTA el token (revoca el usado), así que
+// dos llamadas seguidas harían que la segunda viajase con un token ya revocado
+// y cerrase la sesión. StrictMode monta dos veces en desarrollo, y sin esto el
+// arreglo se convertiría en el bug que intenta corregir.
+let started: Promise<void> | null = null;
+
+/**
+ * Recupera la sesión al arrancar la app.
+ *
+ * El access token no se persiste a propósito, así que tras recargar la página
+ * solo queda el refresh token. Sin este arranque, las guardas de ruta miran un
+ * access token que todavía es null y mandan al alumno a /login teniendo una
+ * sesión perfectamente válida: cada F5, cada enlace guardado y cada pestaña
+ * nueva lo echaban fuera.
+ *
+ * El interceptor de 401 de axios no cubre este caso porque nunca llega a
+ * dispararse: la redirección ocurre antes de que se haga ninguna petición.
+ */
+export function bootstrapSession(): Promise<void> {
+  if (started) return started;
+
+  const { accessToken, refreshToken } = useAuthStore.getState();
+
+  // Nada que recuperar: ni sesión viva ni token con el que pedirla
+  if (accessToken || !refreshToken) {
+    useAuthStore.getState().setSessionReady(true);
+    started = Promise.resolve();
+    return started;
+  }
+
+  started = axios
+    .post(`${BASE_URL}/auth/refresh`, { refreshToken })
+    .then(({ data }) => {
+      useAuthStore.getState().setTokens(data);
+    })
+    .catch(() => {
+      // Token caducado, revocado o API caída: sesión no recuperable
+      useAuthStore.getState().logout();
+    })
+    .finally(() => {
+      useAuthStore.getState().setSessionReady(true);
+    });
+
+  return started;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AcademyProvider } from './contexts/AcademyContext';
+import { bootstrapSession } from './lib/session-bootstrap';
 import './styles/global.css';
 
 const queryClient = new QueryClient({
@@ -14,6 +15,10 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+// Antes de pintar: si queda un refresh token de una sesión anterior, renovarla.
+// Las guardas de ruta esperan a que esto resuelva (ver sessionReady).
+void bootstrapSession();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/web/src/store/auth.store.ts
+++ b/apps/web/src/store/auth.store.ts
@@ -7,6 +7,9 @@ interface AuthState {
   refreshToken: string | null;
   user: User | null;
   academy: Academy | null;
+  /** false hasta que el arranque decide si hay sesion recuperable (ver session-bootstrap) */
+  sessionReady: boolean;
+  setSessionReady: (ready: boolean) => void;
   setTokens: (tokens: { accessToken: string; refreshToken: string }) => void;
   setUser: (user: User) => void;
   setAcademy: (academy: Academy | null) => void;
@@ -20,10 +23,19 @@ export const useAuthStore = create<AuthState>()(
       refreshToken: null,
       user: null,
       academy: null,
+      sessionReady: false,
+      setSessionReady: (sessionReady) => set({ sessionReady }),
       setTokens: ({ accessToken, refreshToken }) => set({ accessToken, refreshToken }),
       setUser: (user) => set({ user, academy: user.academy ?? null }),
       setAcademy: (academy) => set({ academy }),
-      logout: () => set({ accessToken: null, refreshToken: null, user: null, academy: null }),
+      logout: () =>
+        set({
+          accessToken: null,
+          refreshToken: null,
+          user: null,
+          academy: null,
+          sessionReady: true,
+        }),
     }),
     {
       name: 'vkb-auth',


### PR DESCRIPTION
Recargar la página cerraba la sesión del alumno teniendo un refresh token válido guardado.

## El fallo

`PrivateRoute` decidía con `!!accessToken`. El store **no persiste el access token a propósito** — solo `refreshToken`, `user` y `academy`. Así que al recargar:

1. Zustand rehidrata: `accessToken` a `null`, `refreshToken` intacto.
2. `PrivateRoute` ve `accessToken` nulo y redirige a `/login`.
3. El interceptor de 401 de axios, que sí sabe refrescar, **nunca llega a dispararse**: la redirección ocurre antes de que se haga ninguna petición.

Comprobado en vivo antes de tocar nada: tras recargar acabo en `/login`, el refresh token sigue en `localStorage`, y ese mismo token devuelve **200 con un access token nuevo**. La app echaba al usuario teniendo la llave buena en el bolsillo.

Afecta a **cada F5, cada enlace guardado en favoritos y cada "abrir en pestaña nueva"**, a todos los roles. Es previo a cualquier trabajo reciente.

## El arreglo

Un arranque (`lib/session-bootstrap.ts`) que renueva la sesión antes de que las guardas decidan, y un flag `sessionReady` en el store —no persistido— al que esperan `PrivateRoute` y `PublicOnlyRoute`.

**La trampa que había que sortear:** `/auth/refresh` **rota** el token (`auth.service.ts` revoca el usado y emite un par nuevo). Sin guarda, el doble montaje de `StrictMode` en desarrollo haría que la segunda llamada viajase con un token ya revocado y cerrase la sesión — el arreglo se convertiría en el bug que corrige. Por eso la promesa se memoriza a nivel de módulo y el arranque se lanza una sola vez desde `main.tsx`.

Las páginas públicas (landing, `/nosotros`, `/precios`) no esperan al arranque: solo lo hacen las guardas.

## Verificación en navegador

Los cuatro escenarios, con sesión real contra la API:

| Escenario | Resultado |
| --- | --- |
| Sesión válida + recarga en `/challenges` | Se queda dentro y la página carga |
| Sesión válida + abrir `/login` | Redirige solo a `/dashboard` |
| Sin sesión guardada + ruta privada | Sigue yendo a `/login` |
| Refresh token inválido | Limpia la sesión y va a `/login`, sin colgarse en "Cargando..." |
| Logout | Sigue funcionando; no vuelve a entrar solo |

Confirmado además que `sessionReady` **no** se persiste: en `localStorage` siguen solo `refreshToken`, `user` y `academy`.

`pnpm --filter @vkbacademy/web exec tsc --noEmit` limpio.

## Sin tests

`apps/web` tiene specs de vitest pero **ningún job del pipeline los ejecuta** (`deploy-pipeline.yml` solo corre la suite de la API), así que un test aquí no protegería nada. Enganchar vitest al workflow merece su propia PR.

## Seguimiento

Con dos pestañas abiertas, recargar ambas a la vez hace que las dos intenten renovar con el mismo token; una gana y la otra se queda fuera. Es consecuencia de la rotación de tokens, previa a esta PR, y ahora simplemente se nota al recargar. Resolverlo bien pide coordinación entre pestañas (BroadcastChannel o un lock), y no lo abordo aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
