### PR TITLE
fix(ci): despierta la API antes de la verificación final de PROD

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -416,12 +416,33 @@ jobs:
           echo "Smoke tests PROD superados. Render/Vercel ya sirven la versión nueva."
           echo "Promoción confirmada."
 
+      # Este job espera detrás de una aprobación manual, y entre que pasan los
+      # smoke tests y alguien aprueba pueden pasar horas: Render Starter vuelve
+      # a dormir el servicio. Sin despertarlo primero, la verificación final se
+      # come el arranque en frío (30-60s) y da por malo un despliegue sano.
+      - name: Esperar a que la API PROD responda (puede haberse dormido)
+        env:
+          SMOKE_API_URL: ${{ vars.SMOKE_API_URL }}
+        run: |
+          for i in $(seq 1 20); do
+            if curl -fsS --max-time 10 "$SMOKE_API_URL/api/health" > /dev/null 2>&1; then
+              echo "API PROD lista en intento $i"
+              exit 0
+            fi
+            echo "Esperando API PROD... intento $i"
+            sleep 15
+          done
+          echo "API PROD no respondió tras 20 intentos (cold start de Render)"
+          exit 1
+
+      # Con el servicio ya caliente, esta comprobación es deliberadamente
+      # estricta: exige 3 respuestas sanas seguidas y falla al primer tropiezo.
       - name: Verificación final post-promoción
         env:
           SMOKE_API_URL: ${{ vars.SMOKE_API_URL }}
         run: |
           for i in 1 2 3; do
-            if curl -fsS --max-time 10 "$SMOKE_API_URL/api/health" | grep -q '"status":"ok"'; then
+            if curl -fsS --max-time 30 "$SMOKE_API_URL/api/health" | grep -q '"status":"ok"'; then
               echo "Health check PROD OK ($i/3)"
               sleep 5
             else


### PR DESCRIPTION
El job `promote-prod` falla de vez en cuando sin que nada esté roto. Pasó el 14 de agosto, en el despliegue de #75.

## Por qué falla

`promote-prod` tiene `environment: name: prod`, es decir **está detrás de una aprobación manual**. Entre que `smoke-prod` pasa y una persona aprueba la promoción pueden pasar horas, y en Render Starter el servicio se vuelve a dormir mientras tanto.

Su verificación final atacaba con `--max-time 10` y abortaba al primer fallo, así que se comía el arranque en frío —30-60 segundos, documentado en el propio `CLAUDE.md`— y daba por malo un despliegue perfectamente sano:

```
curl: (28) Operation timed out after 10001 milliseconds with 0 bytes received
Health check PROD FALLÓ en intento 1
```

Las ejecuciones posteriores pasaron solo porque el servicio ya estaba caliente. Es decir: **el job es estructuralmente frágil, no fue mala suerte**.

## Qué cambia

**Un paso nuevo que despierta el servicio antes de verificarlo**, con el mismo patrón de reintento que ya usan los jobs de PRE y PROD en este mismo fichero (20 intentos, `sleep 15`, sale a la primera que responde). Nada inventado: es el patrón que ya funciona aquí.

**`--max-time` de 10 a 30** en la verificación final, para que una respuesta lenta pero viva no la tumbe.

**La comprobación de estabilidad se queda igual de estricta**: 3 respuestas sanas seguidas, fallo al primer tropiezo. Eso no era el bug — con el servicio ya caliente, esa severidad es justo lo que se quiere de un check post-promoción.

**No toco los otros `--max-time 10`** del fichero: están dentro de bucles que reintentan, así que ahí un timeout corto solo descarta ese intento y sigue. Cambiarlos sería ruido.

## Verificación

El YAML parsea y `promote-prod` queda con sus tres pasos en orden.

La lógica de shell se probó simulando el arranque en frío exacto que ocurrió: los dos primeros intentos devuelven el código 28 de `curl` y el tercero responde sano.

| Bucle | Resultado |
| --- | --- |
| El viejo | Aborta en el intento 1, código de salida **1** |
| El nuevo (espera) | Espera dos intentos, lista en el 3º, código **0** |
| El estricto, ya caliente | Exige y consigue sus 3 seguidas, código **0** |

## Lo que esto no arregla

El servicio seguirá durmiéndose: esto solo evita que dormirse se confunda con estar roto. Si os molesta el arranque en frío en sí, la salida es un plan de Render sin suspensión o un ping periódico, y eso es otra conversación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
