### PR TITLE
fix(challenges): refresca el progreso al resolver un ejercicio

### DIFF
--- a/apps/web/src/components/exercises/ExercisePractice.tsx
+++ b/apps/web/src/components/exercises/ExercisePractice.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { StudyDifficulty, StudyExercise } from '@vkbacademy/shared';
 import api from '../../lib/axios';
 import MathText from '../ui/MathText';
@@ -39,6 +39,7 @@ export default function ExercisePractice({
   const [answers, setAnswers] = useState<Record<number, string>>({});
   const [evaluations, setEvaluations] = useState<Record<number, EvaluationResult>>({});
   const [evalErrors, setEvalErrors] = useState<Record<number, string>>({});
+  const queryClient = useQueryClient();
 
   const attemptMutation = useMutation({
     mutationFn: ({
@@ -64,6 +65,11 @@ export default function ExercisePractice({
         delete next[index];
         return next;
       });
+      // El intento mueve retos y puntos en el servidor. Sin esto, el alumno
+      // veria su progreso congelado hasta 5 minutos (staleTime global).
+      // Se invalida con cualquier veredicto: un fallo tambien cuenta, porque
+      // pone a cero la racha de aciertos.
+      void queryClient.invalidateQueries({ queryKey: ['challenges'] });
     },
     onError: (err, variables) => {
       const msg = (err as { response?: { data?: { message?: string | string[] } } } | null)

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -248,7 +248,12 @@ const S: Record<string, React.CSSProperties> = {
     fontSize: '0.875rem',
     fontWeight: 500,
     transition: 'background 0.18s, color 0.18s, box-shadow 0.18s',
-    borderLeft: '3px solid transparent',
+    // Longhand a proposito: navItemActive sobrescribe solo borderLeftColor, y
+    // mezclarlo con la abreviada borderLeft hace que React avise de un posible
+    // bug de estilo al re-renderizar.
+    borderLeftWidth: 3,
+    borderLeftStyle: 'solid',
+    borderLeftColor: 'transparent',
   },
   navItemActive: {
     background: 'linear-gradient(90deg, var(--brand-soft) 0%, transparent 100%)',


### PR DESCRIPTION
Dos arreglos pequeños en la zona de retos, ambos salidos de verificar el trabajo anterior en navegador.

## 1. El progreso de retos se quedaba congelado hasta 5 minutos

`ExercisePractice` **no invalidaba ninguna query**, y el `staleTime` global es de 5 minutos (`main.tsx`). El alumno resolvía ejercicios, el servidor le sumaba progreso y puntos con `checkAndAward`, y su página de Retos podía seguir enseñándole datos viejos todo ese rato. En la Tienda, lo mismo con los puntos disponibles.

Es un cabo suelto del rediseño de retos (#73): allí se construyó el endpoint de intento y se cableó `checkAndAward`, pero nadie le dijo al front que refrescara.

Se invalida `['challenges']` **con cualquier veredicto**, no solo al acertar: un fallo también cambia el progreso, porque pone a cero la racha de aciertos (`EXERCISES_CORRECT_STREAK`).

## 2. Warning de React en cada render del menú

El `NavLink` del sidebar mezclaba la propiedad abreviada `borderLeft` con `borderLeftColor` (que `navItemActive` sobrescribe). React avisaba en consola de un posible bug de estilo al re-renderizar. Pasa a longhand (`borderLeftWidth` / `borderLeftStyle` / `borderLeftColor`).

Solo afecta a desarrollo, pero ensuciaba la consola y hacía más difícil ver errores de verdad.

## Verificación en navegador

Para el punto 1 hace falta un plan con ejercicios, y no había ninguno en la base local (crear uno pasa por la IA, que no está operativa en este entorno). Sembré uno a mano en la base de datos, con un ejercicio de opción múltiple que se corrige sin IA.

1. Visitar Retos primero, para dejar la caché de React Query poblada con el progreso a **0/10**.
2. Ir al plan, resolver el ejercicio correctamente.
3. Volver a Retos: **"Primeros aciertos" en 1/10 y "Misión: 20 ejercicios" en 1/20**, al instante, sin esperar los 5 minutos.

Para el punto 2: la consola queda **sin errores** en la navegación por el menú, donde antes aparecía el warning en cada render.

Datos de prueba limpiados después (plan, tema, intento, progreso de retos y campos denormalizados del usuario).

`pnpm --filter @vkbacademy/web exec tsc --noEmit` limpio.

## Nota sobre una carrera que no se resuelve aquí

`checkAndAward` se invoca con `void` en el servidor (deliberadamente, para no bloquear la respuesta HTTP), así que en teoría la invalidación podría refrescar antes de que el servidor termine de escribir. En la práctica no ocurre —`checkAndAward` arranca antes de que se serialice la respuesta, y el viaje de ida y vuelta de la siguiente petición le da tiempo de sobra—, y así lo confirmó la verificación. Aun sin ganar siempre la carrera, el peor caso pasa de "datos viejos hasta 5 minutos" a "datos viejos hasta la siguiente navegación".

## Sin tests

`apps/web` tiene specs de vitest pero **ningún job del pipeline los ejecuta** (`deploy-pipeline.yml` solo corre la suite de la API), así que un test aquí no protegería nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
